### PR TITLE
Handle invalid IDs gracefully

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/MatchProposalService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchProposalService.java
@@ -4,6 +4,7 @@ import co.com.arena.real.domain.entity.matchmaking.MatchProposal;
 import co.com.arena.real.domain.entity.partida.EstadoPartida;
 import co.com.arena.real.domain.entity.partida.Partida;
 import co.com.arena.real.infrastructure.repository.MatchProposalRepository;
+import co.com.arena.real.infrastructure.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,7 +21,7 @@ public class MatchProposalService {
 
     public Optional<Partida> aceptarPropuesta(UUID partidaId, String jugadorId) {
         MatchProposal proposal = matchProposalRepository.findByIdForUpdate(partidaId)
-                .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
+                .orElseThrow(() -> new ResourceNotFoundException("Partida no encontrada"));
 
         if (proposal.getJugador1() != null && jugadorId.equals(proposal.getJugador1().getId())) {
             proposal.setAceptadoJugador1(true);

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -16,6 +16,7 @@ import co.com.arena.real.infrastructure.repository.ApuestaRepository;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
 import co.com.arena.real.infrastructure.repository.PartidaRepository;
 import co.com.arena.real.infrastructure.repository.TransaccionRepository;
+import co.com.arena.real.infrastructure.exception.ResourceNotFoundException;
 import co.com.arena.real.infrastructure.repository.MatchProposalRepository;
 import co.com.arena.real.domain.entity.matchmaking.MatchProposal;
 import co.com.arena.real.domain.entity.partida.EstadoPartida;
@@ -83,7 +84,7 @@ public class PartidaService {
                 matchService.procesarSiListo(partida);
             } else {
                 MatchProposal updated = matchProposalRepository.findById(partidaId)
-                        .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
+                        .orElseThrow(() -> new ResourceNotFoundException("Partida no encontrada"));
                 return partidaMapper.toDto(matchProposalService.crearPartidaDesdePropuesta(updated));
             }
         } else {
@@ -99,7 +100,7 @@ public class PartidaService {
     @Transactional
     public PartidaResponse reportarResultado(UUID partidaId, PartidaResultadoRequest dto) {
         Partida partida = partidaRepository.findByIdForUpdate(partidaId)
-                .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
+                .orElseThrow(() -> new ResourceNotFoundException("Partida no encontrada"));
 
         if (partida.isValidada() || partida.getEstado() == EstadoPartida.FINALIZADA) {
             throw new IllegalStateException("La partida ya está finalizada");
@@ -124,7 +125,7 @@ public class PartidaService {
     @Transactional
     public PartidaResponse asignarGanador(UUID partidaId, String jugadorId) {
         Partida partida = partidaRepository.findByIdForUpdate(partidaId)
-                .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
+                .orElseThrow(() -> new ResourceNotFoundException("Partida no encontrada"));
 
         co.com.arena.real.domain.entity.Jugador jugador = jugadorRepository.findById(jugadorId)
                 .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado"));
@@ -139,7 +140,7 @@ public class PartidaService {
     @Transactional
     public PartidaResponse marcarComoValidada(UUID partidaId) {
         Partida partida = partidaRepository.findByIdForUpdate(partidaId)
-                .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
+                .orElseThrow(() -> new ResourceNotFoundException("Partida no encontrada"));
         partida.setValidada(true);
         partida.setValidadaEn(LocalDateTime.now());
         partida.setEstado(EstadoPartida.FINALIZADA);
@@ -170,7 +171,7 @@ public class PartidaService {
     @Transactional
     public PartidaResponse cancelarPartida(UUID partidaId) {
         Partida partida = partidaRepository.findByIdForUpdate(partidaId)
-                .orElseThrow(() -> new IllegalArgumentException("Partida no encontrada"));
+                .orElseThrow(() -> new ResourceNotFoundException("Partida no encontrada"));
 
         if (partida.getEstado() == EstadoPartida.CANCELADA || partida.getEstado() == EstadoPartida.FINALIZADA) {
             throw new IllegalStateException("La partida ya está finalizada");

--- a/back/src/main/java/co/com/arena/real/infrastructure/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package co.com.arena.real.infrastructure.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -33,5 +34,15 @@ public class GlobalExceptionHandler {
         ex.getBindingResult().getFieldErrors()
                 .forEach(err -> errors.put(err.getField(), err.getDefaultMessage()));
         return ResponseEntity.badRequest().body(errors);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<String> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        return ResponseEntity.badRequest().body("Parámetro inválido: " + ex.getName());
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<String> handleNotFound(ResourceNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/exception/ResourceNotFoundException.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/exception/ResourceNotFoundException.java
@@ -1,0 +1,16 @@
+package co.com.arena.real.infrastructure.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.io.Serial;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ResourceNotFoundException`
- handle invalid UUIDs and not-found errors in `GlobalExceptionHandler`
- use `ResourceNotFoundException` in `PartidaService` and `MatchProposalService`

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686661bd0f5c832da3469ca7e4b40e3d