### PR TITLE
Fix frontend types

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-scroll-area": "^1.2.3",
+        "@radix-ui/react-separator": "^1.0.0",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-toast": "^1.2.6",
@@ -1887,6 +1888,85 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/front/package.json
+++ b/front/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.3",
+    "@radix-ui/react-separator": "^1.0.0",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@reduxjs/toolkit": "^2.2.2",

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -227,7 +227,7 @@ const HomePageContent = () => {
     setIsModeModalOpen(true);
   };
 
-  const handleModeSelect = async (mode: 'CLASICO' | 'TRIPLE_ELECCION  ') => {
+  const handleModeSelect = async (mode: 'CLASICO' | 'TRIPLE_ELECCION') => {
     setIsModeModalOpen(false);
     await handleFindMatch(mode);
   };

--- a/front/src/hooks/useTransactionUpdates.ts
+++ b/front/src/hooks/useTransactionUpdates.ts
@@ -34,7 +34,10 @@ export default function useTransactionUpdates() {
       }
     };
 
-    es.addEventListener('transaccion-aprobada', handler as EventListener);
+    es.addEventListener(
+      'transaccion-aprobada',
+      handler as unknown as EventListener
+    );
 
     es.onerror = (err) => {
       console.error('SSE error:', err);
@@ -42,7 +45,10 @@ export default function useTransactionUpdates() {
 
     return () => {
       if (eventSourceRef.current) {
-        eventSourceRef.current.removeEventListener('transaccion-aprobada', handler as EventListener);
+        eventSourceRef.current.removeEventListener(
+          'transaccion-aprobada',
+          handler as unknown as EventListener
+        );
         eventSourceRef.current.close();
       }
     };

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -76,6 +76,7 @@ export interface BackendMatchmakingResponseDto {
   apuestaId: string; // UUID de la apuesta resultante
   jugadorOponenteId: string; // googleId del oponente
   jugadorOponenteTag: string;
+  chatId: string;
   jugadorOponenteAvatarUrl?: string;
 }
 


### PR DESCRIPTION
## Summary
- add missing chatId field to BackendMatchmakingResponseDto
- support SSE type casting in useTransactionUpdates
- clean up game mode constant
- install @radix-ui/react-separator dependency

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_685bbb410df8832daaedb64dba1f1ae3