### PR TITLE
Add admin backend endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,37 @@ NEXT_PUBLIC_FIREBASE_APP_ID=tu-app-id
 
 Recuerda reiniciar el servidor de desarrollo después de modificar este archivo.
 
+
+## Admin console
+
+Two new applications provide an isolated admin panel:
+
+- `admin-back` – Spring Boot backend exposing admin endpoints on port `8081`.
+- `admin` – Next.js frontend located in the `admin/` folder.
+
+Run the admin backend:
+
+```bash
+cd admin-back
+mvn spring-boot:run
+```
+
+The admin backend expects a secret used to validate JWTs:
+
+```bash
+export ADMIN_JWT_SECRET=changeMe
+```
+
+Run the admin frontend:
+
+```bash
+cd admin
+npm install
+npm run dev
+```
+
+Create `admin/.env.local` with:
+
+```env
+NEXT_PUBLIC_ADMIN_API_URL=http://localhost:8081
+```

--- a/admin-back/pom.xml
+++ b/admin-back/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.6</version>
+    <relativePath/> 
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>admin-service</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.32</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/admin-back/src/main/java/com/example/admin/AdminApplication.java
+++ b/admin-back/src/main/java/com/example/admin/AdminApplication.java
@@ -1,0 +1,11 @@
+package com.example.admin;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AdminApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(AdminApplication.class, args);
+    }
+}

--- a/admin-back/src/main/java/com/example/admin/application/controller/AdminController.java
+++ b/admin-back/src/main/java/com/example/admin/application/controller/AdminController.java
@@ -1,0 +1,57 @@
+package com.example.admin.application.controller;
+
+import com.example.admin.application.service.AdminService;
+import com.example.admin.infrastructure.dto.GameResultDto;
+import com.example.admin.infrastructure.dto.ImageDto;
+import com.example.admin.infrastructure.dto.TransactionDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @GetMapping("/images")
+    public ResponseEntity<List<ImageDto>> pendingImages() {
+        return ResponseEntity.ok(adminService.listPendingImages());
+    }
+
+    @PostMapping("/images/{id}/approve")
+    public ResponseEntity<Void> approveImage(@PathVariable UUID id) {
+        adminService.approveImage(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/transactions")
+    public ResponseEntity<List<TransactionDto>> pendingTransactions() {
+        return ResponseEntity.ok(adminService.listPendingTransactions());
+    }
+
+    @PostMapping("/transactions/{id}/approve")
+    public ResponseEntity<Void> approveTransaction(@PathVariable UUID id) {
+        adminService.approveTransaction(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/games/results")
+    public ResponseEntity<List<GameResultDto>> gameResults() {
+        return ResponseEntity.ok(adminService.listGameResults());
+    }
+
+    @PostMapping("/games/{id}/distribute")
+    public ResponseEntity<Void> distributePrize(@PathVariable UUID id) {
+        adminService.distributePrize(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -1,0 +1,41 @@
+package com.example.admin.application.service;
+
+import com.example.admin.infrastructure.dto.GameResultDto;
+import com.example.admin.infrastructure.dto.ImageDto;
+import com.example.admin.infrastructure.dto.TransactionDto;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class AdminService {
+
+    public List<ImageDto> listPendingImages() {
+        // TODO connect to database and fetch real data
+        return Collections.emptyList();
+    }
+
+    public void approveImage(UUID id) {
+        // TODO update image status in database
+    }
+
+    public List<TransactionDto> listPendingTransactions() {
+        // TODO connect to database and fetch real data
+        return Collections.emptyList();
+    }
+
+    public void approveTransaction(UUID id) {
+        // TODO update transaction status in database
+    }
+
+    public List<GameResultDto> listGameResults() {
+        // TODO connect to database and fetch real data
+        return Collections.emptyList();
+    }
+
+    public void distributePrize(UUID gameId) {
+        // TODO distribute prize in database
+    }
+}

--- a/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.example.admin.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeHttpRequests(auth -> auth.anyRequest().hasRole("ADMIN"))
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt());
+        return http.build();
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder(@Value("${admin.security.jwt-secret}") String secret) {
+        SecretKey key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        return NimbusJwtDecoder.withSecretKey(key).build();
+    }
+}

--- a/admin-back/src/main/java/com/example/admin/infrastructure/dto/GameResultDto.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/dto/GameResultDto.java
@@ -1,0 +1,12 @@
+package com.example.admin.infrastructure.dto;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class GameResultDto {
+    private UUID id;
+    private UUID winnerId;
+    private boolean distributed;
+}

--- a/admin-back/src/main/java/com/example/admin/infrastructure/dto/ImageDto.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/dto/ImageDto.java
@@ -1,0 +1,12 @@
+package com.example.admin.infrastructure.dto;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class ImageDto {
+    private UUID id;
+    private String base64;
+    private boolean approved;
+}

--- a/admin-back/src/main/java/com/example/admin/infrastructure/dto/TransactionDto.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/dto/TransactionDto.java
@@ -1,0 +1,14 @@
+package com.example.admin.infrastructure.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Data
+public class TransactionDto {
+    private UUID id;
+    private String playerId;
+    private BigDecimal amount;
+    private boolean approved;
+}

--- a/admin-back/src/main/resources/application.properties
+++ b/admin-back/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+server.port=8081
+spring.application.name=admin-service
+admin.security.jwt-secret=changeMe

--- a/admin/next-env.d.ts
+++ b/admin/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/admin/next.config.js
+++ b/admin/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+module.exports = nextConfig;

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "admin-panel",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "15.3.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/admin/src/pages/index.tsx
+++ b/admin/src/pages/index.tsx
@@ -1,0 +1,24 @@
+import type { NextPage } from 'next';
+import { useState, useEffect } from 'react';
+
+const Home: NextPage = () => {
+  const [images, setImages] = useState<string[]>([]);
+
+  useEffect(() => {
+    const baseUrl = process.env.NEXT_PUBLIC_ADMIN_API_URL || '';
+    fetch(`${baseUrl}/api/admin/images`)
+      .then(res => res.json())
+      .then(data => setImages(data.map((i: any) => i.base64)));
+  }, []);
+
+  return (
+    <div>
+      <h1>Admin Panel</h1>
+      {images.map((img, idx) => (
+        <img key={idx} src={`data:image/jpeg;base64,${img}`} alt={`img-${idx}`} />
+      ))}
+    </div>
+  );
+};
+
+export default Home;

--- a/admin/tsconfig.json
+++ b/admin/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "noEmit": true,
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- secure admin backend with JWT-based auth
- add endpoints for game results and prize distribution
- update Next.js admin page to use env-based API URL
- document admin secret and frontend env setup in the README
- include OAuth2 resource server and test deps in admin pom

## Testing
- `mvn -q -f back/pom.xml package` *(fails: command not found)*
- `npm run lint` in `admin` *(fails: `next` not found)*
- `npm run lint` in `front` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_b_686677a63ff0832db8f8e1ca7adeb70e