### PR TITLE
Ensure transaction events fire after commit

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/events/TransaccionAprobadaEventListener.java
+++ b/back/src/main/java/co/com/arena/real/application/events/TransaccionAprobadaEventListener.java
@@ -2,7 +2,8 @@ package co.com.arena.real.application.events;
 
 import co.com.arena.real.application.service.SseService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,7 +12,7 @@ public class TransaccionAprobadaEventListener {
 
     private final SseService sseService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTransaccionAprobada(TransaccionAprobadaEvent event) {
         sseService.notificarTransaccionAprobada(event.transaccion());
     }


### PR DESCRIPTION
## Summary
- send SSE notification for transaction approvals only after the surrounding transaction commits

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6863c2664a18832dad3dbb05cb5bb7c2