### PR TITLE
Fix Firebase credentials handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,19 @@ cd back
 mvn spring-boot:run
 ```
 
+Before starting the backend, set the path to your Firebase service account
+credentials using either the custom `FIREBASE_SERVICE_ACCOUNT_FILE` variable or
+the standard `GOOGLE_APPLICATION_CREDENTIALS`:
+
+```bash
+export FIREBASE_SERVICE_ACCOUNT_FILE=/path/to/serviceAccountKey.json
+# or
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/serviceAccountKey.json
+```
+
+Ensure the file path points to an existing JSON file containing your service
+account credentials.
+
+If neither variable is set, the backend won't start because Firebase cannot
+locate credentials.
+

--- a/back/src/main/java/co/com/arena/real/config/FirebaseConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/FirebaseConfig.java
@@ -3,7 +3,7 @@ package co.com.arena.real.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.FileInputStream;
@@ -12,20 +12,40 @@ import java.io.IOException;
 @Configuration
 public class FirebaseConfig {
 
-    @PostConstruct
-    public void init() throws IOException {
+    @Bean
+    public FirebaseApp firebaseApp() {
         if (!FirebaseApp.getApps().isEmpty()) {
-            return;
+            return FirebaseApp.getInstance();
         }
+
         String serviceAccountPath = System.getenv("FIREBASE_SERVICE_ACCOUNT_FILE");
         if (serviceAccountPath == null) {
-            return;
+            serviceAccountPath = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
         }
-        try (FileInputStream serviceAccount = new FileInputStream(serviceAccountPath)) {
-            FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                    .build();
-            FirebaseApp.initializeApp(options);
+
+        GoogleCredentials credentials;
+        if (serviceAccountPath != null && !serviceAccountPath.isBlank()) {
+            try (FileInputStream serviceAccount = new FileInputStream(serviceAccountPath)) {
+                credentials = GoogleCredentials.fromStream(serviceAccount);
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                        "Cannot read Firebase credentials from " + serviceAccountPath,
+                        e);
+            }
+        } else {
+            try {
+                credentials = GoogleCredentials.getApplicationDefault();
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                        "Firebase credentials not found. Set FIREBASE_SERVICE_ACCOUNT_FILE or GOOGLE_APPLICATION_CREDENTIALS",
+                        e);
+            }
         }
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(credentials)
+                .build();
+
+        return FirebaseApp.initializeApp(options);
     }
 }

--- a/back/src/main/java/co/com/arena/real/config/FirestoreConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/FirestoreConfig.java
@@ -1,14 +1,17 @@
 package co.com.arena.real.config;
 
 import com.google.cloud.firestore.Firestore;
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.cloud.FirestoreClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 
 @Configuration
+@DependsOn("firebaseApp")
 public class FirestoreConfig {
     @Bean
-    public Firestore firestore() {
-        return FirestoreClient.getFirestore();
+    public Firestore firestore(FirebaseApp firebaseApp) {
+        return FirestoreClient.getFirestore(firebaseApp);
     }
 }


### PR DESCRIPTION
## Summary
- warn README to check service account file path
- catch IO errors when reading the credentials file

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bdfee1eb8832da1a2ae910d3600b2