### PR TITLE
Fix chat start messages

### DIFF
--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -53,7 +53,7 @@ const ChatPageContent = () => {
   }, [chatId, opponentTagParam, opponentGoogleIdParam, paramsLoaded, hasValidParams]);
 
   const { toast } = useToast();
-  const { messages, sendMessage } = useFirestoreChat(hasValidParams ? chatId : undefined);
+  const { messages, sendMessage, isLoading } = useFirestoreChat(hasValidParams ? chatId : undefined);
   const opponentTag = hasValidParams ? opponentTagParam! : undefined;
   const opponentGoogleId = hasValidParams ? opponentGoogleIdParam! : undefined;
   const opponentAvatar = hasValidParams ? (searchParams.get('opponentAvatar') || `https://placehold.co/40x40.png?text=${opponentTag![0]}`) : undefined;
@@ -119,7 +119,7 @@ const ChatPageContent = () => {
   }, [hasValidParams, validOpponentGoogleId, BACKEND_URL]);
 
   useEffect(() => {
-    if (incompleteData || !user || !opponentProfile || startMessageSentRef.current) return;
+    if (incompleteData || isLoading || !user || !opponentProfile || startMessageSentRef.current) return;
     if (messages.length === 0) {
       const startMsg = {
         matchId: validChatId,
@@ -131,7 +131,7 @@ const ChatPageContent = () => {
       sendMessageSafely(startMsg);
       startMessageSentRef.current = true;
     }
-  }, [user, opponentProfile, validChatId, validOpponentTag, opponentDisplayName, messages.length, incompleteData]);
+  }, [user, opponentProfile, validChatId, validOpponentTag, opponentDisplayName, messages.length, incompleteData, isLoading]);
 
   const handleSendMessage = (e: FormEvent) => {
     e.preventDefault();

--- a/front/src/app/chat/page.tsx
+++ b/front/src/app/chat/page.tsx
@@ -9,7 +9,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { BACKEND_URL } from '@/lib/config';
 
-interface OpponentInfo { id: string; tag: string; }
+interface OpponentInfo { id: string; name: string; }
 
 const ChatListPageContent = () => {
   const { user } = useAuth();
@@ -26,7 +26,7 @@ const ChatListPageContent = () => {
           const res = await fetch(`${BACKEND_URL}/api/jugadores/${id}`);
           if (res.ok) {
             const data = await res.json();
-            setOpponents(prev => ({ ...prev, [id]: { id: data.id, tag: data.tagClash || data.nombre } }));
+            setOpponents(prev => ({ ...prev, [id]: { id: data.id, name: data.nombre } }));
           }
         } catch (err) {
           console.error('Error fetching opponent', err);
@@ -54,13 +54,13 @@ const ChatListPageContent = () => {
             {chats.map(chat => {
               const opponentId = chat.jugadores.find(j => j !== user.id) as string | undefined;
               const opponent = opponentId ? opponents[opponentId] : undefined;
-              const tag = opponent ? opponent.tag : opponentId || 'Oponente';
-              const href = `/chat/${chat.id}?opponentTag=${encodeURIComponent(tag)}&opponentGoogleId=${encodeURIComponent(opponentId ?? '')}`;
+              const name = opponent ? opponent.name : opponentId || 'Oponente';
+              const href = `/chat/${chat.id}?opponentTag=${encodeURIComponent(name)}&opponentGoogleId=${encodeURIComponent(opponentId ?? '')}`;
               return (
                 <li key={chat.id}>
                   <Link href={href} className="block border rounded-lg p-3 hover:bg-primary/10">
                     <div className="flex justify-between items-center">
-                      <span className="font-medium">{tag}</span>
+                      <span className="font-medium">{name}</span>
                       {chat.activo && <Badge className="ml-2">En curso</Badge>}
                     </div>
                   </Link>

--- a/front/src/hooks/useFirestoreChat.ts
+++ b/front/src/hooks/useFirestoreChat.ts
@@ -6,9 +6,11 @@ import type { ChatMessage } from '@/types';
 export default function useFirestoreChat(chatId: string | undefined) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     if (!chatId) return;
+    setIsLoading(true);
 
     const q = query(collection(db, 'chats', chatId, 'messages'), orderBy('timestamp'));
     const unsub = onSnapshot(
@@ -27,10 +29,12 @@ export default function useFirestoreChat(chatId: string | undefined) {
           });
         });
         setMessages(msgs);
+        setIsLoading(false);
       },
       err => {
         console.error('Error listening to chat messages', err);
         setError(err);
+        setIsLoading(false);
       }
     );
 
@@ -52,5 +56,5 @@ export default function useFirestoreChat(chatId: string | undefined) {
     }
   }, [chatId]);
 
-  return { messages, sendMessage, error };
+  return { messages, sendMessage, error, isLoading };
 }


### PR DESCRIPTION
## Summary
- avoid sending duplicate "chat started" system messages
- show opponent name instead of tag in chat list
- expose loading state in `useFirestoreChat` hook

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck` *(fails: some type errors)*

------
https://chatgpt.com/codex/tasks/task_b_686144baa180832dba3a8d6a9320e942