### PR TITLE
Fix partida lookup by chat

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -34,10 +34,15 @@ public class PartidaController {
 
     @GetMapping("/chat/{chatId}")
     @Operation(summary = "Buscar por chat", description = "Obtiene la partida asociada a un chat")
-    public ResponseEntity<PartidaResponse> obtenerPorChat(@PathVariable UUID chatId) {
-        return partidaService.obtenerPorChatId(chatId)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+    public ResponseEntity<PartidaResponse> obtenerPorChat(@PathVariable String chatId) {
+        try {
+            UUID uuid = UUID.fromString(chatId);
+            return partidaService.obtenerPorChatId(uuid)
+                    .map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.notFound().build());
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @PutMapping("/{id}/aceptar/{jugadorId}")

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -70,6 +70,7 @@ public class PartidaService {
                 .map(Partida::getChatId);
     }
 
+    @Transactional(readOnly = true)
     public Optional<PartidaResponse> obtenerPorChatId(UUID chatId) {
         return partidaRepository.findByChatId(chatId).map(partidaMapper::toDto);
     }


### PR DESCRIPTION
## Summary
- handle invalid or missing partidas when requesting `/api/partidas/chat/{chatId}`
- query chat lookups in a read-only transaction

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68666b9937d8832d8871088f1235bf9e