### PR TITLE
Add deposit screenshot size validation

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -164,6 +164,10 @@ const HomePageContent = () => {
       toast({ title: "Comprobante Requerido", description: "Por favor, adjunta el comprobante.", variant: "destructive" });
       return;
     }
+    if (depositScreenshotFile.size > 5 * 1024 * 1024) {
+      toast({ title: "Archivo muy grande", description: "El comprobante no debe exceder 5 MB.", variant: "destructive" });
+      return;
+    }
 
     setIsDepositLoading(true);
     let comprobanteBase64: string | undefined;


### PR DESCRIPTION
## Summary
- validate screenshot upload size for deposits in handleDepositConfirm

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_6861592824cc832d955307438146ece6