### PR TITLE
Fix chatActive default

### DIFF
--- a/front/src/hooks/useFirestoreChat.ts
+++ b/front/src/hooks/useFirestoreChat.ts
@@ -19,7 +19,9 @@ export default function useFirestoreChat(chatId: string | undefined) {
     const chatRef = doc(db, 'chats', chatId);
     const unsubChat = onSnapshot(chatRef, snap => {
       const data = snap.data() as any;
-      setChatActive(data?.activo ?? false);
+      if (snap.exists() && typeof data.activo === 'boolean') {
+        setChatActive(data.activo);
+      }
     });
 
     const q = query(collection(db, 'chats', chatId, 'messages'), orderBy('timestamp'));


### PR DESCRIPTION
## Summary
- prevent defaulting to inactive chat when Firestore doc is missing

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_6865469b45c0832dba7663716c268e73