### PR TITLE
Configure admin datasource

### DIFF
--- a/admin-back/src/main/resources/application.yml
+++ b/admin-back/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate.format_sql: true
+    database-platform: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## Summary
- add datasource configuration to `admin-back`

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686761ae662c832dafd7e732b4983b9d