### PR TITLE
Improve chat creation logs

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/ChatService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/ChatService.java
@@ -4,6 +4,8 @@ import co.com.arena.real.domain.entity.Chat;
 import co.com.arena.real.infrastructure.repository.ChatRepository;
 import com.google.cloud.firestore.Firestore;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,10 +15,13 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ChatService {
 
+    private static final Logger log = LoggerFactory.getLogger(ChatService.class);
+
     private final ChatRepository chatRepository;
     private final Firestore firestore;
 
     public UUID crearChatParaPartida(String jugador1Id, String jugador2Id) {
+        log.info("Creando chat para partida entre {} y {}", jugador1Id, jugador2Id);
         Chat chat = Chat.builder()
                 .jugadores(List.of(jugador1Id, jugador2Id))
                 .build();
@@ -30,7 +35,8 @@ public class ChatService {
             firestore.collection("chats")
                     .document(saved.getId().toString())
                     .set(data);
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            log.error("Error al crear documento de chat en Firestore", e);
         }
 
         return saved.getId();
@@ -44,6 +50,7 @@ public class ChatService {
         if (chatId == null) {
             return;
         }
+        log.info("Cerrando chat {}", chatId);
         chatRepository.findById(chatId).ifPresent(chat -> {
             chat.setActivo(false);
             chatRepository.save(chat);
@@ -64,7 +71,8 @@ public class ChatService {
                     .document(chatId.toString())
                     .collection("messages")
                     .add(msg);
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            log.error("Error al cerrar chat en Firestore", e);
         }
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -24,6 +24,8 @@ import co.com.arena.real.application.service.ApuestaService;
 import co.com.arena.real.application.service.TransaccionService;
 import co.com.arena.real.application.service.MatchSseService;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +47,8 @@ public class PartidaService {
     private final ApuestaService apuestaService;
     private final TransaccionService transaccionService;
     private final MatchSseService matchSseService;
+
+    private static final Logger log = LoggerFactory.getLogger(PartidaService.class);
 
     public Optional<PartidaResponse> obtenerPorApuestaId(UUID apuestaId) {
         return partidaRepository.findByApuesta_Id(apuestaId).map(partidaMapper::toDto);
@@ -153,13 +157,16 @@ public class PartidaService {
             }
 
             if (partida.getChatId() == null) {
+                log.info("Creando chat para partida {}", partida.getId());
                 UUID chatId = chatService.crearChatParaPartida(
                         partida.getJugador1().getId(),
                         partida.getJugador2().getId());
                 partida.setChatId(chatId);
+                log.info("Chat {} creado para partida {}", chatId, partida.getId());
             }
 
             partida.setEstado(EstadoPartida.EN_CURSO);
+            log.info("Notificando chat listo para partida {}", partida.getId());
             matchSseService.notifyChatReady(partida);
         }
 


### PR DESCRIPTION
## Summary
- log chat creation and closure errors
- log creation and notifications when both players accept a match

## Testing
- `mvn -q test -DskipTests=false` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_6864a06cbe90832d8c8dc86313826eac