### PR TITLE
Prevent matchmaking while player already active

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/MatchmakingService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchmakingService.java
@@ -50,6 +50,12 @@ public class MatchmakingService {
             throw new IllegalArgumentException("Saldo insuficiente para realizar esta operación");
         }
 
+        if (partidaRepository.existsActiveByJugador(
+                jugadorEnEspera.getId(),
+                List.of(EstadoPartida.EN_CURSO, EstadoPartida.POR_APROBAR))) {
+            throw new IllegalStateException("El jugador ya tiene una partida en curso");
+        }
+
         cancelarSolicitudes(jugadorEnEspera);
 
         PartidaEnEspera partidaEnEsperaRq = PartidaEnEsperaMapper.toEntity(request);

--- a/back/src/main/java/co/com/arena/real/infrastructure/repository/PartidaRepository.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/repository/PartidaRepository.java
@@ -1,12 +1,19 @@
 package co.com.arena.real.infrastructure.repository;
 
+import co.com.arena.real.domain.entity.partida.EstadoPartida;
 import co.com.arena.real.domain.entity.partida.Partida;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface PartidaRepository extends JpaRepository<Partida, UUID> {
     Optional<Partida> findByApuesta_Id(UUID apuestaId);
+
+    @Query("SELECT COUNT(p) > 0 FROM Partida p WHERE (p.jugador1.id = :jugadorId OR p.jugador2.id = :jugadorId) AND p.estado IN :estados")
+    boolean existsActiveByJugador(@Param("jugadorId") String jugadorId, @Param("estados") Collection<EstadoPartida> estados);
 
 }


### PR DESCRIPTION
## Summary
- block matchmaking if player already has an active game
- expose repository method to check active matches

## Testing
- `npm run lint` *(fails: interactive ESLint prompt)*
- `npm run typecheck` *(fails: TS2307 cannot find module '@radix-ui/react-separator')*

------
https://chatgpt.com/codex/tasks/task_b_685cd6a28724832d9ab7025e3941ed7f