### PR TITLE
Handle conflict when canceling matches

### DIFF
--- a/back/src/main/java/co/com/arena/real/infrastructure/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/exception/GlobalExceptionHandler.java
@@ -22,6 +22,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(ex.getMessage());
     }
 
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleConflict(IllegalStateException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();


### PR DESCRIPTION
## Summary
- return HTTP 409 when a match or duel is already finalised or cancelled

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network being unreachable)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863801c385c832d9568148730ee4b58