### PR TITLE
Fix race condition when accepting matches

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -65,9 +65,9 @@ public class PartidaService {
 
     @Transactional
     public PartidaResponse aceptarPartida(UUID partidaId, String jugadorId) {
-        Partida partida = partidaRepository.findById(partidaId).orElse(null);
+        Partida partida = partidaRepository.findByIdForUpdate(partidaId).orElse(null);
         if (partida == null) {
-            MatchProposal proposal = matchProposalRepository.findById(partidaId)
+            MatchProposal proposal = matchProposalRepository.findByIdForUpdate(partidaId)
                     .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
 
             if (proposal.getJugador1() != null && proposal.getJugador1().getId().equals(jugadorId)) {
@@ -169,7 +169,7 @@ public class PartidaService {
 
     @Transactional
     public PartidaResponse reportarResultado(UUID partidaId, PartidaResultadoRequest dto) {
-        Partida partida = partidaRepository.findById(partidaId)
+        Partida partida = partidaRepository.findByIdForUpdate(partidaId)
                 .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
 
         if (partida.isValidada() || partida.getEstado() == EstadoPartida.FINALIZADA) {
@@ -194,7 +194,7 @@ public class PartidaService {
 
     @Transactional
     public PartidaResponse asignarGanador(UUID partidaId, String jugadorId) {
-        Partida partida = partidaRepository.findById(partidaId)
+        Partida partida = partidaRepository.findByIdForUpdate(partidaId)
                 .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
 
         co.com.arena.real.domain.entity.Jugador jugador = jugadorRepository.findById(jugadorId)
@@ -209,7 +209,7 @@ public class PartidaService {
 
     @Transactional
     public PartidaResponse marcarComoValidada(UUID partidaId) {
-        Partida partida = partidaRepository.findById(partidaId)
+        Partida partida = partidaRepository.findByIdForUpdate(partidaId)
                 .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
         partida.setValidada(true);
         partida.setValidadaEn(LocalDateTime.now());
@@ -240,7 +240,7 @@ public class PartidaService {
 
     @Transactional
     public PartidaResponse cancelarPartida(UUID partidaId) {
-        Partida partida = partidaRepository.findById(partidaId)
+        Partida partida = partidaRepository.findByIdForUpdate(partidaId)
                 .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
 
         if (partida.getEstado() == EstadoPartida.CANCELADA || partida.getEstado() == EstadoPartida.FINALIZADA) {

--- a/back/src/main/java/co/com/arena/real/infrastructure/repository/MatchProposalRepository.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/repository/MatchProposalRepository.java
@@ -2,8 +2,18 @@ package co.com.arena.real.infrastructure.repository;
 
 import co.com.arena.real.domain.entity.matchmaking.MatchProposal;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 
 import java.util.UUID;
 
 public interface MatchProposalRepository extends JpaRepository<MatchProposal, UUID> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM MatchProposal p WHERE p.id = :id")
+    Optional<MatchProposal> findByIdForUpdate(@Param("id") UUID id);
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/repository/PartidaRepository.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/repository/PartidaRepository.java
@@ -3,8 +3,11 @@ package co.com.arena.real.infrastructure.repository;
 import co.com.arena.real.domain.entity.partida.EstadoPartida;
 import co.com.arena.real.domain.entity.partida.Partida;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -12,6 +15,10 @@ import java.util.UUID;
 
 public interface PartidaRepository extends JpaRepository<Partida, UUID> {
     Optional<Partida> findByApuesta_Id(UUID apuestaId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Partida p WHERE p.id = :id")
+    Optional<Partida> findByIdForUpdate(@Param("id") UUID id);
 
     @Query("SELECT COUNT(p) > 0 FROM Partida p WHERE (p.jugador1.id = :jugadorId OR p.jugador2.id = :jugadorId) AND p.estado IN :estados")
     boolean existsActiveByJugador(@Param("jugadorId") String jugadorId, @Param("estados") Collection<EstadoPartida> estados);


### PR DESCRIPTION
## Summary
- add pessimistic locking to match proposal and partida repositories
- use locked queries in `PartidaService`

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863bc5df9c0832d8db4a8c1fdc7a046