### PR TITLE
Add match cancel SSE notification

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
@@ -2,6 +2,8 @@ package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.MatchmakingService;
 import co.com.arena.real.application.service.MatchDeclineService;
+import co.com.arena.real.application.service.MatchSseService;
+import co.com.arena.real.infrastructure.repository.JugadorRepository;
 import co.com.arena.real.infrastructure.dto.rq.CancelarMatchmakingRequest;
 import co.com.arena.real.infrastructure.dto.rq.MatchDeclineRequest;
 import co.com.arena.real.infrastructure.dto.rq.PartidaEnEsperaRequest;
@@ -24,6 +26,8 @@ public class MatchmakingController {
 
     private final MatchmakingService matchmakingService;
     private final MatchDeclineService matchDeclineService;
+    private final MatchSseService matchSseService;
+    private final JugadorRepository jugadorRepository;
 
     @PostMapping("/ejecutar")
     public ResponseEntity<?> ejecutarMatchmaking(@RequestBody PartidaEnEsperaRequest request) {
@@ -60,6 +64,11 @@ public class MatchmakingController {
     @PostMapping("/declinar")
     public ResponseEntity<?> declinarPareja(@RequestBody MatchDeclineRequest request) {
         matchDeclineService.recordDecline(request.getJugadorId(), request.getOponenteId());
+        jugadorRepository.findById(request.getJugadorId()).ifPresent(declinante ->
+                jugadorRepository.findById(request.getOponenteId()).ifPresent(oponente ->
+                        matchSseService.notifyMatchCancelled(request.getPartidaId(), declinante, oponente)
+                )
+        );
         Map<String, Object> resp = new HashMap<>();
         resp.put("status", "registrado");
         return ResponseEntity.ok(resp);

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/MatchDeclineRequest.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/MatchDeclineRequest.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class MatchDeclineRequest {
     private String jugadorId;
     private String oponenteId;
+    private java.util.UUID partidaId;
 }

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -69,7 +69,16 @@ const HomePageContent = () => {
     }
   };
 
-  useMatchmakingSse(user?.id, handleMatchFound, handleChatReady, handleOpponentAccepted);
+  const handleMatchCancelled = (data: { apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; }) => {
+    if (pendingMatch && pendingMatch.partidaId === data.partidaId) {
+      toast({ title: 'Duelo cancelado', description: `${data.jugadorOponenteTag} canceló el duelo.` });
+      setPendingMatch(null);
+      setHasAccepted(false);
+      setOpponentAccepted(false);
+    }
+  };
+
+  useMatchmakingSse(user?.id, handleMatchFound, handleChatReady, handleOpponentAccepted, handleMatchCancelled);
 
   useEffect(() => {
     console.log("¡La página de inicio se ha cargado en el frontend! Puedes ver este mensaje en la consola del navegador.");
@@ -161,7 +170,7 @@ const HomePageContent = () => {
 
   async function handleDeclineMatch() {
     if (!pendingMatch) return;
-    await declineMatchAction(user.id, pendingMatch.jugadorOponenteId);
+    await declineMatchAction(user.id, pendingMatch.jugadorOponenteId, pendingMatch.partidaId);
     toast({ title: 'Duelo cancelado', description: 'No se iniciará este duelo.' });
     setPendingMatch(null);
   }

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -286,13 +286,14 @@ export async function cancelMatchmakingAction(
 
 export async function declineMatchAction(
   userGoogleId: string,
-  opponentId: string
+  opponentId: string,
+  matchId: string
 ): Promise<{ success: boolean; error: string | null }> {
   try {
     const res = await fetch(`${BACKEND_URL}/api/matchmaking/declinar`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ jugadorId: userGoogleId, oponenteId: opponentId }),
+      body: JSON.stringify({ jugadorId: userGoogleId, oponenteId: opponentId, partidaId: matchId }),
     })
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- send `match-cancelled` SSE when a player declines a match
- propagate cancellation via hook and page handler
- extend declineMatch action with match id

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module declarations)*
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863b39c3b3c832db2f4c8d309ab925a