### PR TITLE
Fix chat visibility by updating Firestore rules

### DIFF
--- a/firebase.rules
+++ b/firebase.rules
@@ -1,8 +1,12 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /chats/{chatId}/messages/{messageId} {
+    match /chats/{chatId} {
       allow read, write: if request.auth != null;
+
+      match /messages/{messageId} {
+        allow read, write: if request.auth != null;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow read and write access to chat documents in Firebase rules

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6865da3b55e8832da25711f15e06475a