### PR TITLE
Implement match proposal before accepting

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
@@ -28,15 +28,15 @@ public class MatchmakingController {
     @PostMapping("/ejecutar")
     public ResponseEntity<?> ejecutarMatchmaking(@RequestBody PartidaEnEsperaRequest request) {
         return matchmakingService.intentarEmparejar(request)
-                .map(partida -> {
-                    Jugador oponente = partida.getJugador1().getId().equals(request.getJugadorId())
-                            ? partida.getJugador2()
-                            : partida.getJugador1();
+                .map(proposal -> {
+                    Jugador oponente = proposal.getJugador1().getId().equals(request.getJugadorId())
+                            ? proposal.getJugador2()
+                            : proposal.getJugador1();
 
                     String tag = oponente.getTagClash() != null ? oponente.getTagClash() : oponente.getNombre();
                     return MatchSseDto.builder()
-                            .apuestaId(partida.getApuesta() != null ? partida.getApuesta().getId() : null)
-                            .partidaId(partida.getId())
+                            .apuestaId(null)
+                            .partidaId(proposal.getId())
                             .jugadorOponenteId(oponente.getId())
                             .jugadorOponenteTag(tag)
                             .build();

--- a/back/src/main/java/co/com/arena/real/domain/entity/matchmaking/MatchProposal.java
+++ b/back/src/main/java/co/com/arena/real/domain/entity/matchmaking/MatchProposal.java
@@ -1,0 +1,57 @@
+package co.com.arena.real.domain.entity.matchmaking;
+
+import co.com.arena.real.domain.entity.Jugador;
+import co.com.arena.real.domain.entity.partida.ModoJuego;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Table(name = "match_proposals")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchProposal {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "jugador1_id")
+    private Jugador jugador1;
+
+    @ManyToOne
+    @JoinColumn(name = "jugador2_id")
+    private Jugador jugador2;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "modo_juego", nullable = false)
+    private ModoJuego modoJuego;
+
+    @Column(nullable = false)
+    private BigDecimal monto;
+
+    @Builder.Default
+    @Column(name = "aceptado_jugador1")
+    private boolean aceptadoJugador1 = false;
+
+    @Builder.Default
+    @Column(name = "aceptado_jugador2")
+    private boolean aceptadoJugador2 = false;
+}

--- a/back/src/main/java/co/com/arena/real/infrastructure/repository/MatchProposalRepository.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/repository/MatchProposalRepository.java
@@ -1,0 +1,9 @@
+package co.com.arena.real.infrastructure.repository;
+
+import co.com.arena.real.domain.entity.matchmaking.MatchProposal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MatchProposalRepository extends JpaRepository<MatchProposal, UUID> {
+}


### PR DESCRIPTION
## Summary
- introduce `MatchProposal` entity and repository
- adjust matchmaking flow to create proposals instead of matches
- update acceptance logic to create a match only once both players accept

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -f back/pom.xml -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6862e3d3dd1c832dad8ad667c2c9cb73