### PR TITLE
Enable CORS and send 401 on invalid login

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/controller/AuthController.java
+++ b/admin-back/src/main/java/com/example/admin/application/controller/AuthController.java
@@ -7,6 +7,8 @@ import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,7 +32,7 @@ public class AuthController {
     private String adminPassword;
 
     @PostMapping("/login")
-    public Map<String, String> login(@RequestBody Map<String, String> payload) {
+    public ResponseEntity<Map<String, String>> login(@RequestBody Map<String, String> payload) {
         String username = payload.get("username");
         String password = payload.get("password");
         if (adminUser.equals(username) && adminPassword.equals(password)) {
@@ -42,8 +44,8 @@ public class AuthController {
                     .build();
             JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
             String token = encoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
-            return Map.of("token", token);
+            return ResponseEntity.ok(Map.of("token", token));
         }
-        throw new RuntimeException("Invalid credentials");
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
 }

--- a/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())
+            .cors(Customizer.withDefaults())
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/api/admin/auth/login").permitAll()
                     .anyRequest().hasRole("ADMIN"))

--- a/admin-back/src/main/java/com/example/admin/config/WebConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.example.admin.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOriginPatterns("*")
+                        .allowedMethods("*")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- return 401 from admin login instead of 500
- enable CORS in the security filter chain

## Testing
- ❌ `mvn -v` (command not found)
- ❌ `npm run lint` (failed: `next` not installed)


------
https://chatgpt.com/codex/tasks/task_b_686d115e8c20832dbba735665e36b4de