### PR TITLE
Implement refund on match cancel

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -48,6 +48,13 @@ public class PartidaController {
         return ResponseEntity.ok(response);
     }
 
+    @PutMapping("/{id}/cancelar")
+    @Operation(summary = "Cancelar partida", description = "Cancela la partida y reembolsa la apuesta")
+    public ResponseEntity<PartidaResponse> cancelar(@PathVariable UUID id) {
+        PartidaResponse response = partidaService.cancelarPartida(id);
+        return ResponseEntity.ok(response);
+    }
+
     @PutMapping("/{id}/resultado")
     @Operation(
             summary = "Reportar resultado",

--- a/back/src/main/java/co/com/arena/real/application/service/TransaccionService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TransaccionService.java
@@ -70,7 +70,7 @@ public class TransaccionService {
                 .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado"));
 
         switch (transaccion.getTipo()) {
-            case DEPOSITO, PREMIO -> jugador.setSaldo(jugador.getSaldo().add(transaccion.getMonto()));
+            case DEPOSITO, PREMIO, REEMBOLSO -> jugador.setSaldo(jugador.getSaldo().add(transaccion.getMonto()));
             case RETIRO, APUESTA -> {
                 if (!(jugador.getSaldo().compareTo(transaccion.getMonto()) >= 0)) {
                     throw new IllegalArgumentException("Saldo insuficiente para realizar la transacción");

--- a/back/src/main/java/co/com/arena/real/domain/entity/TipoTransaccion.java
+++ b/back/src/main/java/co/com/arena/real/domain/entity/TipoTransaccion.java
@@ -4,5 +4,6 @@ public enum TipoTransaccion {
     DEPOSITO,
     RETIRO,
     APUESTA,
-    PREMIO
+    PREMIO,
+    REEMBOLSO
 }

--- a/back/src/main/java/co/com/arena/real/domain/entity/partida/EstadoPartida.java
+++ b/back/src/main/java/co/com/arena/real/domain/entity/partida/EstadoPartida.java
@@ -4,5 +4,6 @@ public enum EstadoPartida {
     PENDIENTE,
     EN_CURSO,
     POR_APROBAR,
-    FINALIZADA
+    FINALIZADA,
+    CANCELADA
 }


### PR DESCRIPTION
## Summary
- add `CANCELADA` state to matches
- support new `REEMBOLSO` transaction type
- deposit funds back to both players when a match is cancelled
- expose API to cancel a match

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6861ef597b30832dae97a9a02780502f