### PR TITLE
Add mobile top header and main layout

### DIFF
--- a/front/src/components/AppLayout.tsx
+++ b/front/src/components/AppLayout.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import Navbar from './Navbar';
+import BottomNav from './BottomNav';
 import AuthGuard from './AuthGuard';
 
 const AppLayout = ({ children }: { children: React.ReactNode }) => {
@@ -16,6 +17,7 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
         <footer className="bg-primary/10 text-center py-4 text-sm text-foreground/70 font-headline">
           Arena Real &copy; {new Date().getFullYear()}
         </footer>
+        <BottomNav />
       </div>
     </AuthGuard>
   );

--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  Home,
+  Bell,
+  Gamepad2,
+  User,
+  MessageCircle,
+  Menu as MenuIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const navItems = [
+  { id: "inicio", label: "Inicio", href: "/", icon: Home },
+  { id: "notificaciones", label: "Notificaciones", href: "/notifications", icon: Bell },
+  { id: "jugar", label: "Jugar", href: "/play", icon: Gamepad2 },
+  { id: "usuario", label: "Usuario", href: "/profile", icon: User },
+  { id: "chat", label: "Chat", href: "/chat", icon: MessageCircle },
+  { id: "menu", label: "Menú", href: "/menu", icon: MenuIcon },
+];
+
+const BottomNav = () => {
+  const [active, setActive] = useState("jugar");
+
+  return (
+    <nav className="md:hidden fixed bottom-0 w-full z-50 bg-[#3973FF] border-t border-blue-800 h-16">
+      <ul className="flex h-full items-center justify-around">
+        {navItems.map(({ id, label, href, icon: Icon }) => {
+          const isActive = active === id;
+          return (
+            <li key={id}>
+              <Link
+                href={href}
+                onClick={() => setActive(id)}
+                className={cn(
+                  "flex flex-col items-center text-xs transition-all ease-in-out",
+                  isActive
+                    ? "text-[#FFD600] scale-110 font-bold"
+                    : "text-white opacity-70"
+                )}
+              >
+                <Icon className="w-6 h-6 mb-1" />
+                <span>{label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};
+
+export default BottomNav;

--- a/front/src/components/MainLayout.tsx
+++ b/front/src/components/MainLayout.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import React from "react";
+import AuthGuard from "./AuthGuard";
+import TopNavbar from "./TopNavbar";
+import BottomNav from "./BottomNav";
+
+const MainLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <AuthGuard>
+      <div className="flex flex-col min-h-screen bg-background text-foreground font-body">
+        <TopNavbar />
+        <main className="flex-grow pt-14 pb-24 px-4">{children}</main>
+        <BottomNav />
+      </div>
+    </AuthGuard>
+  );
+};
+
+export default MainLayout;

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useAuth } from "@/hooks/useAuth";
+
+const TopNavbar = () => {
+  const { user } = useAuth();
+  const balance = user?.balance ?? 0;
+
+  const formatted = new Intl.NumberFormat("es-CO", {
+    style: "currency",
+    currency: "COP",
+    minimumFractionDigits: 0,
+  }).format(balance);
+
+  return (
+    <header className="md:hidden flex justify-between items-center px-4 py-2 bg-[#3973FF]">
+      <span className="font-bold text-white">Arena Real</span>
+      <span className="text-[#FFD600]">{formatted}</span>
+    </header>
+  );
+};
+
+export default TopNavbar;


### PR DESCRIPTION
## Summary
- implement `TopNavbar` showing brand and balance for mobile
- add `MainLayout` wrapper with mobile navbars
- redesign `BottomNav` for six-icon menu on mobile

## Testing
- `npm run typecheck` *(fails to find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d0c64e544832d962eaba0d814d1e3