### PR TITLE
Improve SSE service reliability

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/MatchDeclineService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchDeclineService.java
@@ -4,6 +4,7 @@ import co.com.arena.real.domain.entity.matchmaking.MatchDecline;
 import co.com.arena.real.infrastructure.repository.MatchDeclineRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,5 +53,10 @@ public class MatchDeclineService {
         return repository.findByJugador1IdAndJugador2Id(j1, j2)
                 .filter(p -> p.getExpiraEn().isAfter(LocalDateTime.now()))
                 .isPresent();
+    }
+
+    @Scheduled(fixedRate = 5 * 60 * 1000)
+    public void limpiarDeclinacionesExpiradas() {
+        repository.deleteAllByExpiraEnBefore(LocalDateTime.now());
     }
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/repository/MatchDeclineRepository.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/repository/MatchDeclineRepository.java
@@ -3,9 +3,11 @@ package co.com.arena.real.infrastructure.repository;
 import co.com.arena.real.domain.entity.matchmaking.MatchDecline;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface MatchDeclineRepository extends JpaRepository<MatchDecline, UUID> {
     Optional<MatchDecline> findByJugador1IdAndJugador2Id(String jugador1Id, String jugador2Id);
+    void deleteAllByExpiraEnBefore(LocalDateTime expiraEn);
 }


### PR DESCRIPTION
## Summary
- add logging and locks for `SseService`
- improve `MatchSseService` concurrency handling and add logging
- schedule cleanup for expired match declines
- expose cleanup method in `MatchDeclineRepository`

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6863a8994bfc832dba21b942e4fd0bbd