### PR TITLE
Fix SSE emitter reuse

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/ChatController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/ChatController.java
@@ -1,9 +1,11 @@
 package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.ChatService;
+import co.com.arena.real.application.service.PartidaService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,11 +19,19 @@ import java.util.UUID;
 public class ChatController {
 
     private final ChatService chatService;
+    private final PartidaService partidaService;
 
     @GetMapping("/between")
     public ResponseEntity<Map<String, UUID>> getChatId(@RequestParam String jugador1Id,
                                                        @RequestParam String jugador2Id) {
         UUID id = chatService.obtenerOcrear(jugador1Id, jugador2Id);
         return ResponseEntity.ok(Map.of("chatId", id));
+    }
+
+    @GetMapping("/partida/{partidaId}")
+    public ResponseEntity<Map<String, UUID>> getChatIdByPartida(@PathVariable UUID partidaId) {
+        return partidaService.obtenerChatActivo(partidaId)
+                .map(id -> ResponseEntity.ok(Map.of("chatId", id)))
+                .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/ChatService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/ChatService.java
@@ -29,6 +29,12 @@ public class ChatService {
                 .map(Chat::getId)
                 .orElseGet(() -> crearChatParaPartida(jugador1Id, jugador2Id));
     }
+
+    public void cerrarChat(UUID chatId) {
+        if (chatId != null) {
+            chatRepository.deleteById(chatId);
+        }
+    }
 }
 
 

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -11,6 +11,8 @@ import co.com.arena.real.infrastructure.repository.ApuestaRepository;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
 import co.com.arena.real.infrastructure.repository.PartidaRepository;
 import co.com.arena.real.infrastructure.repository.TransaccionRepository;
+import co.com.arena.real.domain.entity.partida.EstadoPartida;
+import co.com.arena.real.application.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,9 +30,16 @@ public class PartidaService {
     private final ApuestaRepository apuestaRepository;
     private final JugadorRepository jugadorRepository;
     private final TransaccionRepository transaccionRepository;
+    private final ChatService chatService;
 
     public Optional<PartidaResponse> obtenerPorApuestaId(UUID apuestaId) {
         return partidaRepository.findByApuesta_Id(apuestaId).map(partidaMapper::toDto);
+    }
+
+    public Optional<UUID> obtenerChatActivo(UUID partidaId) {
+        return partidaRepository.findById(partidaId)
+                .filter(p -> p.getEstado() == EstadoPartida.EN_CURSO || p.getEstado() == EstadoPartida.POR_APROBAR)
+                .map(Partida::getChatId);
     }
 
     @Transactional
@@ -39,6 +48,7 @@ public class PartidaService {
                 .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
         partida.setValidada(true);
         partida.setValidadaEn(LocalDateTime.now());
+        partida.setEstado(EstadoPartida.FINALIZADA);
         if (partida.getGanador() != null && partida.getApuesta() != null) {
             Apuesta apuesta = apuestaRepository.findById(partida.getApuesta().getId())
                     .orElseThrow(() -> new IllegalArgumentException("Apuesta no encontrada"));
@@ -56,6 +66,8 @@ public class PartidaService {
                 jugadorRepository.save(u);
             });
         }
+
+        chatService.cerrarChat(partida.getChatId());
 
         Partida saved = partidaRepository.save(partida);
         return partidaMapper.toDto(saved);

--- a/back/src/main/java/co/com/arena/real/application/service/SseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/SseService.java
@@ -6,52 +6,45 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @Service
 @RequiredArgsConstructor
 public class SseService {
 
-    private final Map<String, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     public SseEmitter subscribe(String jugadorId) {
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
 
-        emitter.onCompletion(() -> removeEmitter(jugadorId, emitter));
-        emitter.onTimeout(() -> removeEmitter(jugadorId, emitter));
-        emitter.onError(e -> removeEmitter(jugadorId, emitter));
+        emitter.onCompletion(() -> removeEmitter(jugadorId));
+        emitter.onTimeout(() -> removeEmitter(jugadorId));
+        emitter.onError(e -> removeEmitter(jugadorId));
 
-        emitters.computeIfAbsent(jugadorId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+        emitters.put(jugadorId, emitter);
         return emitter;
     }
 
     public void notificarTransaccionAprobada(TransaccionResponse dto) {
         String jugadorId = dto.getJugadorId();
 
-        List<SseEmitter> userEmitters = emitters.get(jugadorId);
-        if (userEmitters == null) return;
-
-        List<SseEmitter> muertos = new ArrayList<>();
-        for (SseEmitter emitter : userEmitters) {
-            try {
-                emitter.send(SseEmitter.event()
-                        .name("transaccion-aprobada")
-                        .data(dto));
-            } catch (IOException e) {
-                muertos.add(emitter);
-            }
+        SseEmitter emitter = emitters.get(jugadorId);
+        if (emitter == null) {
+            return;
         }
-        userEmitters.removeAll(muertos);
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("transaccion-aprobada")
+                    .data(dto));
+        } catch (IOException e) {
+            removeEmitter(jugadorId);
+            emitter.completeWithError(e);
+        }
     }
 
-    private void removeEmitter(String jugadorId, SseEmitter emitter) {
-        List<SseEmitter> userEmitters = emitters.get(jugadorId);
-        if (userEmitters != null) {
-            userEmitters.remove(emitter);
-        }
+    private void removeEmitter(String jugadorId) {
+        emitters.remove(jugadorId);
     }
 }


### PR DESCRIPTION
## Summary
- track only one `SseEmitter` per player
- clean up emitters when sending fails
- close chats when a match is finished
- allow retrieving chat id for ongoing matches

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_685b9d4bcbbc832dba79ac0aa8308902