### PR TITLE
Refactor frontend config

### DIFF
--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -14,6 +14,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Send, Link as LinkIconLucide, CheckCircle, XCircle, UploadCloud } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
 import useFirestoreChat from '@/hooks/useFirestoreChat';
+import { BACKEND_URL } from '@/lib/config';
 import type { ChatMessage, User } from '@/types';
 
 import { Label } from '@/components/ui/label';
@@ -24,7 +25,6 @@ const ChatPageContent = () => {
   const params = useParams();
   const searchParams = useSearchParams();
 
-  const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_API_URL || 'http://localhost:8080';
 
   const chatId = params.matchId as string | undefined;
   const opponentTagParam = searchParams.get('opponentTag');

--- a/front/src/hooks/useApprovedTransactionsSse.ts
+++ b/front/src/hooks/useApprovedTransactionsSse.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
+import { BACKEND_URL } from '@/lib/config';
 
 export interface ApprovedTransaction {
   id: string;
@@ -10,7 +11,6 @@ export interface ApprovedTransaction {
   creadoEn: string;
 }
 
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_API_URL || 'http://localhost:8080';
 
 export default function useApprovedTransactionsSse() {
   const [transactions, setTransactions] = useState<ApprovedTransaction[]>([]);

--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useToast } from '@/hooks/use-toast';
-
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_API_URL || 'http://localhost:8080';
+import { BACKEND_URL } from '@/lib/config';
 
 interface MatchEventData {
   apuestaId: string;

--- a/front/src/hooks/useTransactionUpdates.ts
+++ b/front/src/hooks/useTransactionUpdates.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
+import { BACKEND_URL } from '@/lib/config';
 
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_API_URL || 'http://localhost:8080';
 
 /**
  * Hook to subscribe to transaction updates via Server-Sent Events (SSE).

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -12,8 +12,7 @@ import type {
   BackendMatchmakingResponseDto,
   RegistrarUsuarioRequest,
 } from '@/types'
-
-const BACKEND_URL = process.env.BACKEND_API_URL || 'http://localhost:8080'
+import { BACKEND_URL } from '@/lib/config'
 
 /* -------------------------
    USUARIO

--- a/front/src/lib/config.ts
+++ b/front/src/lib/config.ts
@@ -1,0 +1,4 @@
+export const BACKEND_URL =
+  process.env.NEXT_PUBLIC_BACKEND_API_URL ||
+  process.env.BACKEND_API_URL ||
+  'http://localhost:8080';


### PR DESCRIPTION
## Summary
- centralize BACKEND_URL constant in frontend
- update matchmaking and chat code to use the shared config

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*
- `npm run lint` *(prompts for ESLint config)*
- `npm run typecheck` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_685c6f55e524832db18f5b27661316a3