### PR TITLE
Improve matchmaking SSE reconnection

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -59,7 +59,7 @@ const HomePageContent = () => {
     }
   };
 
-  useMatchmakingSse(isSearching || hasAccepted ? user?.id : undefined, handleMatchFound, handleChatReady);
+  useMatchmakingSse(user?.id, handleMatchFound, handleChatReady);
 
   useEffect(() => {
     console.log("¡La página de inicio se ha cargado en el frontend! Puedes ver este mensaje en la consola del navegador.");


### PR DESCRIPTION
## Summary
- persist latest matchmaking events server-side
- resend latest event when client subscribes
- keep frontend SSE connection open whenever user is on the home page

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68638bedd130832d959f843136e57d2f