### PR TITLE
Fix repeated start message

### DIFF
--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -74,6 +74,12 @@ const ChatPageContent = () => {
   const [screenshotFile, setScreenshotFile] = useState<File | null>(null);
   const [resultSubmitted, setResultSubmitted] = useState(false);
 
+  const startMessageSentRef = useRef(false);
+
+  useEffect(() => {
+    startMessageSentRef.current = false;
+  }, [validChatId]);
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const scrollToBottom = () => {
@@ -113,7 +119,7 @@ const ChatPageContent = () => {
   }, [hasValidParams, validOpponentGoogleId, BACKEND_URL]);
 
   useEffect(() => {
-    if (incompleteData || !user || !opponentProfile) return;
+    if (incompleteData || !user || !opponentProfile || startMessageSentRef.current) return;
     if (messages.length === 0) {
       const startMsg = {
         matchId: validChatId,
@@ -123,7 +129,7 @@ const ChatPageContent = () => {
         isSystemMessage: true,
       };
       sendMessageSafely(startMsg);
-
+      startMessageSentRef.current = true;
     }
   }, [user, opponentProfile, validChatId, validOpponentTag, opponentDisplayName, messages.length, incompleteData]);
 


### PR DESCRIPTION
## Summary
- prevent sending the initial duel message multiple times by tracking if it was already sent

## Testing
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run typecheck` *(fails: missing module '@radix-ui/react-separator')*

------
https://chatgpt.com/codex/tasks/task_b_685dc1412aac832d9eef8bf5fed45f93