### PR TITLE
Show duel confirmation modal and record match declines

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
@@ -1,7 +1,9 @@
 package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.MatchmakingService;
+import co.com.arena.real.application.service.MatchDeclineService;
 import co.com.arena.real.infrastructure.dto.rq.CancelarMatchmakingRequest;
+import co.com.arena.real.infrastructure.dto.rq.MatchDeclineRequest;
 import co.com.arena.real.infrastructure.dto.rq.PartidaEnEsperaRequest;
 import co.com.arena.real.infrastructure.dto.rs.MatchSseDto;
 import co.com.arena.real.domain.entity.Jugador;
@@ -18,9 +20,10 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/matchmaking")
 @RequiredArgsConstructor
-public class    MatchmakingController {
+public class MatchmakingController {
 
     private final MatchmakingService matchmakingService;
+    private final MatchDeclineService matchDeclineService;
 
     @PostMapping("/ejecutar")
     public ResponseEntity<?> ejecutarMatchmaking(@RequestBody PartidaEnEsperaRequest request) {
@@ -51,6 +54,14 @@ public class    MatchmakingController {
         matchmakingService.cancelarSolicitudes(request.getJugadorId());
         Map<String, Object> resp = new HashMap<>();
         resp.put("status", "cancelado");
+        return ResponseEntity.ok(resp);
+    }
+
+    @PostMapping("/declinar")
+    public ResponseEntity<?> declinarPareja(@RequestBody MatchDeclineRequest request) {
+        matchDeclineService.recordDecline(request.getJugadorId(), request.getOponenteId());
+        Map<String, Object> resp = new HashMap<>();
+        resp.put("status", "registrado");
         return ResponseEntity.ok(resp);
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/MatchDeclineService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchDeclineService.java
@@ -1,0 +1,56 @@
+package co.com.arena.real.application.service;
+
+import co.com.arena.real.domain.entity.matchmaking.MatchDecline;
+import co.com.arena.real.infrastructure.repository.MatchDeclineRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class MatchDeclineService {
+
+    private final MatchDeclineRepository repository;
+
+    private String normalizeId(String a, String b, boolean first) {
+        return first ? (a.compareTo(b) <= 0 ? a : b) : (a.compareTo(b) <= 0 ? b : a);
+    }
+
+    @Transactional
+    public void recordDecline(String jugadorAId, String jugadorBId) {
+        String j1 = normalizeId(jugadorAId, jugadorBId, true);
+        String j2 = normalizeId(jugadorAId, jugadorBId, false);
+        LocalDateTime expira = LocalDateTime.now().plusHours(1);
+        repository.findByJugador1IdAndJugador2Id(j1, j2)
+                .ifPresentOrElse(p -> {
+                    p.setExpiraEn(expira);
+                    repository.save(p);
+                }, () -> {
+                    try {
+                        MatchDecline p = MatchDecline.builder()
+                                .jugador1Id(j1)
+                                .jugador2Id(j2)
+                                .expiraEn(expira)
+                                .build();
+                        repository.save(p);
+                    } catch (DataIntegrityViolationException e) {
+                        repository.findByJugador1IdAndJugador2Id(j1, j2)
+                                .ifPresent(existing -> {
+                                    existing.setExpiraEn(expira);
+                                    repository.save(existing);
+                                });
+                    }
+                });
+    }
+
+    public boolean isDeclined(String jugadorAId, String jugadorBId) {
+        String j1 = normalizeId(jugadorAId, jugadorBId, true);
+        String j2 = normalizeId(jugadorAId, jugadorBId, false);
+        return repository.findByJugador1IdAndJugador2Id(j1, j2)
+                .filter(p -> p.getExpiraEn().isAfter(LocalDateTime.now()))
+                .isPresent();
+    }
+}

--- a/back/src/main/java/co/com/arena/real/application/service/MatchmakingService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchmakingService.java
@@ -15,6 +15,11 @@ import co.com.arena.real.infrastructure.mapper.PartidaEnEsperaMapper;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
 import co.com.arena.real.infrastructure.repository.PartidaEnEsperaRepository;
 import co.com.arena.real.infrastructure.repository.PartidaRepository;
+import co.com.arena.real.application.service.ChatService;
+import co.com.arena.real.application.service.ApuestaService;
+import co.com.arena.real.application.service.MatchSseService;
+import co.com.arena.real.application.service.MatchDeclineService;
+import co.com.arena.real.application.service.TransaccionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +40,7 @@ public class MatchmakingService {
     private final ChatService chatService;
     private final ApuestaService apuestaService;
     private final MatchSseService matchSseService;
+    private final MatchDeclineService matchDeclineService;
 
     private static final List<ModoJuego> PRIORIDAD_MODO_JUEGO = List.of(
             ModoJuego.TRIPLE_ELECCION,
@@ -66,6 +72,14 @@ public class MatchmakingService {
         return partidaEnEsperaRepository.findByModoJuegoAndMonto(partidaEnEspera.getModoJuego(), request.getMonto())
                 .stream()
                 .filter(p -> !p.getJugador().getId().equals(partidaEnEspera.getJugador().getId()))
+                .filter(p -> {
+                    String a = p.getJugador().getId();
+                    String b = partidaEnEspera.getJugador().getId();
+                    if (matchDeclineService.isDeclined(a, b) && Math.random() < 0.5) {
+                        return false;
+                    }
+                    return true;
+                })
                 .findFirst() //todo: aquí debería estar la lógica para emparejar el matchmaking con personas del mismo nivel
                 .map(partidaEncontrada -> {
 

--- a/back/src/main/java/co/com/arena/real/domain/entity/matchmaking/MatchDecline.java
+++ b/back/src/main/java/co/com/arena/real/domain/entity/matchmaking/MatchDecline.java
@@ -1,0 +1,37 @@
+package co.com.arena.real.domain.entity.matchmaking;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "match_declines", uniqueConstraints = @UniqueConstraint(columnNames = {"jugador1_id", "jugador2_id"}))
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchDecline {
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "jugador1_id", nullable = false)
+    private String jugador1Id;
+
+    @Column(name = "jugador2_id", nullable = false)
+    private String jugador2Id;
+
+    @Column(name = "expira_en", nullable = false)
+    private LocalDateTime expiraEn;
+}

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/MatchDeclineRequest.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/MatchDeclineRequest.java
@@ -1,0 +1,9 @@
+package co.com.arena.real.infrastructure.dto.rq;
+
+import lombok.Data;
+
+@Data
+public class MatchDeclineRequest {
+    private String jugadorId;
+    private String oponenteId;
+}

--- a/back/src/main/java/co/com/arena/real/infrastructure/repository/MatchDeclineRepository.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/repository/MatchDeclineRepository.java
@@ -1,0 +1,11 @@
+package co.com.arena.real.infrastructure.repository;
+
+import co.com.arena.real.domain.entity.matchmaking.MatchDecline;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MatchDeclineRepository extends JpaRepository<MatchDecline, UUID> {
+    Optional<MatchDecline> findByJugador1IdAndJugador2Id(String jugador1Id, String jugador2Id);
+}

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -13,7 +13,7 @@ import { Label } from '@/components/ui/label';
 import { SaldoIcon, FindMatchIcon } from '@/components/icons/ClashRoyaleIcons';
 import { useToast } from "@/hooks/use-toast";
 import { Coins, UploadCloud, Swords, Layers, Banknote, Loader2 } from 'lucide-react';
-import { requestTransactionAction, matchmakingAction, cancelMatchmakingAction } from '@/lib/actions';
+import { requestTransactionAction, matchmakingAction, cancelMatchmakingAction, declineMatchAction } from '@/lib/actions';
 import useTransactionUpdates from '@/hooks/useTransactionUpdates';
 import useMatchmakingSse from '@/hooks/useMatchmakingSse';
 
@@ -35,14 +35,14 @@ const HomePageContent = () => {
 
   const [isModeModalOpen, setIsModeModalOpen] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
+  const [pendingMatch, setPendingMatch] = useState<{ apuestaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; chatId: string; } | null>(null);
+  const [timeLeft, setTimeLeft] = useState(25);
 
   const handleMatchFound = (data: { apuestaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; chatId: string; }) => {
     console.log('Match encontrado via SSE:', data);
     setIsSearching(false);
-    toast({ title: 'Duelo encontrado', description: 'Abriendo chat con tu oponente...' });
-    router.push(
-      `/chat/${data.chatId}?opponentTag=${encodeURIComponent(data.jugadorOponenteTag)}&opponentGoogleId=${encodeURIComponent(data.jugadorOponenteId)}`
-    );
+    setTimeLeft(25);
+    setPendingMatch(data);
   };
 
   useMatchmakingSse(isSearching ? user?.id : undefined, handleMatchFound);
@@ -53,6 +53,21 @@ const HomePageContent = () => {
       console.log("Datos del usuario actualmente en el estado del frontend:", user);
     }
   }, [user]);
+
+  useEffect(() => {
+    if (!pendingMatch) return;
+    const interval = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval);
+          handleDeclineMatch();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [pendingMatch]);
 
   if (!user) {
     return <p>Cargando datos del usuario...</p>;
@@ -103,6 +118,22 @@ const HomePageContent = () => {
       handleMatchFound(result.match);
     }
   };
+
+  function handleAcceptMatch() {
+    if (!pendingMatch) return;
+    toast({ title: 'Duelo encontrado', description: 'Abriendo chat con tu oponente...' });
+    router.push(
+      `/chat/${pendingMatch.chatId}?opponentTag=${encodeURIComponent(pendingMatch.jugadorOponenteTag)}&opponentGoogleId=${encodeURIComponent(pendingMatch.jugadorOponenteId)}`
+    );
+    setPendingMatch(null);
+  }
+
+  async function handleDeclineMatch() {
+    if (!pendingMatch) return;
+    await declineMatchAction(user.id, pendingMatch.jugadorOponenteId);
+    toast({ title: 'Duelo cancelado', description: 'No se iniciará este duelo.' });
+    setPendingMatch(null);
+  }
 
   // Deposit Modal Logic
   const handleOpenDepositModal = () => {
@@ -363,6 +394,30 @@ const HomePageContent = () => {
               <CartoonButton variant="secondary" size="small" onClick={handleCancelSearch}>
                 Cancelar
               </CartoonButton>
+            </CardFooter>
+          </Card>
+        </div>
+      )}
+
+      {/* Match Found Modal */}
+      {pendingMatch && (
+        <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4 animate-fade-in-up">
+          <Card className="w-full max-w-md shadow-xl border-2 border-accent">
+            <CardHeader>
+              <CardTitle className="text-3xl font-headline text-accent text-center">¡Duelo encontrado!</CardTitle>
+              <CardDescription className="text-center text-muted-foreground">Contra {pendingMatch.jugadorOponenteTag}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="h-3 w-full bg-secondary rounded">
+                <div
+                  className="h-3 bg-accent rounded"
+                  style={{ width: `${(timeLeft / 25) * 100}%`, transition: 'width 1s linear' }}
+                ></div>
+              </div>
+            </CardContent>
+            <CardFooter className="flex justify-end gap-3">
+              <CartoonButton variant="secondary" size="small" onClick={handleDeclineMatch}>Cancelar</CartoonButton>
+              <CartoonButton variant="default" size="small" onClick={handleAcceptMatch}>Aceptar</CartoonButton>
             </CardFooter>
           </Card>
         </div>

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -280,3 +280,25 @@ export async function cancelMatchmakingAction(
     return { success: false, error: err.message || 'Error de red.' }
   }
 }
+
+export async function declineMatchAction(
+  userGoogleId: string,
+  opponentId: string
+): Promise<{ success: boolean; error: string | null }> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/matchmaking/declinar`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jugadorId: userGoogleId, oponenteId: opponentId }),
+    })
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      return { success: false, error: err.message || `Error ${res.status}` }
+    }
+
+    return { success: true, error: null }
+  } catch (err: any) {
+    return { success: false, error: err.message || 'Error de red.' }
+  }
+}

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -154,3 +154,8 @@ export interface ChatMessage {
   timestamp: string;
   isSystemMessage?: boolean;
 }
+
+export interface BackendMatchDeclineRequestDto {
+  jugadorId: string;
+  oponenteId: string;
+}


### PR DESCRIPTION
## Summary
- rename penalty concept to match decline
- record declined pairs via `MatchDeclineService`
- add `/api/matchmaking/declinar` endpoint
- skip declined pairs with 50% chance when matchmaking
- show modal to accept/cancel duel with countdown

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_685e39a06f6c832d927ccd0154b21c0a