### PR TITLE
Fix immediate match notification

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletableFuture;
 
 @Service
 public class MatchSseService {
@@ -54,13 +55,18 @@ public class MatchSseService {
 
             LatestEvent last = latestEvents.get(jugadorId);
             if (last != null) {
-                try {
-                    emitter.send(SseEmitter.event().name(last.name()).data(last.dto()));
-                    latestEvents.remove(jugadorId);
-                } catch (IOException e) {
-                    removeEmitter(jugadorId);
-                    emitter.completeWithError(e);
-                }
+                CompletableFuture.runAsync(() -> {
+                    try {
+                        wrapper.emitter.send(SseEmitter.event()
+                                .name(last.name())
+                                .data(last.dto()));
+                        wrapper.lastAccess = System.currentTimeMillis();
+                        latestEvents.remove(jugadorId);
+                    } catch (IOException e) {
+                        removeEmitter(jugadorId);
+                        wrapper.emitter.completeWithError(e);
+                    }
+                });
             }
 
             log.info("Nueva conexión SSE para jugador: {}", jugadorId);


### PR DESCRIPTION
## Summary
- deliver pending SSE events after connection using `CompletableFuture`

## Testing
- `npm run typecheck`
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_686482f9b434832d961ca9359af390e3