### PR TITLE
Fix SSE emitter reuse

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/SseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/SseService.java
@@ -6,52 +6,45 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @Service
 @RequiredArgsConstructor
 public class SseService {
 
-    private final Map<String, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     public SseEmitter subscribe(String jugadorId) {
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
 
-        emitter.onCompletion(() -> removeEmitter(jugadorId, emitter));
-        emitter.onTimeout(() -> removeEmitter(jugadorId, emitter));
-        emitter.onError(e -> removeEmitter(jugadorId, emitter));
+        emitter.onCompletion(() -> removeEmitter(jugadorId));
+        emitter.onTimeout(() -> removeEmitter(jugadorId));
+        emitter.onError(e -> removeEmitter(jugadorId));
 
-        emitters.computeIfAbsent(jugadorId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+        emitters.put(jugadorId, emitter);
         return emitter;
     }
 
     public void notificarTransaccionAprobada(TransaccionResponse dto) {
         String jugadorId = dto.getJugadorId();
 
-        List<SseEmitter> userEmitters = emitters.get(jugadorId);
-        if (userEmitters == null) return;
-
-        List<SseEmitter> muertos = new ArrayList<>();
-        for (SseEmitter emitter : userEmitters) {
-            try {
-                emitter.send(SseEmitter.event()
-                        .name("transaccion-aprobada")
-                        .data(dto));
-            } catch (IOException e) {
-                muertos.add(emitter);
-            }
+        SseEmitter emitter = emitters.get(jugadorId);
+        if (emitter == null) {
+            return;
         }
-        userEmitters.removeAll(muertos);
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("transaccion-aprobada")
+                    .data(dto));
+        } catch (IOException e) {
+            removeEmitter(jugadorId);
+            emitter.completeWithError(e);
+        }
     }
 
-    private void removeEmitter(String jugadorId, SseEmitter emitter) {
-        List<SseEmitter> userEmitters = emitters.get(jugadorId);
-        if (userEmitters != null) {
-            userEmitters.remove(emitter);
-        }
+    private void removeEmitter(String jugadorId) {
+        emitters.remove(jugadorId);
     }
 }


### PR DESCRIPTION
## Summary
- track only one `SseEmitter` per player
- clean up emitters when sending fails

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_685b9d4bcbbc832dba79ac0aa8308902