### PR TITLE
Fix logging conflict and enable chat launch

### DIFF
--- a/back/pom.xml
+++ b/back/pom.xml
@@ -30,7 +30,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
-        <!-- Web sin logback ni log4j-to-slf4j -->
+        <!-- Web sin logback ni log4j-to-slf4j ni spring-boot-starter-logging -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -43,10 +43,14 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-to-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
-        <!-- JPA sin log4j-to-slf4j -->
+        <!-- JPA sin log4j-to-slf4j ni spring-boot-starter-logging -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -54,6 +58,10 @@
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -110,6 +118,10 @@
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -39,6 +39,7 @@ const HomePageContent = () => {
   const handleMatchFound = (data: { apuestaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; }) => {
     console.log('Match encontrado via SSE:', data);
     setIsSearching(false);
+    toast({ title: 'Duelo encontrado', description: 'Abriendo chat con tu oponente...' });
     router.push(
       `/chat/${data.apuestaId}?opponentTag=${encodeURIComponent(data.jugadorOponenteTag)}&opponentGoogleId=${encodeURIComponent(data.jugadorOponenteId)}`
     );


### PR DESCRIPTION
## Summary
- remove `spring-boot-starter-logging` so Log4j2 is the only SLF4J provider
- show toast and open chat page when a match is found

## Testing
- `npm run lint` *(fails: next not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b38d99c70832d924b61edac8c18db