### PR TITLE
Implement result report with screenshot

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -1,6 +1,7 @@
 package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.PartidaService;
+import co.com.arena.real.infrastructure.dto.rq.PartidaResultadoRequest;
 import co.com.arena.real.infrastructure.dto.rs.PartidaResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -34,6 +36,32 @@ public class PartidaController {
     @Operation(summary = "Validar", description = "Marca una partida como validada y reparte el premio")
     public ResponseEntity<PartidaResponse> validar(@PathVariable UUID id) {
         PartidaResponse response = partidaService.marcarComoValidada(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}/resultado")
+    @Operation(
+            summary = "Reportar resultado",
+            description = "Envía el resultado de un jugador y la captura"
+    )
+    public ResponseEntity<PartidaResponse> reportarResultado(
+            @PathVariable("id") UUID id,
+            @RequestBody PartidaResultadoRequest dto
+    ) {
+        PartidaResponse response = partidaService.reportarResultado(id, dto);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}/ganador/{jugadorId}")
+    @Operation(
+            summary = "Asignar ganador",
+            description = "Asigna el jugador ganador de la partida"
+    )
+    public ResponseEntity<PartidaResponse> asignarGanador(
+            @PathVariable("id") UUID id,
+            @PathVariable("jugadorId") String jugadorId
+    ) {
+        PartidaResponse response = partidaService.asignarGanador(id, jugadorId);
         return ResponseEntity.ok(response);
     }
 

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -5,7 +5,9 @@ import co.com.arena.real.domain.entity.EstadoTransaccion;
 import co.com.arena.real.domain.entity.TipoTransaccion;
 import co.com.arena.real.domain.entity.Transaccion;
 import co.com.arena.real.domain.entity.partida.Partida;
+import co.com.arena.real.domain.entity.partida.ResultadoJugador;
 import co.com.arena.real.infrastructure.dto.rs.PartidaResponse;
+import co.com.arena.real.infrastructure.dto.rq.PartidaResultadoRequest;
 import co.com.arena.real.infrastructure.mapper.PartidaMapper;
 import co.com.arena.real.infrastructure.repository.ApuestaRepository;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
@@ -47,6 +49,42 @@ public class PartidaService {
         return partidaRepository.findById(partidaId)
                 .filter(p -> p.getEstado() == EstadoPartida.EN_CURSO || p.getEstado() == EstadoPartida.POR_APROBAR)
                 .map(Partida::getChatId);
+    }
+
+    @Transactional
+    public PartidaResponse reportarResultado(UUID partidaId, PartidaResultadoRequest dto) {
+        Partida partida = partidaRepository.findById(partidaId)
+                .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
+
+        if (partida.getJugador1() != null && partida.getJugador1().getId().equals(dto.getJugadorId())) {
+            partida.setResultadoJugador1(ResultadoJugador.valueOf(dto.getResultado()));
+            partida.setCapturaJugador1(dto.getCaptura());
+        } else if (partida.getJugador2() != null && partida.getJugador2().getId().equals(dto.getJugadorId())) {
+            partida.setResultadoJugador2(ResultadoJugador.valueOf(dto.getResultado()));
+            partida.setCapturaJugador2(dto.getCaptura());
+        } else {
+            throw new IllegalArgumentException("Jugador no pertenece a la partida");
+        }
+
+        partida.setEstado(EstadoPartida.POR_APROBAR);
+
+        Partida saved = partidaRepository.save(partida);
+        return partidaMapper.toDto(saved);
+    }
+
+    @Transactional
+    public PartidaResponse asignarGanador(UUID partidaId, String jugadorId) {
+        Partida partida = partidaRepository.findById(partidaId)
+                .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
+
+        co.com.arena.real.domain.entity.Jugador jugador = jugadorRepository.findById(jugadorId)
+                .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado"));
+
+        partida.setGanador(jugador);
+        partida.setEstado(EstadoPartida.FINALIZADA);
+
+        Partida saved = partidaRepository.save(partida);
+        return partidaMapper.toDto(saved);
     }
 
     @Transactional

--- a/back/src/main/java/co/com/arena/real/domain/entity/partida/Partida.java
+++ b/back/src/main/java/co/com/arena/real/domain/entity/partida/Partida.java
@@ -2,6 +2,7 @@ package co.com.arena.real.domain.entity.partida;
 
 import co.com.arena.real.domain.entity.Apuesta;
 import co.com.arena.real.domain.entity.Jugador;
+import co.com.arena.real.domain.entity.partida.ResultadoJugador;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,6 +10,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
@@ -64,4 +66,20 @@ public class Partida {
     @ManyToOne
     @JoinColumn(name = "ganador_id")
     private Jugador ganador;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resultado_jugador1")
+    private ResultadoJugador resultadoJugador1;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resultado_jugador2")
+    private ResultadoJugador resultadoJugador2;
+
+    @Lob
+    @Column(name = "captura_jugador1", columnDefinition = "text")
+    private String capturaJugador1;
+
+    @Lob
+    @Column(name = "captura_jugador2", columnDefinition = "text")
+    private String capturaJugador2;
 }

--- a/back/src/main/java/co/com/arena/real/domain/entity/partida/ResultadoJugador.java
+++ b/back/src/main/java/co/com/arena/real/domain/entity/partida/ResultadoJugador.java
@@ -1,0 +1,6 @@
+package co.com.arena.real.domain.entity.partida;
+
+public enum ResultadoJugador {
+    VICTORIA,
+    DERROTA
+}

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/PartidaResultadoRequest.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/PartidaResultadoRequest.java
@@ -1,0 +1,16 @@
+package co.com.arena.real.infrastructure.dto.rq;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PartidaResultadoRequest {
+    private String jugadorId;
+    private String resultado; // VICTORIA o DERROTA
+    private String captura;
+}

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/PartidaResponse.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/PartidaResponse.java
@@ -30,4 +30,8 @@ public class PartidaResponse implements Serializable {
     private LocalDateTime creada;
     private LocalDateTime validadaEn;
     private java.math.BigDecimal monto;
+    private String capturaJugador1;
+    private String capturaJugador2;
+    private String resultadoJugador1;
+    private String resultadoJugador2;
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/mapper/PartidaMapper.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/mapper/PartidaMapper.java
@@ -23,6 +23,10 @@ public class PartidaMapper {
                 .creada(entity.getCreada())
                 .validadaEn(entity.getValidadaEn())
                 .monto(entity.getApuesta() != null ? entity.getApuesta().getMonto() : null)
+                .capturaJugador1(entity.getCapturaJugador1())
+                .capturaJugador2(entity.getCapturaJugador2())
+                .resultadoJugador1(entity.getResultadoJugador1() != null ? entity.getResultadoJugador1().name() : null)
+                .resultadoJugador2(entity.getResultadoJugador2() != null ? entity.getResultadoJugador2().name() : null)
                 .build();
     }
 }

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -12,6 +12,7 @@ import type {
   BackendPartidaResponseDto,
   BackendMatchmakingResponseDto,
   RegistrarUsuarioRequest,
+  BackendPartidaResultadoRequestDto,
 } from '@/types'
 import { BACKEND_URL } from '@/lib/config'
 
@@ -302,5 +303,52 @@ export async function declineMatchAction(
     return { success: true, error: null }
   } catch (err: any) {
     return { success: false, error: err.message || 'Error de red.' }
+  }
+}
+
+export async function assignMatchWinnerAction(
+  matchId: string,
+  winnerId: string
+): Promise<{ duel: BackendPartidaResponseDto | null; error: string | null }> {
+  try {
+    const res = await fetch(
+      `${BACKEND_URL}/api/partidas/${matchId}/ganador/${winnerId}`,
+      { method: 'PUT' }
+    )
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      return { duel: null, error: err.message || `Error ${res.status}` }
+    }
+
+    const data = (await res.json()) as BackendPartidaResponseDto
+    return { duel: data, error: null }
+  } catch (err: any) {
+    return { duel: null, error: err.message || 'Error de red.' }
+  }
+}
+
+export async function submitMatchResultAction(
+  matchId: string,
+  jugadorId: string,
+  result: 'VICTORIA' | 'DERROTA',
+  screenshot?: string,
+): Promise<{ duel: BackendPartidaResponseDto | null; error: string | null }> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/partidas/${matchId}/resultado`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jugadorId, resultado: result, captura: screenshot }),
+    })
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      return { duel: null, error: err.message || `Error ${res.status}` }
+    }
+
+    const data = (await res.json()) as BackendPartidaResponseDto
+    return { duel: data, error: null }
+  } catch (err: any) {
+    return { duel: null, error: err.message || 'Error de red.' }
   }
 }

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -59,6 +59,12 @@ export interface BackendPartidaRequestDto {
   resultadoJson?: string;
 }
 
+export interface BackendPartidaResultadoRequestDto {
+  jugadorId: string;
+  resultado: 'VICTORIA' | 'DERROTA';
+  captura?: string;
+}
+
 export interface BackendPartidaResponseDto {
   id: string; // UUID de la partida
   apuestaId: string; // UUID de la apuesta
@@ -71,6 +77,10 @@ export interface BackendPartidaResponseDto {
   creada: string; // date-time
   validadaEn?: string; // date-time
   monto: number;
+  capturaJugador1?: string;
+  capturaJugador2?: string;
+  resultadoJugador1?: string;
+  resultadoJugador2?: string;
 }
 
 export interface BackendMatchResultDto {


### PR DESCRIPTION
## Summary
- add fields for player results and screenshots to `Partida`
- expose `PUT /api/partidas/{id}/resultado` endpoint
- implement service logic to store screenshots and mark match pending approval
- update frontend types and actions to send screenshot data
- submit result from chat page using the new API

## Testing
- `mvn -q -DskipTests package` *(fails: mvn: command not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails with TypeScript errors)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_68617691431c832dab05e65c621ea9c0