### PR TITLE
Improve chat param handling

### DIFF
--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -24,25 +24,32 @@ const ChatPageContent = () => {
   const params = useParams();
   const searchParams = useSearchParams();
 
-  const chatId = params.matchId as string | undefined; // ID del chat (UUID)
+  const chatId = params.matchId as string | undefined;
   const opponentTagParam = searchParams.get('opponentTag');
-  const opponentGoogleIdParam = searchParams.get('opponentGoogleId'); // googleId del oponente
+  const opponentGoogleIdParam = searchParams.get('opponentGoogleId');
 
-  const hasValidParams =
-    chatId && opponentTagParam && opponentTagParam !== 'null' &&
-    opponentGoogleIdParam && opponentGoogleIdParam !== 'null';
+  const paramsLoaded = chatId !== undefined && opponentTagParam !== null && opponentGoogleIdParam !== null;
+  const hasValidParams = paramsLoaded && opponentTagParam !== 'null' && opponentGoogleIdParam !== 'null';
 
-  const opponentTag = hasValidParams ? opponentTagParam : undefined;
-  const opponentGoogleId = hasValidParams ? opponentGoogleIdParam : undefined;
-  const opponentAvatar = searchParams.get('opponentAvatar') ||
-    (opponentTag ? `https://placehold.co/40x40.png?text=${opponentTag[0]}` : undefined);
+  const incompleteData = !hasValidParams;
+
+  useEffect(() => {
+    console.log('router.query', { chatId, opponentTag: opponentTagParam, opponentGoogleId: opponentGoogleIdParam });
+    if (!paramsLoaded) {
+      console.warn('Faltan parámetros para cargar el chat', { chatId, opponentTag: opponentTagParam, opponentGoogleId: opponentGoogleIdParam });
+    } else if (!hasValidParams) {
+      console.warn('Parámetros inválidos', { chatId, opponentTag: opponentTagParam, opponentGoogleId: opponentGoogleIdParam });
+    }
+  }, [chatId, opponentTagParam, opponentGoogleIdParam, paramsLoaded, hasValidParams]);
 
   const { toast } = useToast();
-  const incompleteData = !hasValidParams;
+  const { messages, sendMessage } = useFirestoreChat(hasValidParams ? chatId : undefined);
+  const opponentTag = hasValidParams ? opponentTagParam! : undefined;
+  const opponentGoogleId = hasValidParams ? opponentGoogleIdParam! : undefined;
+  const opponentAvatar = hasValidParams ? (searchParams.get('opponentAvatar') || `https://placehold.co/40x40.png?text=${opponentTag![0]}`) : undefined;
   const validChatId = chatId as string;
   const validOpponentTag = opponentTag as string;
   const validOpponentGoogleId = opponentGoogleId as string;
-  const { messages, sendMessage } = useFirestoreChat(incompleteData ? undefined : chatId);
   const sendMessageSafely = (msg: Omit<ChatMessage, 'id'>) => {
     if (!opponentTag || !opponentGoogleId) {
       console.error('❌ Datos incompletos para iniciar chat');
@@ -149,7 +156,8 @@ const ChatPageContent = () => {
 
 
   if (!user) return <p>Cargando chat...</p>;
-  if (incompleteData) return <p>Datos de la partida incompletos.</p>;
+  if (!paramsLoaded) return <p>Cargando datos del chat...</p>;
+  if (!hasValidParams) return <p>Datos de la partida incompletos.</p>;
 
 
   return (


### PR DESCRIPTION
## Summary
- guard against missing query parameters in chat page
- log query params and warn when incomplete
- show loading message while params load

## Testing
- `npm --prefix front run lint` *(fails: next not found / prompts)*
- `npm --prefix front run typecheck` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_b_685bf45ef560832d8a0db4fcfef1a9a6