### PR TITLE
Improve matchmaking SSE reconnection

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
@@ -16,13 +16,33 @@ import java.util.concurrent.ConcurrentHashMap;
 public class MatchSseService {
 
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, LatestEvent> latestEvents = new ConcurrentHashMap<>();
+
+    private record LatestEvent(String name, MatchSseDto dto) {
+    }
 
     public SseEmitter subscribe(String jugadorId) {
+        SseEmitter existing = emitters.remove(jugadorId);
+        if (existing != null) {
+            existing.complete();
+        }
+
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
         emitters.put(jugadorId, emitter);
         emitter.onCompletion(() -> emitters.remove(jugadorId));
         emitter.onTimeout(() -> emitters.remove(jugadorId));
         emitter.onError(ex -> emitters.remove(jugadorId));
+
+        LatestEvent last = latestEvents.get(jugadorId);
+        if (last != null) {
+            try {
+                emitter.send(SseEmitter.event().name(last.name()).data(last.dto()));
+                latestEvents.remove(jugadorId);
+            } catch (IOException e) {
+                emitters.remove(jugadorId);
+                emitter.completeWithError(e);
+            }
+        }
         return emitter;
     }
 
@@ -46,10 +66,6 @@ public class MatchSseService {
     }
 
     private void sendMatchFound(String receptorId, UUID apuestaId, UUID partidaId, Jugador oponente) {
-        SseEmitter emitter = emitters.get(receptorId);
-        if (emitter == null) {
-            return;
-        }
         String tag = oponente.getTagClash() != null ? oponente.getTagClash() : oponente.getNombre();
         MatchSseDto dto = MatchSseDto.builder()
                 .apuestaId(apuestaId)
@@ -57,10 +73,17 @@ public class MatchSseService {
                 .jugadorOponenteId(oponente.getId())
                 .jugadorOponenteTag(tag)
                 .build();
+        latestEvents.put(receptorId, new LatestEvent("match-found", dto));
+
+        SseEmitter emitter = emitters.get(receptorId);
+        if (emitter == null) {
+            return;
+        }
         try {
             emitter.send(SseEmitter.event()
                     .name("match-found")
                     .data(dto));
+            latestEvents.remove(receptorId);
         } catch (IOException e) {
             emitters.remove(receptorId);
             emitter.completeWithError(e);
@@ -68,10 +91,6 @@ public class MatchSseService {
     }
 
     private void sendChatReady(String receptorId, UUID apuestaId, UUID partidaId, UUID chatId, Jugador oponente) {
-        SseEmitter emitter = emitters.get(receptorId);
-        if (emitter == null) {
-            return;
-        }
         String tag = oponente.getTagClash() != null ? oponente.getTagClash() : oponente.getNombre();
         MatchSseDto dto = MatchSseDto.builder()
                 .apuestaId(apuestaId)
@@ -80,10 +99,17 @@ public class MatchSseService {
                 .jugadorOponenteId(oponente.getId())
                 .jugadorOponenteTag(tag)
                 .build();
+        latestEvents.put(receptorId, new LatestEvent("chat-ready", dto));
+
+        SseEmitter emitter = emitters.get(receptorId);
+        if (emitter == null) {
+            return;
+        }
         try {
             emitter.send(SseEmitter.event()
                     .name("chat-ready")
                     .data(dto));
+            latestEvents.remove(receptorId);
         } catch (IOException e) {
             emitters.remove(receptorId);
             emitter.completeWithError(e);

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -59,7 +59,7 @@ const HomePageContent = () => {
     }
   };
 
-  useMatchmakingSse(isSearching || hasAccepted ? user?.id : undefined, handleMatchFound, handleChatReady);
+  useMatchmakingSse(user?.id, handleMatchFound, handleChatReady);
 
   useEffect(() => {
     console.log("¡La página de inicio se ha cargado en el frontend! Puedes ver este mensaje en la consola del navegador.");


### PR DESCRIPTION
## Summary
- persist latest matchmaking events server-side
- resend latest event when client subscribes
- keep frontend SSE connection open whenever user is on the home page
- store events until successfully delivered

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68638bedd130832d959f843136e57d2f