### PR TITLE
Fix admin login route

### DIFF
--- a/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
@@ -24,7 +24,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())
-            .authorizeHttpRequests(auth -> auth.anyRequest().hasRole("ADMIN"))
+            .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/api/admin/auth/login").permitAll()
+                    .anyRequest().hasRole("ADMIN"))
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
         return http.build();
     }


### PR DESCRIPTION
## Summary
- allow unauthenticated access to `/api/admin/auth/login`

## Testing
- `npm install`
- `npm run lint` *(fails: Next.js ESLint plugin missing)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_686cafc67a68832d894519b28522b2dc