### PR TITLE
Fix header user name display

### DIFF
--- a/front/src/components/AppHeader.tsx
+++ b/front/src/components/AppHeader.tsx
@@ -58,7 +58,7 @@ const AppHeader = () => {
                   <AvatarImage src={user.avatarUrl || `https://placehold.co/100x100.png?text=${user.clashTag?.[0] || 'U'}`} alt={user.clashTag || "User"} data-ai-hint="gaming avatar" />
                   <AvatarFallback>{user.clashTag?.[0] || 'U'}</AvatarFallback>
                 </Avatar>
-                <span className="hidden lg:inline text-primary-foreground font-semibold">{user.clashTag}</span>
+                <span className="hidden lg:inline text-primary-foreground font-semibold">{user.username}</span>
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="bg-card border-border shadow-xl w-56">


### PR DESCRIPTION
## Summary
- show the current user's username in the header dropdown trigger

## Testing
- `npm run lint` *(fails: asks for ESLint configuration)*
- `npm run typecheck` *(fails: several TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_685ceefb3ccc832da284cfbe0ab599fe