### PR TITLE
Notify opponent acceptance via SSE

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -72,8 +72,22 @@ public class PartidaService {
 
             if (proposal.getJugador1() != null && proposal.getJugador1().getId().equals(jugadorId)) {
                 proposal.setAceptadoJugador1(true);
+                if (!proposal.isAceptadoJugador2()) {
+                    matchSseService.notifyOpponentAccepted(
+                            null,
+                            proposal.getId(),
+                            proposal.getJugador1(),
+                            proposal.getJugador2());
+                }
             } else if (proposal.getJugador2() != null && proposal.getJugador2().getId().equals(jugadorId)) {
                 proposal.setAceptadoJugador2(true);
+                if (!proposal.isAceptadoJugador1()) {
+                    matchSseService.notifyOpponentAccepted(
+                            null,
+                            proposal.getId(),
+                            proposal.getJugador2(),
+                            proposal.getJugador1());
+                }
             } else {
                 throw new IllegalArgumentException("Jugador no pertenece a la partida");
             }
@@ -109,8 +123,22 @@ public class PartidaService {
 
         if (partida.getJugador1() != null && partida.getJugador1().getId().equals(jugadorId)) {
             partida.setAceptadoJugador1(true);
+            if (!partida.isAceptadoJugador2()) {
+                matchSseService.notifyOpponentAccepted(
+                        partida.getApuesta() != null ? partida.getApuesta().getId() : null,
+                        partida.getId(),
+                        partida.getJugador1(),
+                        partida.getJugador2());
+            }
         } else if (partida.getJugador2() != null && partida.getJugador2().getId().equals(jugadorId)) {
             partida.setAceptadoJugador2(true);
+            if (!partida.isAceptadoJugador1()) {
+                matchSseService.notifyOpponentAccepted(
+                        partida.getApuesta() != null ? partida.getApuesta().getId() : null,
+                        partida.getId(),
+                        partida.getJugador2(),
+                        partida.getJugador1());
+            }
         } else {
             throw new IllegalArgumentException("Jugador no pertenece a la partida");
         }

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -38,6 +38,7 @@ const HomePageContent = () => {
   const [isSearching, setIsSearching] = useState(false);
   const [pendingMatch, setPendingMatch] = useState<{ apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; chatId?: string; } | null>(null);
   const [hasAccepted, setHasAccepted] = useState(false);
+  const [opponentAccepted, setOpponentAccepted] = useState(false);
   const [timeLeft, setTimeLeft] = useState(25);
 
   const handleMatchFound = (data: { apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; }) => {
@@ -46,6 +47,7 @@ const HomePageContent = () => {
     setTimeLeft(25);
     setPendingMatch({ ...data, chatId: undefined });
     setHasAccepted(false);
+    setOpponentAccepted(false);
   };
 
   const handleChatReady = (data: { chatId: string; apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; }) => {
@@ -56,10 +58,18 @@ const HomePageContent = () => {
       );
       setPendingMatch(null);
       setHasAccepted(false);
+      setOpponentAccepted(false);
     }
   };
 
-  useMatchmakingSse(user?.id, handleMatchFound, handleChatReady);
+  const handleOpponentAccepted = (data: { apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; }) => {
+    if (pendingMatch && pendingMatch.partidaId === data.partidaId) {
+      setOpponentAccepted(true);
+      toast({ title: 'Oponente listo', description: `${data.jugadorOponenteTag} ha aceptado el duelo.` });
+    }
+  };
+
+  useMatchmakingSse(user?.id, handleMatchFound, handleChatReady, handleOpponentAccepted);
 
   useEffect(() => {
     console.log("¡La página de inicio se ha cargado en el frontend! Puedes ver este mensaje en la consola del navegador.");
@@ -445,10 +455,21 @@ const HomePageContent = () => {
                   style={{ width: `${(timeLeft / 25) * 100}%`, transition: 'width 1s linear' }}
                 ></div>
               </div>
+              {hasAccepted && !opponentAccepted && (
+                <p className="text-center text-sm text-muted-foreground">Esperando al oponente...</p>
+              )}
+              {opponentAccepted && !hasAccepted && (
+                <p className="text-center text-sm text-muted-foreground">El oponente ya aceptó.</p>
+              )}
+              {hasAccepted && opponentAccepted && (
+                <p className="text-center text-sm text-muted-foreground">Preparando el chat...</p>
+              )}
             </CardContent>
             <CardFooter className="flex justify-end gap-3">
               <CartoonButton variant="secondary" size="small" onClick={handleDeclineMatch}>Cancelar</CartoonButton>
-              <CartoonButton variant="default" size="small" onClick={handleAcceptMatch}>Aceptar</CartoonButton>
+              {!hasAccepted && (
+                <CartoonButton variant="default" size="small" onClick={handleAcceptMatch}>Aceptar</CartoonButton>
+              )}
             </CardFooter>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
- emit `opponent-accepted` SSE events from the backend
- notify the other player when a match is accepted
- handle `opponent-accepted` on the frontend via `useMatchmakingSse`
- show waiting state in the duel modal

## Testing
- `mvn spring-boot:run` *(fails: `mvn` not found)*
- `npm run typecheck` *(fails: missing dependencies)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863a637f9ec832db3c49be74d6ed082