### PR TITLE
Add button hover animation

### DIFF
--- a/front/src/components/Navbar.tsx
+++ b/front/src/components/Navbar.tsx
@@ -49,7 +49,7 @@ const Navbar = () => {
 
         {/* Mobile hamburger */}
         <button
-          className="rounded-md p-2 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:hidden"
+          className="rounded-md p-2 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:hidden transition-transform hover:scale-105"
           onClick={() => setMobileOpen(!mobileOpen)}
           aria-label="Toggle menu"
         >
@@ -73,7 +73,7 @@ const Navbar = () => {
         {/* Right side icons */}
         {isAuthenticated && user && (
           <div className="hidden items-center gap-4 md:flex">
-            <button className="relative rounded-full p-2 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">
+            <button className="relative rounded-full p-2 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white transition-transform hover:scale-105">
               <Bell className="h-6 w-6" />
               {notifications > 0 && (
                 <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-600 text-xs">
@@ -83,7 +83,7 @@ const Navbar = () => {
             </button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <button className="flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">
+                <button className="flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white transition-transform hover:scale-105">
                   <Avatar className="h-8 w-8">
                     <AvatarImage src={user.avatarUrl} alt={user.username} />
                     <AvatarFallback>{user.username?.[0] || 'U'}</AvatarFallback>
@@ -119,7 +119,7 @@ const Navbar = () => {
             ))}
             {isAuthenticated && user && (
               <div className="flex items-center gap-3 pt-2">
-                <button className="relative rounded-full p-2 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">
+                <button className="relative rounded-full p-2 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white transition-transform hover:scale-105">
                   <Bell className="h-6 w-6" />
                   {notifications > 0 && (
                     <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-600 text-xs">
@@ -129,7 +129,7 @@ const Navbar = () => {
                 </button>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <button className="flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">
+                    <button className="flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white transition-transform hover:scale-105">
                       <Avatar className="h-8 w-8">
                         <AvatarImage src={user.avatarUrl} alt={user.username} />
                         <AvatarFallback>{user.username?.[0] || 'U'}</AvatarFallback>

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -31,7 +31,7 @@ const TopNavbar = () => {
         </div>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <button className="flex items-center gap-2 focus-visible:outline-none">
+            <button className="flex items-center gap-2 focus-visible:outline-none transition-transform hover:scale-105">
               <span className="text-white text-sm font-medium">
                 {user?.username || 'Invitado'}
               </span>

--- a/front/src/components/ui/CartoonButton.tsx
+++ b/front/src/components/ui/CartoonButton.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from "class-variance-authority";
 
 const cartoonButtonVariants = cva(
-  "inline-flex items-center justify-center rounded-lg font-headline text-lg font-semibold tracking-wide transition-all duration-150 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-0.5 disabled:pointer-events-none disabled:opacity-70",
+  "inline-flex items-center justify-center rounded-lg font-headline text-lg font-semibold tracking-wide transition-transform duration-150 ease-in-out hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-0.5 disabled:pointer-events-none disabled:opacity-70",
   {
     variants: {
       variant: {

--- a/front/src/components/ui/button.tsx
+++ b/front/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- add `hover:scale-105` and `transition-transform` to UI button components
- update navbar button classes for hover animation

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@radix-ui/react-separator')*

------
https://chatgpt.com/codex/tasks/task_b_685de72dda60832d96a6e5dd8577af0b