### PR TITLE
Fix type error in admin panel

### DIFF
--- a/admin/next-env.d.ts
+++ b/admin/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="node" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/admin/package.json
+++ b/admin/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/node": "^20",
     "typescript": "^5.8.3"
   }
 }

--- a/admin/tsconfig.json
+++ b/admin/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES6",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -12,10 +16,22 @@
     "jsx": "preserve",
     "noEmit": true,
     "incremental": true,
+    "types": [
+      "node"
+    ],
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "strict": false
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add Node type definitions to the admin front-end
- include `node` types in `tsconfig.json` and `next-env.d.ts`

## Testing
- `npm run typecheck`
- `CI=true npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_686766c30a58832daf87825b386268d1