### PR TITLE
Improve matchmaking response

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
@@ -3,6 +3,8 @@ package co.com.arena.real.application.controller;
 import co.com.arena.real.application.service.MatchmakingService;
 import co.com.arena.real.infrastructure.dto.rq.CancelarMatchmakingRequest;
 import co.com.arena.real.infrastructure.dto.rq.PartidaEnEsperaRequest;
+import co.com.arena.real.infrastructure.dto.rs.MatchSseDto;
+import co.com.arena.real.domain.entity.Jugador;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,12 +26,18 @@ public class    MatchmakingController {
     public ResponseEntity<?> ejecutarMatchmaking(@RequestBody PartidaEnEsperaRequest request) {
         return matchmakingService.intentarEmparejar(request)
                 .map(partida -> {
-                    Map<String, Object> partidaMap = new HashMap<>();
-                    partidaMap.put("id", partida.getId());
-                    Map<String, Object> resp = new HashMap<>();
-                    resp.put("match", true);
-                    resp.put("partida", partidaMap);
-                    return ResponseEntity.ok(resp);
+                    Jugador oponente = partida.getJugador1().getId().equals(request.getJugadorId())
+                            ? partida.getJugador2()
+                            : partida.getJugador1();
+
+                    MatchSseDto dto = MatchSseDto.builder()
+                            .apuestaId(partida.getApuesta().getId())
+                            .chatId(partida.getChatId())
+                            .jugadorOponenteId(oponente.getId())
+                            .jugadorOponenteTag(oponente.getTagClash())
+                            .build();
+
+                    return ResponseEntity.ok(dto);
                 })
                 .orElseGet(() -> {
                     Map<String, Object> resp = new HashMap<>();

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -96,7 +96,8 @@ const HomePageContent = () => {
       result.match &&
       result.match.apuestaId &&
       result.match.jugadorOponenteId &&
-      result.match.jugadorOponenteTag
+      result.match.jugadorOponenteTag &&
+      result.match.chatId
     ) {
       handleMatchFound(result.match);
     }

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -76,6 +76,7 @@ export interface BackendMatchmakingResponseDto {
   apuestaId: string; // UUID de la apuesta resultante
   jugadorOponenteId: string; // googleId del oponente
   jugadorOponenteTag: string;
+  chatId: string;
   jugadorOponenteAvatarUrl?: string;
 }
 


### PR DESCRIPTION
## Summary
- include chat details in `MatchmakingController`
- expose `chatId` in `BackendMatchmakingResponseDto`
- verify chat data when handling match result

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bbe8c04f8832dbb3e5b6e2c5978db