### PR TITLE
Fix SSE handler scope

### DIFF
--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -16,27 +16,24 @@ export default function useMatchmakingSse(playerId: string | undefined, onMatch:
   useEffect(() => {
     if (!playerId) return;
 
+    const handler = (event: MessageEvent) => {
+      try {
+        const data: MatchEventData = JSON.parse(event.data);
+        console.log('Match encontrado:', data);
+        onMatch(data);
+        eventSourceRef.current?.close();
+      } catch (err) {
+        console.error('Error al procesar evento SSE de matchmaking:', err);
+      }
+    };
+
     const connect = () => {
       const url = `${BACKEND_URL}/sse/matchmaking/${encodeURIComponent(playerId)}`;
       console.log('Abriendo conexión SSE de matchmaking:', url);
       const es = new EventSource(url);
       eventSourceRef.current = es;
 
-      const handler = (event: MessageEvent) => {
-
-        try {
-          const data: MatchEventData = JSON.parse(event.data);
-          console.log('Match encontrado:', data);
-          onMatch(data);
-          es.close();
-        } catch (err) {
-          console.error('Error al procesar evento SSE de matchmaking:', err);
-        }
-      };
-
-
       es.addEventListener('match-found', handler as EventListener);
-
 
       es.onerror = (err) => {
         console.error('Error en la conexión SSE de matchmaking:', err);


### PR DESCRIPTION
## Summary
- ensure handler function is in scope when cleaning up matchmaking SSE connection

## Testing
- `npx --yes next --version`

------
https://chatgpt.com/codex/tasks/task_b_685b7d02a3b0832da7a5d62e9d5eeede