### PR TITLE
Update navbar options

### DIFF
--- a/front/src/components/Navbar.tsx
+++ b/front/src/components/Navbar.tsx
@@ -9,6 +9,7 @@ import {
   Menu,
   Crown,
   ScrollText,
+  MessageCircle,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -30,7 +31,8 @@ const Navbar = () => {
   const navItems = [
     { href: '/', label: 'Home', icon: Home },
     { href: '/history', label: 'Historial', icon: ScrollText },
-    { href: '/torneo', label: 'Torneo', icon: Trophy },
+    { href: '/chat', label: 'Chats', icon: MessageCircle },
+    { href: '/torneos', label: 'Torneos', icon: Trophy },
   ];
 
   // TODO: replace with real notification count


### PR DESCRIPTION
## Summary
- include Chat and Tournaments links in the main Navbar

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run typecheck` *(fails: cannot find module '@radix-ui/react-separator' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_b_685d279f7d8c832db6dfefa58dd9d3c7