### PR TITLE
Improve SSE stability with heartbeat

### DIFF
--- a/back/src/main/java/co/com/arena/real/Application.java
+++ b/back/src/main/java/co/com/arena/real/Application.java
@@ -2,8 +2,10 @@ package co.com.arena.real;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class Application {
 
     public static void main(String[] args) {

--- a/back/src/main/java/co/com/arena/real/application/service/SseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/SseService.java
@@ -2,6 +2,7 @@ package co.com.arena.real.application.service;
 
 import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -29,6 +30,17 @@ public class SseService {
 
         emitters.put(jugadorId, emitter);
         return emitter;
+    }
+
+    @Scheduled(fixedRate = 15000)
+    public void sendHeartbeats() {
+        emitters.forEach((id, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event().comment("heartbeat"));
+            } catch (IOException e) {
+                removeEmitter(id);
+            }
+        });
     }
 
     public void notificarTransaccionAprobada(TransaccionResponse dto) {


### PR DESCRIPTION
## Summary
- keep transaction SSE connections alive by sending heartbeats every 15 seconds
- enable Spring scheduling to run the heartbeat job

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bebd1081c832dbe5ec528ee78ae74