### PR TITLE
Implement winner assignment API

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -38,9 +38,14 @@ public class PartidaController {
     }
 
     @PutMapping("/{id}/ganador/{jugadorId}")
-    @Operation(summary = "Asignar ganador", description = "Asigna el ganador de la partida")
-    public ResponseEntity<PartidaResponse> asignarGanador(@PathVariable UUID id,
-                                                         @PathVariable String jugadorId) {
+    @Operation(
+            summary = "Asignar ganador",
+            description = "Asigna el jugador ganador de la partida"
+    )
+    public ResponseEntity<PartidaResponse> asignarGanador(
+            @PathVariable("id") UUID id,
+            @PathVariable("jugadorId") String jugadorId
+    ) {
         PartidaResponse response = partidaService.asignarGanador(id, jugadorId);
         return ResponseEntity.ok(response);
     }

--- a/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -37,6 +37,14 @@ public class PartidaController {
         return ResponseEntity.ok(response);
     }
 
+    @PutMapping("/{id}/ganador/{jugadorId}")
+    @Operation(summary = "Asignar ganador", description = "Asigna el ganador de la partida")
+    public ResponseEntity<PartidaResponse> asignarGanador(@PathVariable UUID id,
+                                                         @PathVariable String jugadorId) {
+        PartidaResponse response = partidaService.asignarGanador(id, jugadorId);
+        return ResponseEntity.ok(response);
+    }
+
     @GetMapping("/jugador/{jugadorId}")
     @Operation(summary = "Historial", description = "Obtiene las partidas finalizadas de un jugador")
     public ResponseEntity<java.util.List<PartidaResponse>> historial(@PathVariable String jugadorId) {

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -50,6 +50,21 @@ public class PartidaService {
     }
 
     @Transactional
+    public PartidaResponse asignarGanador(UUID partidaId, String jugadorId) {
+        Partida partida = partidaRepository.findById(partidaId)
+                .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
+
+        co.com.arena.real.domain.entity.Jugador jugador = jugadorRepository.findById(jugadorId)
+                .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado"));
+
+        partida.setGanador(jugador);
+        partida.setEstado(EstadoPartida.FINALIZADA);
+
+        Partida saved = partidaRepository.save(partida);
+        return partidaMapper.toDto(saved);
+    }
+
+    @Transactional
     public PartidaResponse marcarComoValidada(UUID partidaId) {
         Partida partida = partidaRepository.findById(partidaId)
                 .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));

--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -16,6 +16,7 @@ import { useToast } from "@/hooks/use-toast";
 import useFirestoreChat from '@/hooks/useFirestoreChat';
 import { BACKEND_URL } from '@/lib/config';
 import type { ChatMessage, User } from '@/types';
+import { assignMatchWinnerAction } from '@/lib/actions';
 
 import { Label } from '@/components/ui/label';
 
@@ -171,16 +172,20 @@ const ChatPageContent = () => {
     toast({ title: "Link de Amigo Compartido", description: `Tu link de amigo ${user.friendLink ? '' : '(o un aviso de que no lo tienes) '}ha sido publicado en el chat.` });
   };
 
-  const handleResultSubmission = (result: 'win' | 'loss') => {
+  const handleResultSubmission = async (result: 'win' | 'loss') => {
     if (!user || !user.id || resultSubmitted) { // user.id es googleId
         toast({ title: "Error", description: "No se puede enviar el resultado sin identificación de usuario.", variant: "destructive"});
         return;
     }
-    
-    // Aquí se llamaría a una acción para enviar el resultado al backend (ej. POST /api/partidas)
-    // Se necesitaría: apuestaId (identificador de la apuesta)
-    // y ganadorId (user.id - googleId, o opponentGoogleId)
-    console.log(`Resultado enviado: Usuario con googleId ${user.id} ${result === 'win' ? 'ganó' : 'perdió'} la apuesta vinculada al chat ${validChatId}. Oponente googleId: ${validOpponentGoogleId}. Adjunto: ${screenshotFile?.name || 'ninguno'}`);
+
+    const winnerId = result === 'win' ? user.id : validOpponentGoogleId;
+
+    const response = await assignMatchWinnerAction(validChatId, winnerId);
+
+    if (response.error) {
+      toast({ title: 'Error', description: response.error, variant: 'destructive' });
+      return;
+    }
     
     toast({
       title: "¡Resultado Enviado!",

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -304,3 +304,25 @@ export async function declineMatchAction(
     return { success: false, error: err.message || 'Error de red.' }
   }
 }
+
+export async function assignMatchWinnerAction(
+  matchId: string,
+  winnerId: string
+): Promise<{ duel: BackendPartidaResponseDto | null; error: string | null }> {
+  try {
+    const res = await fetch(
+      `${BACKEND_URL}/api/partidas/${matchId}/ganador/${winnerId}`,
+      { method: 'PUT' }
+    )
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      return { duel: null, error: err.message || `Error ${res.status}` }
+    }
+
+    const data = (await res.json()) as BackendPartidaResponseDto
+    return { duel: data, error: null }
+  } catch (err: any) {
+    return { duel: null, error: err.message || 'Error de red.' }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `asignarGanador` in `PartidaService`
- expose new PUT `/api/partidas/{id}/ganador/{jugadorId}` endpoint
- add frontend action to call new endpoint
- trigger backend call from chat page when submitting results

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*
- `npm run lint` *(fails: Next.js ESLint plugin prompt)*
- `npm run typecheck` *(fails with type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68617691431c832dab05e65c621ea9c0