### PR TITLE
Fix chat hook loading state

### DIFF
--- a/front/src/hooks/useFirestoreChat.ts
+++ b/front/src/hooks/useFirestoreChat.ts
@@ -9,7 +9,10 @@ export default function useFirestoreChat(chatId: string | undefined) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (!chatId) return;
+    if (!chatId) {
+      setIsLoading(false);
+      return;
+    }
     setIsLoading(true);
 
     const q = query(collection(db, 'chats', chatId, 'messages'), orderBy('timestamp'));


### PR DESCRIPTION
## Summary
- ensure `useFirestoreChat` stops loading when no chat ID is provided

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6861593c0184832d93b498ae33d008a2