### PR TITLE
Delay bet until match accepted

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
@@ -35,7 +35,7 @@ public class MatchmakingController {
 
                     String tag = oponente.getTagClash() != null ? oponente.getTagClash() : oponente.getNombre();
                     return MatchSseDto.builder()
-                            .apuestaId(partida.getApuesta().getId())
+                            .apuestaId(partida.getApuesta() != null ? partida.getApuesta().getId() : null)
                             .partidaId(partida.getId())
                             .jugadorOponenteId(oponente.getId())
                             .jugadorOponenteTag(tag)

--- a/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
@@ -32,7 +32,7 @@ public class MatchSseService {
     }
 
     public void notifyMatchFound(Partida partida) {
-        UUID apuestaId = partida.getApuesta().getId();
+        UUID apuestaId = partida.getApuesta() != null ? partida.getApuesta().getId() : null;
         UUID partidaId = partida.getId();
         notifyMatchFound(apuestaId, partidaId, partida.getJugador1(), partida.getJugador2());
     }
@@ -40,8 +40,9 @@ public class MatchSseService {
     public void notifyChatReady(Partida partida) {
         UUID apuestaId = partida.getApuesta().getId();
         UUID chatId = partida.getChatId();
-        sendChatReady(partida.getJugador1().getId(), apuestaId, chatId, partida.getJugador2());
-        sendChatReady(partida.getJugador2().getId(), apuestaId, chatId, partida.getJugador1());
+        UUID partidaId = partida.getId();
+        sendChatReady(partida.getJugador1().getId(), apuestaId, partidaId, chatId, partida.getJugador2());
+        sendChatReady(partida.getJugador2().getId(), apuestaId, partidaId, chatId, partida.getJugador1());
     }
 
     private void sendMatchFound(String receptorId, UUID apuestaId, UUID partidaId, Jugador oponente) {
@@ -66,7 +67,7 @@ public class MatchSseService {
         }
     }
 
-    private void sendChatReady(String receptorId, UUID apuestaId, UUID chatId, Jugador oponente) {
+    private void sendChatReady(String receptorId, UUID apuestaId, UUID partidaId, UUID chatId, Jugador oponente) {
         SseEmitter emitter = emitters.get(receptorId);
         if (emitter == null) {
             return;
@@ -74,7 +75,7 @@ public class MatchSseService {
         String tag = oponente.getTagClash() != null ? oponente.getTagClash() : oponente.getNombre();
         MatchSseDto dto = MatchSseDto.builder()
                 .apuestaId(apuestaId)
-                .partidaId(null)
+                .partidaId(partidaId)
                 .chatId(chatId)
                 .jugadorOponenteId(oponente.getId())
                 .jugadorOponenteTag(tag)

--- a/back/src/main/java/co/com/arena/real/domain/entity/partida/Partida.java
+++ b/back/src/main/java/co/com/arena/real/domain/entity/partida/Partida.java
@@ -19,6 +19,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Entity
@@ -50,6 +51,9 @@ public class Partida {
 
     @Column(name = "creada_en")
     private LocalDateTime creada;
+
+    @Column(nullable = false)
+    private BigDecimal monto;
 
     @Column(name = "chat_id")
     private UUID chatId;

--- a/back/src/main/java/co/com/arena/real/infrastructure/mapper/PartidaMapper.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/mapper/PartidaMapper.java
@@ -23,7 +23,7 @@ public class PartidaMapper {
                 .validada(entity.isValidada())
                 .creada(entity.getCreada())
                 .validadaEn(entity.getValidadaEn())
-                .monto(entity.getApuesta() != null ? entity.getApuesta().getMonto() : null)
+                .monto(entity.getMonto())
                 .capturaJugador1(entity.getCapturaJugador1())
                 .capturaJugador2(entity.getCapturaJugador2())
                 .resultadoJugador1(entity.getResultadoJugador1() != null ? entity.getResultadoJugador1().name() : null)

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -34,6 +34,7 @@ const HomePageContent = () => {
   const [isWithdrawLoading, setIsWithdrawLoading] = useState(false);
 
   const [isModeModalOpen, setIsModeModalOpen] = useState(false);
+
   const [isSearching, setIsSearching] = useState(false);
   const [pendingMatch, setPendingMatch] = useState<{ apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; chatId?: string; } | null>(null);
   const [hasAccepted, setHasAccepted] = useState(false);


### PR DESCRIPTION
## Summary
- create matches without a bet or chat
- add `monto` to `Partida`
- create bet and withdraw funds only after both players accept
- send match ID when notifying that chat is ready

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails due to missing modules)*
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861ff8b659c832d884e27314dbebd12