### PR TITLE
Improve mobile header

### DIFF
--- a/front/src/components/AppLayout.tsx
+++ b/front/src/components/AppLayout.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import Navbar from './Navbar';
+import TopNavbar from './TopNavbar';
 import BottomNav from './BottomNav';
 import AuthGuard from './AuthGuard';
 
@@ -10,8 +11,13 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <AuthGuard>
       <div className="flex flex-col min-h-screen bg-background text-foreground font-body">
-        <Navbar />
-        <main className="flex-grow container mx-auto px-4 py-6 md:px-6 md:py-8 lg:px-8 lg:py-10 animate-fade-in-up">
+        <div className="md:hidden">
+          <TopNavbar />
+        </div>
+        <div className="hidden md:block">
+          <Navbar />
+        </div>
+        <main className="flex-grow container mx-auto px-4 pt-14 pb-24 md:pt-8 md:pb-8 md:px-6 lg:px-8 lg:py-10 animate-fade-in-up">
           {children}
         </main>
         <footer className="bg-primary/10 text-center py-4 text-sm text-foreground/70 font-headline">


### PR DESCRIPTION
## Summary
- show `TopNavbar` on mobile screens and keep desktop `Navbar`
- adjust `AppLayout` padding for fixed headers

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck` *(fails: cannot find module `@radix-ui/react-separator`)*

------
https://chatgpt.com/codex/tasks/task_b_685dcfe1fd1c832d87741f31ccb9ff68