### PR TITLE
Fix cancel matchmaking in frontend

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -13,7 +13,7 @@ import { Label } from '@/components/ui/label';
 import { SaldoIcon, FindMatchIcon } from '@/components/icons/ClashRoyaleIcons';
 import { useToast } from "@/hooks/use-toast";
 import { Coins, UploadCloud, Swords, Layers, Banknote, Loader2 } from 'lucide-react';
-import { requestTransactionAction, matchmakingAction } from '@/lib/actions';
+import { requestTransactionAction, matchmakingAction, cancelMatchmakingAction } from '@/lib/actions';
 import useTransactionUpdates from '@/hooks/useTransactionUpdates';
 import useMatchmakingSse from '@/hooks/useMatchmakingSse';
 
@@ -229,13 +229,21 @@ const HomePageContent = () => {
     setIsModeModalOpen(true);
   };
 
-  const handleModeSelect = async (mode: 'CLASICO' | 'TRIPLE_ELECCION  ') => {
+  const handleModeSelect = async (mode: 'CLASICO' | 'TRIPLE_ELECCION') => {
     setIsModeModalOpen(false);
     await handleFindMatch(mode);
   };
 
-  const handleCancelSearch = () => {
+  const handleCancelSearch = async () => {
     setIsSearching(false);
+    if (user?.id) {
+      const result = await cancelMatchmakingAction(user.id);
+      if (result.error) {
+        toast({ title: 'Error al cancelar', description: result.error, variant: 'destructive' });
+      } else {
+        toast({ title: 'Búsqueda cancelada', description: 'Se canceló la búsqueda de oponente.' });
+      }
+    }
   };
 
 

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -240,3 +240,24 @@ export async function matchmakingAction(
     return { match: null, error: err.message || 'Error de red durante el matchmaking.' }
   }
 }
+
+export async function cancelMatchmakingAction(
+  userGoogleId: string
+): Promise<{ success: boolean; error: string | null }> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/matchmaking/cancelar`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jugadorId: userGoogleId }),
+    })
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      return { success: false, error: err.message || `Error ${res.status}` }
+    }
+
+    return { success: true, error: null }
+  } catch (err: any) {
+    return { success: false, error: err.message || 'Error de red.' }
+  }
+}


### PR DESCRIPTION
## Summary
- allow cancelling matchmaking in the frontend
- send cancel request to backend when stopping search

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: missing module '@radix-ui/react-separator' and EventListener type errors)*

------
https://chatgpt.com/codex/tasks/task_b_685c93b498b4832d9a42c9f530cce6ad