### PR TITLE
Add Firebase env setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Arena Real
+
+Este proyecto usa Firebase en el front-end. Las credenciales deben declararse en un archivo `.env.local` en la carpeta `front`.
+
+Ejemplo de archivo `.env.local`:
+
+```env
+NEXT_PUBLIC_FIREBASE_API_KEY=tuApiKey
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=tu-app.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=tu-project-id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=tu-storage-bucket
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=tu-sender-id
+NEXT_PUBLIC_FIREBASE_APP_ID=tu-app-id
+```
+
+Recuerda reiniciar el servidor de desarrollo después de modificar este archivo.

--- a/front/firebaseConfig.js
+++ b/front/firebaseConfig.js
@@ -1,0 +1,12 @@
+import { initializeApp } from 'firebase/app';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+export const firebaseApp = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- add README with Firebase `.env.local` instructions
- add `front/firebaseConfig.js` example using env vars

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685bfd3dd994832d9fc18e9506493d1f