### PR TITLE
Fix chat list error handling

### DIFF
--- a/front/src/app/chat/page.tsx
+++ b/front/src/app/chat/page.tsx
@@ -13,30 +13,46 @@ interface OpponentInfo { id: string; tag: string; }
 
 const ChatListPageContent = () => {
   const { user } = useAuth();
-  const { chats } = useFirestoreChats(user?.id);
+  const { chats, error } = useFirestoreChats(user?.id);
   const [opponents, setOpponents] = useState<Record<string, OpponentInfo>>({});
 
   useEffect(() => {
     const loadOpponents = async () => {
       if (!user) return;
-      const ids = Array.from(new Set(chats.map(c => c.jugadores.find(j => j !== user.id)).filter(Boolean))) as string[];
-      await Promise.all(ids.map(async id => {
-        if (opponents[id]) return;
-        try {
-          const res = await fetch(`${BACKEND_URL}/api/jugadores/${id}`);
-          if (res.ok) {
-            const data = await res.json();
-            setOpponents(prev => ({ ...prev, [id]: { id: data.id, tag: data.tagClash || data.nombre } }));
+      const ids = Array.from(
+        new Set(chats.map(c => c.jugadores.find(j => j !== user.id)).filter(Boolean))
+      ) as string[];
+      await Promise.all(
+        ids.map(async id => {
+          if (opponents[id]) return;
+          try {
+            const res = await fetch(`${BACKEND_URL}/api/jugadores/${id}`);
+            if (res.ok) {
+              const data = await res.json();
+              setOpponents(prev => ({ ...prev, [id]: { id: data.id, tag: data.tagClash || data.nombre } }));
+            }
+          } catch (err) {
+            console.error('Error fetching opponent', err);
           }
-        } catch (err) {
-          console.error('Error fetching opponent', err);
-        }
-      }));
+        })
+      );
     };
     loadOpponents();
-  }, [chats, user, opponents]);
+  }, [chats, user]);
 
   if (!user) return <p>Cargando chats...</p>;
+  if (error) {
+    return (
+      <Card className="shadow-card-medieval border-2 border-primary-dark overflow-hidden">
+        <CardHeader className="bg-primary/10">
+          <CardTitle className="text-3xl font-headline text-primary">Chats</CardTitle>
+        </CardHeader>
+        <CardContent className="p-4">
+          <p className="text-center text-destructive">Error cargando tus chats.</p>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card className="shadow-card-medieval border-2 border-primary-dark overflow-hidden">


### PR DESCRIPTION
## Summary
- handle errors in chat list page and remove unnecessary dependency in chat list data fetch

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run typecheck` *(fails: cannot find module '@radix-ui/react-separator')*

------
https://chatgpt.com/codex/tasks/task_b_6865e699702c832db89c3bb4a3a46ed3