### PR TITLE
Fix logback conflict and redirect to chat

### DIFF
--- a/back/pom.xml
+++ b/back/pom.xml
@@ -29,8 +29,22 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-        <!-- Web sin logback ni log4j-to-slf4j -->
+        <!-- Web sin logback ni log4j-to-slf4j ni spring-boot-starter-logging -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -43,10 +57,14 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-to-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
-        <!-- JPA sin log4j-to-slf4j -->
+        <!-- JPA sin log4j-to-slf4j ni spring-boot-starter-logging -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -54,6 +72,10 @@
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -110,6 +132,10 @@
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "socket-server": "node socket-server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^4.1.3",
@@ -34,7 +35,9 @@
     "react-redux": "^9.2.0",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "socket.io-client": "^4.7.5",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/front/socket-server.js
+++ b/front/socket-server.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server, {
+  cors: {
+    origin: '*'
+  }
+});
+
+io.on('connection', socket => {
+  console.log('Client connected:', socket.id);
+
+  socket.on('joinMatch', matchId => {
+    socket.join(matchId);
+  });
+
+  socket.on('chatMessage', message => {
+    io.to(message.matchId).emit('chatMessage', message);
+  });
+
+  socket.on('disconnect', () => {
+    console.log('Client disconnected:', socket.id);
+  });
+});
+
+const PORT = process.env.SOCKET_PORT || 4000;
+server.listen(PORT, () => {
+  console.log(`Socket.io server listening on port ${PORT}`);
+});

--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -13,7 +13,8 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Send, Link as LinkIconLucide, CheckCircle, XCircle, UploadCloud } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
-import type { ChatMessage } from '@/types'; 
+import type { ChatMessage } from '@/types';
+import useChatSocket from '@/hooks/useChatSocket';
 import { Label } from '@/components/ui/label';
 
 
@@ -32,9 +33,13 @@ const ChatPageContent = () => {
   const [newMessage, setNewMessage] = useState('');
   const [isSubmittingResult, setIsSubmittingResult] = useState(false);
   const [screenshotFile, setScreenshotFile] = useState<File | null>(null);
-  const [resultSubmitted, setResultSubmitted] = useState(false); 
+  const [resultSubmitted, setResultSubmitted] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const sendChatMessage = useChatSocket(matchId, (msg) => {
+    setMessages(prev => [...prev, msg]);
+  });
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -73,7 +78,8 @@ const ChatPageContent = () => {
     };
     const updatedMessages = [...messages, message];
     setMessages(updatedMessages);
-    saveMessages(updatedMessages); 
+    saveMessages(updatedMessages);
+    sendChatMessage(message);
     setNewMessage('');
   };
   
@@ -101,6 +107,7 @@ const ChatPageContent = () => {
     const updatedMessages = [...messages, message];
     setMessages(updatedMessages);
     saveMessages(updatedMessages);
+    sendChatMessage(message);
     toast({ title: "Link de Amigo Compartido", description: `Tu link de amigo ${user.friendLink ? '' : '(o un aviso de que no lo tienes) '}ha sido publicado en el chat.` });
   };
 
@@ -127,7 +134,7 @@ const ChatPageContent = () => {
     
      const userDisplayName = user.clashTag || user.username;
      const resultMessageText = `${userDisplayName} envió el resultado del duelo como ${result === 'win' ? 'VICTORIA' : 'DERROTA'}. ${screenshotFile ? 'Captura de pantalla proporcionada.' : 'No se proporcionó captura.'}`;
-     const resultSystemMessage: ChatMessage = {
+    const resultSystemMessage: ChatMessage = {
       id: `sys-result-${user.id}-${Date.now()}`, // user.id es googleId
       matchId, // ID de la apuesta del backend (UUID)
       senderId: 'system',
@@ -138,6 +145,7 @@ const ChatPageContent = () => {
     const updatedMessages = [...messages, resultSystemMessage];
     setMessages(updatedMessages);
     saveMessages(updatedMessages);
+    sendChatMessage(resultSystemMessage);
   };
 
 

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -39,6 +39,7 @@ const HomePageContent = () => {
   const handleMatchFound = (data: { apuestaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; }) => {
     console.log('Match encontrado via SSE:', data);
     setIsSearching(false);
+    toast({ title: 'Duelo encontrado', description: 'Abriendo chat con tu oponente...' });
     router.push(
       `/chat/${data.apuestaId}?opponentTag=${encodeURIComponent(data.jugadorOponenteTag)}&opponentGoogleId=${encodeURIComponent(data.jugadorOponenteId)}`
     );

--- a/front/src/hooks/useChatSocket.ts
+++ b/front/src/hooks/useChatSocket.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+import type { ChatMessage } from '@/types';
+
+const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:4000';
+
+
+export default function useChatSocket(matchId: string | undefined, onMessage: (msg: ChatMessage) => void) {
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    if (!matchId) return;
+
+    const socket = io(SOCKET_URL);
+    socketRef.current = socket;
+
+    socket.emit('joinMatch', matchId);
+
+    socket.on('chatMessage', (msg: ChatMessage) => {
+      if (msg.matchId === matchId) {
+        onMessage(msg);
+      }
+    });
+
+    return () => {
+      socket.disconnect();
+    };
+  }, [matchId, onMessage]);
+
+  const sendMessage = (msg: ChatMessage) => {
+    socketRef.current?.emit('chatMessage', msg);
+  };
+
+  return sendMessage;
+}


### PR DESCRIPTION
## Summary
- exclude logging starter from `spring-boot-starter-validation`
- show toast and open chat page when a match is found
- add socket.io server and hook for realtime chat

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails due to missing modules)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b38d99c70832d924b61edac8c18db