### PR TITLE
Fix match start after proposal acceptance

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -75,7 +75,8 @@ public class PartidaService {
         if (partida == null) {
             java.util.Optional<Partida> maybe = matchProposalService.aceptarPropuesta(partidaId, jugadorId);
             if (maybe.isPresent()) {
-                partida = partidaRepository.save(maybe.get());
+                partida = maybe.get();
+                matchService.procesarSiListo(partida);
             } else {
                 MatchProposal updated = matchProposalRepository.findById(partidaId)
                         .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));


### PR DESCRIPTION
## Summary
- process matches right after accepting proposals so chat and transactions trigger

## Testing
- `npm install`
- `npm run lint` *(fails: asks for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_686540440268832d89beba4de306cc48