### PR TITLE
Implement winner assignment endpoint

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -43,4 +43,12 @@ public class PartidaController {
         java.util.List<PartidaResponse> lista = partidaService.listarHistorial(jugadorId);
         return ResponseEntity.ok(lista);
     }
+
+    @PutMapping("/{id}/ganador/{jugadorId}")
+    @Operation(summary = "Asignar ganador", description = "Asigna el ganador de una partida")
+    public ResponseEntity<PartidaResponse> asignarGanador(@PathVariable UUID id,
+                                                         @PathVariable String jugadorId) {
+        PartidaResponse response = partidaService.asignarGanador(id, jugadorId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -79,4 +79,17 @@ public class PartidaService {
         Partida saved = partidaRepository.save(partida);
         return partidaMapper.toDto(saved);
     }
+
+    @Transactional
+    public PartidaResponse asignarGanador(UUID partidaId, String jugadorId) {
+        Partida partida = partidaRepository.findById(partidaId)
+                .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
+
+        partida.setGanador(jugadorRepository.findById(jugadorId)
+                .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado")));
+        partida.setEstado(EstadoPartida.FINALIZADA);
+
+        Partida saved = partidaRepository.save(partida);
+        return partidaMapper.toDto(saved);
+    }
 }

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -280,3 +280,25 @@ export async function cancelMatchmakingAction(
     return { success: false, error: err.message || 'Error de red.' }
   }
 }
+
+export async function setMatchWinnerAction(
+  matchId: string,
+  winnerId: string
+): Promise<{ duel: BackendPartidaResponseDto | null; error: string | null }> {
+  try {
+    const res = await fetch(
+      `${BACKEND_URL}/api/partidas/${matchId}/ganador/${winnerId}`,
+      { method: 'PUT' }
+    )
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      return { duel: null, error: err.message || `Error ${res.status}` }
+    }
+
+    const data = (await res.json()) as BackendPartidaResponseDto
+    return { duel: data, error: null }
+  } catch (err: any) {
+    return { duel: null, error: err.message || 'Error de red.' }
+  }
+}


### PR DESCRIPTION
## Summary
- add service method to assign match winner
- expose PUT `/api/partidas/{id}/ganador/{jugadorId}`
- add frontend action to call new endpoint
- report result from chat page using new API

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68615f0435fc832dbc591326bc907b48