### PR TITLE
Fix transaction creation with existing player

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/TransaccionService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TransaccionService.java
@@ -28,10 +28,14 @@ public class TransaccionService {
     private final ApplicationEventPublisher eventPublisher;
 
     public TransaccionResponse registrarTransaccion(TransaccionRequest dto) {
+        Jugador jugador = jugadorRepository.findById(dto.getJugadorId())
+                .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado"));
+
         Transaccion transaccion = transaccionMapper.toEntity(dto);
-        transaccion.setJugador(new Jugador(dto.getJugadorId()));
+        transaccion.setJugador(jugador);
         transaccion.setEstado(EstadoTransaccion.PENDIENTE);
         transaccion.setCreadoEn(LocalDateTime.now());
+
         Transaccion saved = transaccionRepository.save(transaccion);
         return transaccionMapper.toDto(saved);
     }


### PR DESCRIPTION
## Summary
- prevent saving Transaccion with transient Jugador by fetching the player from the repository

## Testing
- `mvn -q -DskipTests package` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685b2cb0f1d0832db99b87cabee3ac8a