### PR TITLE
Fix matchmaking response mapping

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
@@ -30,15 +30,14 @@ public class    MatchmakingController {
                             ? partida.getJugador2()
                             : partida.getJugador1();
 
-                    MatchSseDto dto = MatchSseDto.builder()
+                    return MatchSseDto.builder()
                             .apuestaId(partida.getApuesta().getId())
                             .chatId(partida.getChatId())
                             .jugadorOponenteId(oponente.getId())
                             .jugadorOponenteTag(oponente.getTagClash())
                             .build();
-
-                    return ResponseEntity.ok(dto);
                 })
+                .<ResponseEntity<?>>map(ResponseEntity::ok)
                 .orElseGet(() -> {
                     Map<String, Object> resp = new HashMap<>();
                     resp.put("status", "esperando");


### PR DESCRIPTION
## Summary
- return ResponseEntity correctly in matchmaking controller to avoid type errors

## Testing
- `mvn -q -DskipTests package` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685bc320f108832da9fb51a3570f3eb5