### PR TITLE
Add mobile top header and main layout

### DIFF
--- a/front/src/components/AppLayout.tsx
+++ b/front/src/components/AppLayout.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import Navbar from './Navbar';
+import BottomNav from './BottomNav';
 import AuthGuard from './AuthGuard';
 
 const AppLayout = ({ children }: { children: React.ReactNode }) => {
@@ -16,6 +17,7 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
         <footer className="bg-primary/10 text-center py-4 text-sm text-foreground/70 font-headline">
           Arena Real &copy; {new Date().getFullYear()}
         </footer>
+        <BottomNav />
       </div>
     </AuthGuard>
   );

--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Home, Bell, MessageCircle, User, Menu } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const BottomNav = () => {
+  const pathname = usePathname();
+  const navItems = [
+    { href: "/", label: "Inicio", icon: Home },
+    { href: "/notifications", label: "Notificaciones", icon: Bell },
+    { href: "/chat", label: "Chat", icon: MessageCircle },
+    { href: "/profile", label: "Usuario", icon: User },
+    { href: "/menu", label: "Menú", icon: Menu },
+  ];
+
+  return (
+    <nav className="md:hidden fixed bottom-0 w-full z-50 bg-[#122A70]">
+      <ul className="flex justify-around">
+        {navItems.map(({ href, label, icon: Icon }) => {
+          const active = pathname === href;
+          return (
+            <li key={href}>
+              <Link
+                href={href}
+                className={cn(
+                  "flex flex-col items-center py-2 text-xs transition-all ease-in-out",
+                  active
+                    ? "text-[#FFD600] scale-110 font-bold"
+                    : "text-white opacity-70"
+                )}
+              >
+                <Icon className="h-6 w-6 mb-0.5" />
+                <span>{label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};
+
+export default BottomNav;

--- a/front/src/components/MainLayout.tsx
+++ b/front/src/components/MainLayout.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import React from "react";
+import AuthGuard from "./AuthGuard";
+import TopNavbar from "./TopNavbar";
+import BottomNav from "./BottomNav";
+
+const MainLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <AuthGuard>
+      <div className="flex flex-col min-h-screen bg-background text-foreground font-body">
+        <TopNavbar />
+        <main className="flex-grow pt-14 pb-24 px-4">{children}</main>
+        <BottomNav />
+      </div>
+    </AuthGuard>
+  );
+};
+
+export default MainLayout;

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useAuth } from "@/hooks/useAuth";
+
+const TopNavbar = () => {
+  const { user } = useAuth();
+  const balance = user?.balance ?? 0;
+
+  const formatted = new Intl.NumberFormat("es-CO", {
+    style: "currency",
+    currency: "COP",
+    minimumFractionDigits: 0,
+  }).format(balance);
+
+  return (
+    <header className="md:hidden flex justify-between items-center px-4 py-2 bg-[#3973FF]">
+      <span className="font-bold text-white">Arena Real</span>
+      <span className="text-[#FFD600]">{formatted}</span>
+    </header>
+  );
+};
+
+export default TopNavbar;


### PR DESCRIPTION
## Summary
- implement `TopNavbar` showing brand and balance for mobile
- add `MainLayout` wrapper with mobile navbars

## Testing
- `npm run typecheck` *(fails to find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d0c64e544832d962eaba0d814d1e3