### PR TITLE
Fix accessible names on admin filters

### DIFF
--- a/admin/src/components/TransactionTable.tsx
+++ b/admin/src/components/TransactionTable.tsx
@@ -94,6 +94,7 @@ export default function TransactionTable() {
           onChange={e => setSearch(e.target.value)}
         />
         <select
+          aria-label="Filtrar por estado"
           className="px-2 py-1 rounded bg-gray-800 text-white"
           value={statusFilter}
           onChange={e => setStatusFilter(e.target.value as TransactionStatus | 'ALL')}
@@ -104,6 +105,7 @@ export default function TransactionTable() {
           <option value="CANCELADA">Cancelada</option>
         </select>
         <select
+          aria-label="Filtrar por tipo"
           className="px-2 py-1 rounded bg-gray-800 text-white"
           value={typeFilter}
           onChange={e => setTypeFilter(e.target.value as TransactionType | 'ALL')}


### PR DESCRIPTION
## Summary
- add `aria-label` attributes to transaction filters for accessibility

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: TS errors in existing sources)*

------
https://chatgpt.com/codex/tasks/task_b_686e40c2f208832db96e538c5396f8ae