### PR TITLE
Fix opponent tag null

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
@@ -30,11 +30,12 @@ public class    MatchmakingController {
                             ? partida.getJugador2()
                             : partida.getJugador1();
 
+                    String tag = oponente.getTagClash() != null ? oponente.getTagClash() : oponente.getNombre();
                     return MatchSseDto.builder()
                             .apuestaId(partida.getApuesta().getId())
                             .chatId(partida.getChatId())
                             .jugadorOponenteId(oponente.getId())
-                            .jugadorOponenteTag(oponente.getTagClash())
+                            .jugadorOponenteTag(tag)
                             .build();
                 })
                 .<ResponseEntity<?>>map(ResponseEntity::ok)

--- a/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
@@ -43,11 +43,12 @@ public class MatchSseService {
         if (emitter == null) {
             return;
         }
+        String tag = oponente.getTagClash() != null ? oponente.getTagClash() : oponente.getNombre();
         MatchSseDto dto = MatchSseDto.builder()
                 .apuestaId(apuestaId)
                 .chatId(chatId)
                 .jugadorOponenteId(oponente.getId())
-                .jugadorOponenteTag(oponente.getTagClash())
+                .jugadorOponenteTag(tag)
                 .build();
         try {
             emitter.send(SseEmitter.event()


### PR DESCRIPTION
## Summary
- send opponent tag fallback using player name when tag is missing

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(interactive prompt)*
- `npm run typecheck` *(errors, missing modules and TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_685c93fb0edc832d9ada5ad6e09c3868