### PR TITLE
Implement chat list page

### DIFF
--- a/front/src/app/chat/page.tsx
+++ b/front/src/app/chat/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import AppLayout from '@/components/AppLayout';
+import { useAuth } from '@/hooks/useAuth';
+import useFirestoreChats from '@/hooks/useFirestoreChats';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { BACKEND_URL } from '@/lib/config';
+
+interface OpponentInfo { id: string; tag: string; }
+
+const ChatListPageContent = () => {
+  const { user } = useAuth();
+  const { chats } = useFirestoreChats(user?.id);
+  const [opponents, setOpponents] = useState<Record<string, OpponentInfo>>({});
+
+  useEffect(() => {
+    const loadOpponents = async () => {
+      if (!user) return;
+      const ids = Array.from(new Set(chats.map(c => c.jugadores.find(j => j !== user.id)).filter(Boolean))) as string[];
+      await Promise.all(ids.map(async id => {
+        if (opponents[id]) return;
+        try {
+          const res = await fetch(`${BACKEND_URL}/api/jugadores/${id}`);
+          if (res.ok) {
+            const data = await res.json();
+            setOpponents(prev => ({ ...prev, [id]: { id: data.id, tag: data.tagClash || data.nombre } }));
+          }
+        } catch (err) {
+          console.error('Error fetching opponent', err);
+        }
+      }));
+    };
+    loadOpponents();
+  }, [chats, user, opponents]);
+
+  if (!user) return <p>Cargando chats...</p>;
+
+  return (
+    <Card className="shadow-card-medieval border-2 border-primary-dark overflow-hidden">
+      <CardHeader className="bg-primary/10">
+        <CardTitle className="text-3xl font-headline text-primary">Chats</CardTitle>
+        <CardDescription className="text-muted-foreground text-lg pt-1">
+          Conversaciones de tus partidas
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-4">
+        {chats.length === 0 ? (
+          <p className="text-center text-muted-foreground py-8">No tienes chats todavía.</p>
+        ) : (
+          <ul className="space-y-3">
+            {chats.map(chat => {
+              const opponentId = chat.jugadores.find(j => j !== user.id) as string | undefined;
+              const opponent = opponentId ? opponents[opponentId] : undefined;
+              const tag = opponent ? opponent.tag : opponentId || 'Oponente';
+              const href = `/chat/${chat.id}?opponentTag=${encodeURIComponent(tag)}&opponentGoogleId=${encodeURIComponent(opponentId ?? '')}`;
+              return (
+                <li key={chat.id}>
+                  <Link href={href} className="block border rounded-lg p-3 hover:bg-primary/10">
+                    <div className="flex justify-between items-center">
+                      <span className="font-medium">{tag}</span>
+                      {chat.activo && <Badge className="ml-2">En curso</Badge>}
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default function ChatListPage() {
+  return (
+    <AppLayout>
+      <ChatListPageContent />
+    </AppLayout>
+  );
+}

--- a/front/src/hooks/useFirestoreChats.ts
+++ b/front/src/hooks/useFirestoreChats.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { collection, query, where, onSnapshot } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+
+export interface ChatSummary {
+  id: string;
+  jugadores: string[];
+  activo: boolean;
+}
+
+export default function useFirestoreChats(userId: string | undefined) {
+  const [chats, setChats] = useState<ChatSummary[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const q = query(collection(db, 'chats'), where('jugadores', 'array-contains', userId));
+    const unsub = onSnapshot(
+      q,
+      snapshot => {
+        const data: ChatSummary[] = [];
+        snapshot.forEach(doc => {
+          const d = doc.data() as any;
+          data.push({
+            id: doc.id,
+            jugadores: Array.isArray(d.jugadores) ? d.jugadores : [],
+            activo: d.activo ?? false,
+          });
+        });
+        data.sort((a, b) => Number(b.activo) - Number(a.activo));
+        setChats(data);
+      },
+      err => {
+        console.error('Error listening chats', err);
+        setError(err);
+      }
+    );
+
+    return () => unsub();
+  }, [userId]);
+
+  return { chats, error };
+}


### PR DESCRIPTION
## Summary
- add `useFirestoreChats` hook to retrieve chat summaries
- create `/chat` page listing past and active chats

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: cannot find module '@radix-ui/react-separator' and EventListener type errors)*

------
https://chatgpt.com/codex/tasks/task_b_685d2275ffbc832dbdca372a55b901f3