### PR TITLE
Fix admin encoder bean

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AuthService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AuthService.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jose.jws.JwsHeader;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.stereotype.Service;
@@ -34,7 +36,8 @@ public class AuthService {
                     .expiresAt(Instant.now().plus(1, ChronoUnit.HOURS))
                     .claim("scope", "ROLE_ADMIN")
                     .build();
-            String token = encoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
+            JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
+            String token = encoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
             log.debug("Generated admin token for {}", username);
             return token;
         }

--- a/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.admin.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -51,7 +52,9 @@ public class SecurityConfig {
     }
 
     @Bean
+    @Primary
     public JwtEncoder jwtEncoder(@Value("${admin.security.jwt-secret}") String secret) {
+        System.out.println("SECRET => " + secret);
         SecretKey key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
         return new NimbusJwtEncoder(new ImmutableSecret<>(key));
     }


### PR DESCRIPTION
## Summary
- mark admin JWT encoder bean as `@Primary` and log secret injection
- ensure HS256 header is used when generating tokens
- import `@Primary` annotation

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_686d3a00b6a4832db604800dc85b5016