### PR TITLE
Ensure match chat opens after both players accept

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
@@ -36,7 +36,7 @@ public class MatchmakingController {
                     String tag = oponente.getTagClash() != null ? oponente.getTagClash() : oponente.getNombre();
                     return MatchSseDto.builder()
                             .apuestaId(partida.getApuesta().getId())
-                            .chatId(partida.getChatId())
+                            .partidaId(partida.getId())
                             .jugadorOponenteId(oponente.getId())
                             .jugadorOponenteTag(tag)
                             .build();

--- a/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -32,6 +32,15 @@ public class PartidaController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @PutMapping("/{id}/aceptar/{jugadorId}")
+    @Operation(summary = "Aceptar partida", description = "Marca la partida como aceptada por el jugador")
+    public ResponseEntity<PartidaResponse> aceptarPartida(
+            @PathVariable("id") UUID id,
+            @PathVariable("jugadorId") String jugadorId) {
+        PartidaResponse response = partidaService.aceptarPartida(id, jugadorId);
+        return ResponseEntity.ok(response);
+    }
+
     @PutMapping("/{id}/validar")
     @Operation(summary = "Validar", description = "Marca una partida como validada y reparte el premio")
     public ResponseEntity<PartidaResponse> validar(@PathVariable UUID id) {

--- a/back/src/main/java/co/com/arena/real/application/service/MatchmakingService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchmakingService.java
@@ -96,7 +96,7 @@ public class MatchmakingService {
 
                     Partida partida = crearPartida(partidaEnEspera, partidaEncontrada);
 
-                    matchSseService.notifyMatch(partida);
+                    matchSseService.notifyMatchFound(partida);
 
                     realizarTransaccion(partida.getApuesta(), jugadorEnEspera);
                     realizarTransaccion(partida.getApuesta(), jugadorEncontrado);
@@ -120,16 +120,14 @@ public class MatchmakingService {
                 .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado"));
 
         Apuesta apuesta = apuestaService.crearApuesta(new ApuestaRequest(partidaEnEspera.getMonto()));
-        UUID chatId = chatService.crearChatParaPartida(jugador1.getId(), jugador2.getId());
-
         Partida partida = Partida.builder()
                 .jugador1(jugador1)
                 .jugador2(jugador2)
                 .modoJuego(partidaEnEspera.getModoJuego())
-                .estado(EstadoPartida.EN_CURSO)
+                .estado(EstadoPartida.PENDIENTE)
                 .creada(LocalDateTime.now())
                 .validada(false)
-                .chatId(chatId)
+                .chatId(null)
                 .apuesta(apuesta)
                 .build();
 

--- a/back/src/main/java/co/com/arena/real/domain/entity/partida/EstadoPartida.java
+++ b/back/src/main/java/co/com/arena/real/domain/entity/partida/EstadoPartida.java
@@ -1,6 +1,7 @@
 package co.com.arena.real.domain.entity.partida;
 
 public enum EstadoPartida {
+    PENDIENTE,
     EN_CURSO,
     POR_APROBAR,
     FINALIZADA

--- a/back/src/main/java/co/com/arena/real/domain/entity/partida/Partida.java
+++ b/back/src/main/java/co/com/arena/real/domain/entity/partida/Partida.java
@@ -54,6 +54,14 @@ public class Partida {
     @Column(name = "chat_id")
     private UUID chatId;
 
+    @Builder.Default
+    @Column(name = "aceptado_jugador1")
+    private boolean aceptadoJugador1 = false;
+
+    @Builder.Default
+    @Column(name = "aceptado_jugador2")
+    private boolean aceptadoJugador2 = false;
+
     private boolean validada;
 
     @Column(name = "validada_en")

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/MatchSseDto.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/MatchSseDto.java
@@ -18,6 +18,7 @@ public class MatchSseDto implements Serializable {
     private static final long serialVersionUID = -5076615234782375916L;
 
     private UUID apuestaId;
+    private UUID partidaId;
     private String jugadorOponenteId;
     private String jugadorOponenteTag;
     private UUID chatId;

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/PartidaResponse.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/PartidaResponse.java
@@ -21,6 +21,7 @@ public class PartidaResponse implements Serializable {
 
     private UUID id;
     private UUID apuestaId;
+    private UUID chatId;
     private String jugador1Id;
     private String jugador2Id;
     private String ganadorId;

--- a/back/src/main/java/co/com/arena/real/infrastructure/mapper/PartidaMapper.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/mapper/PartidaMapper.java
@@ -14,6 +14,7 @@ public class PartidaMapper {
         return PartidaResponse.builder()
                 .id(entity.getId())
                 .apuestaId(entity.getApuesta() != null ? entity.getApuesta().getId() : null)
+                .chatId(entity.getChatId())
                 .jugador1Id(entity.getJugador1() != null ? entity.getJugador1().getId() : null)
                 .jugador2Id(entity.getJugador2() != null ? entity.getJugador2().getId() : null)
                 .ganadorId(entity.getGanador() != null ? entity.getGanador().getId() : null)

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -306,6 +306,27 @@ export async function declineMatchAction(
   }
 }
 
+export async function acceptMatchAction(
+  matchId: string,
+  userGoogleId: string
+): Promise<{ duel: BackendPartidaResponseDto | null; error: string | null }> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/partidas/${matchId}/aceptar/${userGoogleId}`, {
+      method: 'PUT',
+    })
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      return { duel: null, error: err.message || `Error ${res.status}` }
+    }
+
+    const data = (await res.json()) as BackendPartidaResponseDto
+    return { duel: data, error: null }
+  } catch (err: any) {
+    return { duel: null, error: err.message || 'Error de red.' }
+  }
+}
+
 export async function assignMatchWinnerAction(
   matchId: string,
   winnerId: string

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -92,9 +92,10 @@ export interface BackendMatchResultDto {
 
 export interface BackendMatchmakingResponseDto {
   apuestaId: string; // UUID de la apuesta resultante
+  partidaId: string; // UUID de la partida creada
   jugadorOponenteId: string; // googleId del oponente
   jugadorOponenteTag: string;
-  chatId: string;
+  chatId?: string;
   jugadorOponenteAvatarUrl?: string;
 }
 


### PR DESCRIPTION
## Summary
- add pending state and accept flags to `Partida`
- require both players to accept before creating chat
- send new SSE events when the chat is ready
- update matchmaking hook and home page logic for new flow

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: numerous type errors)*
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861e7ba5e6c832d8e5f20ae3a536195