### PR TITLE
Fix chat matchmaking events

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -77,11 +77,14 @@ const HomePageContent = () => {
       return;
     }
 
+    setIsSearching(true);
+
     console.log('Iniciando matchmaking con', { userId: user.id, mode });
-    const result = await matchmakingAction(user.id,  mode, 6000 );
+    const result = await matchmakingAction(user.id, mode, 6000);
     console.log('Resultado de matchmakingAction:', result);
 
     if (result.error) {
+      setIsSearching(false);
       toast({
         title: "Error de Emparejamiento",
         description: result.error,
@@ -89,8 +92,6 @@ const HomePageContent = () => {
       });
       return;
     }
-
-    setIsSearching(true);
 
     if (
       result.match &&


### PR DESCRIPTION
## Summary
- avoid reconnecting SSE listener on every render
- persist onMatch handler via ref and allow credentials on EventSource
- open SSE connection before calling matchmaking request

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: numerous missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_685c633be6e0832d9442dfc276e92086