### PR TITLE
Fix Firebase initialization

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/FirebaseConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/FirebaseConfig.java
@@ -14,8 +14,6 @@ public class FirebaseConfig {
 
     @Bean
     public FirebaseApp firebaseApp() throws IOException {
-        System.out.println("Firebase inicializado con: " + FirebaseApp.getInstance().getName());
-
         if (!FirebaseApp.getApps().isEmpty()) {
             return FirebaseApp.getInstance(); // Ya hay una instancia, la retornamos.
         }
@@ -41,6 +39,8 @@ public class FirebaseConfig {
                 .setCredentials(credentials)
                 .build();
 
-        return FirebaseApp.initializeApp(options);
+        FirebaseApp app = FirebaseApp.initializeApp(options);
+        System.out.println("Firebase inicializado con: " + app.getName());
+        return app;
     }
 }


### PR DESCRIPTION
## Summary
- ensure firebase bean initializes before logging

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_685cb306a180832db6062b4f142b92e5