### PR TITLE
Add ongoing duel indicator on desktop

### DIFF
--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useAuth } from "@/hooks/useAuth";
+import useFirestoreChats from "@/hooks/useFirestoreChats";
 import {
   Home,
   Bell,
@@ -23,6 +25,9 @@ const navItems = [
 
 const BottomNav = () => {
   const [active, setActive] = useState("jugar");
+  const { user } = useAuth();
+  const { chats } = useFirestoreChats(user?.id);
+  const hasActiveChat = chats.some(c => c.activo);
 
   return (
     <nav className="md:hidden fixed bottom-0 w-full z-50 bg-[#3973FF] border-t border-blue-800 h-16">
@@ -41,7 +46,12 @@ const BottomNav = () => {
                     : "text-white opacity-70"
                 )}
               >
-                <Icon className="w-6 h-6 mb-1" />
+                <span className="relative">
+                  <Icon className="w-6 h-6 mb-1" />
+                  {id === "chat" && hasActiveChat && (
+                    <span className="absolute -top-1 -right-1 block w-3 h-3 bg-red-500 rounded-full" />
+                  )}
+                </span>
                 <span>{label}</span>
               </Link>
             </li>

--- a/front/src/components/Navbar.tsx
+++ b/front/src/components/Navbar.tsx
@@ -23,10 +23,13 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
 // Simple auth hook to access user data
 import { useAuth } from '@/hooks/useAuth';
+import useFirestoreChats from '@/hooks/useFirestoreChats';
 
 const Navbar = () => {
   const { user, logout, isAuthenticated } = useAuth();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const { chats } = useFirestoreChats(user?.id);
+  const hasActiveChat = chats.some(c => c.activo);
 
   const navItems = [
     { href: '/', label: 'Home', icon: Home },
@@ -64,7 +67,12 @@ const Navbar = () => {
               href={href}
               className="flex items-center gap-1 rounded-full px-3 py-1 text-white hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white active:bg-white/30"
             >
-              <Icon className="h-4 w-4" />
+              <span className="relative">
+                <Icon className="h-4 w-4" />
+                {href === '/chat' && hasActiveChat && (
+                  <span className="absolute -top-1 -right-1 block w-3 h-3 bg-red-500 rounded-full" />
+                )}
+              </span>
               {label}
             </Link>
           ))}
@@ -113,7 +121,12 @@ const Navbar = () => {
                 href={href}
                 className="flex items-center gap-2 rounded-full px-3 py-2 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
               >
-                <Icon className="h-5 w-5" />
+                <span className="relative">
+                  <Icon className="h-5 w-5" />
+                  {href === '/chat' && hasActiveChat && (
+                    <span className="absolute -top-1 -right-1 block w-3 h-3 bg-red-500 rounded-full" />
+                  )}
+                </span>
                 {label}
               </Link>
             ))}


### PR DESCRIPTION
## Summary
- show active chat badge in the desktop navigation

## Testing
- `npm run lint` *(fails: interactive ESLint setup prompt)*
- `npm run typecheck` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_68613e9d0320832d8adeb9fc72ee4603