### PR TITLE
Ensure SSE connection is ready on page load

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/events/TransaccionAprobadaEventListener.java
+++ b/back/src/main/java/co/com/arena/real/application/events/TransaccionAprobadaEventListener.java
@@ -2,7 +2,8 @@ package co.com.arena.real.application.events;
 
 import co.com.arena.real.application.service.SseService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,7 +12,7 @@ public class TransaccionAprobadaEventListener {
 
     private final SseService sseService;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTransaccionAprobada(TransaccionAprobadaEvent event) {
         sseService.notificarTransaccionAprobada(event.transaccion());
     }

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -24,6 +24,11 @@ const HomePageContent = () => {
   const { toast } = useToast();
   useTransactionUpdates();
 
+  const storedUserId =
+    typeof window !== 'undefined'
+      ? localStorage.getItem('cr_duels_user_id')
+      : null;
+
   const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
   const [depositAmount, setDepositAmount] = useState('');
   const [depositScreenshotFile, setDepositScreenshotFile] = useState<File | null>(null);
@@ -78,7 +83,13 @@ const HomePageContent = () => {
     }
   };
 
-  useMatchmakingSse(user?.id, handleMatchFound, handleChatReady, handleOpponentAccepted, handleMatchCancelled);
+  useMatchmakingSse(
+    user?.id || storedUserId || undefined,
+    handleMatchFound,
+    handleChatReady,
+    handleOpponentAccepted,
+    handleMatchCancelled
+  );
 
   useEffect(() => {
     console.log("¡La página de inicio se ha cargado en el frontend! Puedes ver este mensaje en la consola del navegador.");


### PR DESCRIPTION
## Summary
- init `useMatchmakingSse` with stored user id so matchmaking events arrive without refresh

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863c2664a18832dad3dbb05cb5bb7c2