### PR TITLE
Enable CORS for admin API

### DIFF
--- a/admin-back/src/main/java/com/example/admin/config/WebConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.example.admin.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOriginPatterns("*")
+                        .allowedMethods("*")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- allow cross-origin requests in `admin-back`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d115e8c20832dbba735665e36b4de