### PR TITLE
Fix duel result submission

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -32,6 +32,14 @@ public class PartidaController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @GetMapping("/chat/{chatId}")
+    @Operation(summary = "Buscar por chat", description = "Obtiene la partida asociada a un chat")
+    public ResponseEntity<PartidaResponse> obtenerPorChat(@PathVariable UUID chatId) {
+        return partidaService.obtenerPorChatId(chatId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
     @PutMapping("/{id}/aceptar/{jugadorId}")
     @Operation(summary = "Aceptar partida", description = "Marca la partida como aceptada por el jugador")
     public ResponseEntity<PartidaResponse> aceptarPartida(

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -69,6 +69,10 @@ public class PartidaService {
                 .map(Partida::getChatId);
     }
 
+    public Optional<PartidaResponse> obtenerPorChatId(UUID chatId) {
+        return partidaRepository.findByChatId(chatId).map(partidaMapper::toDto);
+    }
+
     @Transactional
     public PartidaResponse aceptarPartida(UUID partidaId, String jugadorId) {
         Partida partida = partidaRepository.findByIdForUpdate(partidaId).orElse(null);

--- a/back/src/main/java/co/com/arena/real/infrastructure/repository/PartidaRepository.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/repository/PartidaRepository.java
@@ -16,6 +16,8 @@ import java.util.UUID;
 public interface PartidaRepository extends JpaRepository<Partida, UUID> {
     Optional<Partida> findByApuesta_Id(UUID apuestaId);
 
+    Optional<Partida> findByChatId(UUID chatId);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Partida p WHERE p.id = :id")
     Optional<Partida> findByIdForUpdate(@Param("id") UUID id);

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -61,7 +61,7 @@ const HomePageContent = () => {
       if (data.chatId) {
         toast({ title: 'Duelo encontrado', description: 'Abriendo chat con tu oponente...' });
         router.push(
-          `/chat/${data.chatId}?opponentTag=${encodeURIComponent(data.jugadorOponenteNombre)}&opponentGoogleId=${encodeURIComponent(data.jugadorOponenteId)}`
+          `/chat/${data.chatId}?partidaId=${data.partidaId}&opponentTag=${encodeURIComponent(data.jugadorOponenteNombre)}&opponentGoogleId=${encodeURIComponent(data.jugadorOponenteId)}`
         );
         setPendingMatch(null);
         setHasAccepted(false);
@@ -189,7 +189,7 @@ const HomePageContent = () => {
     if (result.duel && result.duel.chatId) {
       toast({ title: 'Duelo encontrado', description: 'Abriendo chat con tu oponente...' });
       router.push(
-        `/chat/${result.duel.chatId}?opponentTag=${encodeURIComponent(pendingMatch.jugadorOponenteNombre)}&opponentGoogleId=${encodeURIComponent(pendingMatch.jugadorOponenteId)}`
+        `/chat/${result.duel.chatId}?partidaId=${result.duel.id}&opponentTag=${encodeURIComponent(pendingMatch.jugadorOponenteNombre)}&opponentGoogleId=${encodeURIComponent(pendingMatch.jugadorOponenteId)}`
       );
       setPendingMatch(null);
       setHasAccepted(false);


### PR DESCRIPTION
## Summary
- add `findByChatId` to PartidaRepository
- add service and controller to fetch a match by chat id
- use partidaId when routing to chat pages
- fetch partidaId in chat page when missing
- send partidaId when reporting results

## Testing
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run typecheck`
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68660bf4c5e0832d90eb5a6a417c4c2e