### PR TITLE
Improve chat param checks

### DIFF
--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -24,13 +24,20 @@ const ChatPageContent = () => {
   const searchParams = useSearchParams();
 
   const matchId = params.matchId as string | undefined; // ID de la apuesta (UUID)
-  const opponentTag = searchParams.get('opponentTag');
+  const opponentTagParam = searchParams.get('opponentTag');
+  const opponentGoogleIdParam = searchParams.get('opponentGoogleId'); // googleId del oponente
+
+  const hasValidParams =
+    matchId && opponentTagParam && opponentTagParam !== 'null' &&
+    opponentGoogleIdParam && opponentGoogleIdParam !== 'null';
+
+  const opponentTag = hasValidParams ? opponentTagParam : undefined;
+  const opponentGoogleId = hasValidParams ? opponentGoogleIdParam : undefined;
   const opponentAvatar = searchParams.get('opponentAvatar') ||
     (opponentTag ? `https://placehold.co/40x40.png?text=${opponentTag[0]}` : undefined);
-  const opponentGoogleId = searchParams.get('opponentGoogleId'); // googleId del oponente
 
   const { toast } = useToast();
-  const incompleteData = !matchId || !opponentTag || !opponentGoogleId;
+  const incompleteData = !hasValidParams;
   const validMatchId = matchId as string;
   const validOpponentTag = opponentTag as string;
   const validOpponentGoogleId = opponentGoogleId as string;

--- a/front/src/lib/firebase.ts
+++ b/front/src/lib/firebase.ts
@@ -1,5 +1,5 @@
 
-import { initializeApp } from 'firebase/app';
+import { initializeApp, getApps, getApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
@@ -12,7 +12,7 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!
 };
 
-const app = initializeApp(firebaseConfig);
+const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const auth = getAuth(app);
 const db = getFirestore(app);
 


### PR DESCRIPTION
## Summary
- avoid reinitializing Firebase app
- validate query params before starting chat

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck` *(fails: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_b_685bc30f68c0832da335a7f67a2fae38