### PR TITLE
Fix chat using socket

### DIFF
--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -14,7 +14,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Send, Link as LinkIconLucide, CheckCircle, XCircle, UploadCloud } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
 import type { ChatMessage } from '@/types';
-import useFirestoreChat from '@/hooks/useFirestoreChat';
+import useSocketChat from '@/hooks/useSocketChat';
 import { Label } from '@/components/ui/label';
 
 
@@ -41,7 +41,7 @@ const ChatPageContent = () => {
   const validMatchId = matchId as string;
   const validOpponentTag = opponentTag as string;
   const validOpponentGoogleId = opponentGoogleId as string;
-  const { messages, sendMessage } = useFirestoreChat(incompleteData ? undefined : matchId);
+  const { messages, sendMessage } = useSocketChat(incompleteData ? undefined : matchId);
   const [newMessage, setNewMessage] = useState('');
   const [isSubmittingResult, setIsSubmittingResult] = useState(false);
   const [screenshotFile, setScreenshotFile] = useState<File | null>(null);

--- a/front/src/hooks/useSocketChat.ts
+++ b/front/src/hooks/useSocketChat.ts
@@ -1,0 +1,15 @@
+import { useState, useCallback } from 'react';
+import type { ChatMessage } from '@/types';
+import useChatSocket from './useChatSocket';
+
+export default function useSocketChat(matchId: string | undefined) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  const handleIncoming = useCallback((msg: ChatMessage) => {
+    setMessages(prev => [...prev, msg]);
+  }, []);
+
+  const sendMessage = useChatSocket(matchId, handleIncoming);
+
+  return { messages, sendMessage };
+}


### PR DESCRIPTION
## Summary
- add `useSocketChat` hook to manage socket messages
- switch chat page to use socket-based chat

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685bd8b980dc832d9d4a473ff4d18616