### PR TITLE
Remove MacAlgorithm usage

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AuthService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AuthService.java
@@ -4,8 +4,6 @@ import com.example.admin.infrastructure.exception.InvalidCredentialsException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
-import org.springframework.security.oauth2.jwt.JwsHeader;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
@@ -36,8 +34,7 @@ public class AuthService {
                     .expiresAt(Instant.now().plus(1, ChronoUnit.HOURS))
                     .claim("scope", "ROLE_ADMIN")
                     .build();
-            JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
-            String token = encoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+            String token = encoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
             log.debug("Generated admin token for {}", username);
             return token;
         }

--- a/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.Customizer;
@@ -28,8 +30,18 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/api/admin/auth/login").permitAll()
                     .anyRequest().hasRole("ADMIN"))
-            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+            .oauth2ResourceServer(oauth2 -> oauth2
+                    .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
         return http.build();
+    }
+
+    private JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtGrantedAuthoritiesConverter authoritiesConverter = new JwtGrantedAuthoritiesConverter();
+        authoritiesConverter.setAuthorityPrefix("ROLE_");
+        authoritiesConverter.setAuthoritiesClaimName("scope");
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(authoritiesConverter);
+        return converter;
     }
 
     @Bean


### PR DESCRIPTION
## Summary
- drop `JwsHeader` construction from admin AuthService
- configure JWT authorities converter for admin backend

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_686d283315c4832d8a5c26b607cc6f05