### PR TITLE
Fix admin JWT header configuration

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AuthService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AuthService.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jose.jws.JwsHeader;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.stereotype.Service;
@@ -34,7 +36,8 @@ public class AuthService {
                     .expiresAt(Instant.now().plus(1, ChronoUnit.HOURS))
                     .claim("scope", "ROLE_ADMIN")
                     .build();
-            String token = encoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
+            JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
+            String token = encoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
             log.debug("Generated admin token for {}", username);
             return token;
         }


### PR DESCRIPTION
## Summary
- use HS256 header in `AuthService` when generating JWTs

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_686d3a00b6a4832db604800dc85b5016