### PR TITLE
Add bottom navigation bar

### DIFF
--- a/front/src/components/AppLayout.tsx
+++ b/front/src/components/AppLayout.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import Navbar from './Navbar';
+import BottomNav from './BottomNav';
 import AuthGuard from './AuthGuard';
 
 const AppLayout = ({ children }: { children: React.ReactNode }) => {
@@ -16,6 +17,7 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
         <footer className="bg-primary/10 text-center py-4 text-sm text-foreground/70 font-headline">
           Arena Real &copy; {new Date().getFullYear()}
         </footer>
+        <BottomNav />
       </div>
     </AuthGuard>
   );

--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Home, Bell, Gamepad2, User, Menu } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const BottomNav = () => {
+  const pathname = usePathname();
+  const navItems = [
+    { href: "/", label: "Inicio", icon: Home },
+    { href: "/notifications", label: "Notificaciones", icon: Bell },
+    { href: "/play", label: "Jugar", icon: Gamepad2 },
+    { href: "/profile", label: "Usuario", icon: User },
+    { href: "/menu", label: "Menú", icon: Menu },
+  ];
+
+  return (
+    <nav className="md:hidden fixed bottom-0 w-full z-50 bg-[#122A70]">
+      <ul className="flex justify-around">
+        {navItems.map(({ href, label, icon: Icon }) => {
+          const active = pathname === href;
+          return (
+            <li key={href}>
+              <Link
+                href={href}
+                className={cn(
+                  "flex flex-col items-center py-2 text-xs transition-all ease-in-out",
+                  active
+                    ? "text-[#FFD600] scale-110 font-bold"
+                    : "text-white opacity-70"
+                )}
+              >
+                <Icon className="h-6 w-6 mb-0.5" />
+                <span>{label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};
+
+export default BottomNav;


### PR DESCRIPTION
## Summary
- add new `BottomNav` component using lucide-react icons
- use `BottomNav` in `AppLayout` for mobile navigation

## Testing
- `npm run typecheck` *(fails: cannot find module '@radix-ui/react-separator')*
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_b_685d0c64e544832d962eaba0d814d1e3