### PR TITLE
Add fallback for missing partidaId

### DIFF
--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -17,7 +17,7 @@ import { useToast } from "@/hooks/use-toast";
 import useFirestoreChat from '@/hooks/useFirestoreChat';
 import { BACKEND_URL } from '@/lib/config';
 import type { ChatMessage, User } from '@/types';
-import { submitMatchResultAction } from '@/lib/actions';
+import { submitMatchResultAction, fetchMatchIdByChat } from '@/lib/actions';
 
 import { Label } from '@/components/ui/label';
 
@@ -215,13 +215,19 @@ const ChatPageContent = () => {
       })
     }
 
-    if (!partidaId) {
-      toast({ title: 'Error', description: 'No se encontró la partida asociada al chat.', variant: 'destructive' })
-      return
+    let validPartidaId = partidaId
+    if (!validPartidaId) {
+      validPartidaId = await fetchMatchIdByChat(validChatId)
+      if (validPartidaId) {
+        setPartidaId(validPartidaId)
+      } else {
+        toast({ title: 'Error', description: 'No se encontró la partida asociada al chat.', variant: 'destructive' })
+        return
+      }
     }
 
     const response = await submitMatchResultAction(
-      partidaId,
+      validPartidaId,
       user.id,
       result === 'win' ? 'VICTORIA' : 'DERROTA',
       screenshotBase64,

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -373,3 +373,16 @@ export async function submitMatchResultAction(
     return { duel: null, error: err.message || 'Error de red.' }
   }
 }
+
+export async function fetchMatchIdByChat(
+  chatId: string,
+): Promise<string | null> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/partidas/chat/${encodeURIComponent(chatId)}`)
+    if (!res.ok) return null
+    const data = (await res.json()) as { id: string }
+    return data.id
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- ensure chat can retrieve partidaId when reporting results
- add fetchMatchIdByChat helper

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_68673a14fe60832dbb94edfc267a2fbe