### PR TITLE
Fix chat list not loading

### DIFF
--- a/front/src/app/chat/page.tsx
+++ b/front/src/app/chat/page.tsx
@@ -13,30 +13,46 @@ interface OpponentInfo { id: string; tag: string; }
 
 const ChatListPageContent = () => {
   const { user } = useAuth();
-  const { chats } = useFirestoreChats(user?.id);
+  const { chats, error, loading } = useFirestoreChats(user?.id);
   const [opponents, setOpponents] = useState<Record<string, OpponentInfo>>({});
 
   useEffect(() => {
     const loadOpponents = async () => {
       if (!user) return;
-      const ids = Array.from(new Set(chats.map(c => c.jugadores.find(j => j !== user.id)).filter(Boolean))) as string[];
-      await Promise.all(ids.map(async id => {
-        if (opponents[id]) return;
-        try {
-          const res = await fetch(`${BACKEND_URL}/api/jugadores/${id}`);
-          if (res.ok) {
-            const data = await res.json();
-            setOpponents(prev => ({ ...prev, [id]: { id: data.id, tag: data.tagClash || data.nombre } }));
+      const ids = Array.from(
+        new Set(chats.map(c => c.jugadores.find(j => j !== user.id)).filter(Boolean))
+      ) as string[];
+      await Promise.all(
+        ids.map(async id => {
+          if (opponents[id]) return;
+          try {
+            const res = await fetch(`${BACKEND_URL}/api/jugadores/${id}`);
+            if (res.ok) {
+              const data = await res.json();
+              setOpponents(prev => ({ ...prev, [id]: { id: data.id, tag: data.tagClash || data.nombre } }));
+            }
+          } catch (err) {
+            console.error('Error fetching opponent', err);
           }
-        } catch (err) {
-          console.error('Error fetching opponent', err);
-        }
-      }));
+        })
+      );
     };
     loadOpponents();
-  }, [chats, user, opponents]);
+  }, [chats, user]);
 
-  if (!user) return <p>Cargando chats...</p>;
+  if (!user || loading) return <p>Cargando chats...</p>;
+  if (error) {
+    return (
+      <Card className="shadow-card-medieval border-2 border-primary-dark overflow-hidden">
+        <CardHeader className="bg-primary/10">
+          <CardTitle className="text-3xl font-headline text-primary">Chats</CardTitle>
+        </CardHeader>
+        <CardContent className="p-4">
+          <p className="text-center text-destructive">Error cargando tus chats.</p>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card className="shadow-card-medieval border-2 border-primary-dark overflow-hidden">

--- a/front/src/hooks/useFirestoreChats.ts
+++ b/front/src/hooks/useFirestoreChats.ts
@@ -11,10 +11,12 @@ export interface ChatSummary {
 export default function useFirestoreChats(userId: string | undefined) {
   const [chats, setChats] = useState<ChatSummary[]>([]);
   const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!userId) return;
 
+    setLoading(true);
     const q = query(collection(db, 'chats'), where('jugadores', 'array-contains', userId));
     const unsub = onSnapshot(
       q,
@@ -30,15 +32,18 @@ export default function useFirestoreChats(userId: string | undefined) {
         });
         data.sort((a, b) => Number(b.activo) - Number(a.activo));
         setChats(data);
+        setError(null);
+        setLoading(false);
       },
       err => {
         console.error('Error listening chats', err);
         setError(err);
+        setLoading(false);
       }
     );
 
     return () => unsub();
   }, [userId]);
 
-  return { chats, error };
+  return { chats, error, loading };
 }


### PR DESCRIPTION
## Summary
- add loading state to chat list hook and page
- clear Firestore chat errors when connection succeeds

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module 'next/server', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6865e699702c832db89c3bb4a3a46ed3