### PR TITLE
Add admin transaction moderation

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/controller/AdminController.java
+++ b/admin-back/src/main/java/com/example/admin/application/controller/AdminController.java
@@ -9,9 +9,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 import java.util.List;
 import java.util.UUID;
@@ -35,13 +38,14 @@ public class AdminController {
     }
 
     @GetMapping("/transactions")
-    public ResponseEntity<List<TransactionDto>> pendingTransactions() {
-        return ResponseEntity.ok(adminService.listPendingTransactions());
+    public ResponseEntity<List<TransactionDto>> transactions() {
+        return ResponseEntity.ok(adminService.listTransactions());
     }
 
-    @PostMapping("/transactions/{id}/approve")
-    public ResponseEntity<Void> approveTransaction(@PathVariable UUID id) {
-        adminService.approveTransaction(id);
+    @PostMapping("/transactions/{id}/status")
+    public ResponseEntity<Void> changeTransactionStatus(@PathVariable UUID id,
+                                                       @RequestBody Map<String, String> body) {
+        adminService.changeTransactionStatus(id, body.get("status"));
         return ResponseEntity.ok().build();
     }
 

--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -50,14 +50,17 @@ public class AdminService {
         });
     }
 
-    public List<TransactionDto> listPendingTransactions() {
-        return transaccionRepository.findByEstado(EstadoTransaccion.PENDIENTE).stream()
+    public List<TransactionDto> listTransactions() {
+        return transaccionRepository.findAll().stream()
                 .map(t -> {
                     TransactionDto dto = new TransactionDto();
                     dto.setId(t.getId());
                     dto.setPlayerId(t.getJugador().getId());
                     dto.setAmount(t.getMonto());
-                    dto.setApproved(EstadoTransaccion.APROBADA.equals(t.getEstado()));
+                    dto.setType(t.getTipo().name());
+                    dto.setStatus(t.getEstado().name());
+                    dto.setCreatedAt(t.getCreadoEn());
+                    dto.setReceipt(t.getComprobante());
                     return dto;
                 })
                 .toList();
@@ -67,6 +70,14 @@ public class AdminService {
     public void approveTransaction(UUID id) {
         transaccionRepository.findById(id).ifPresent(t -> {
             t.setEstado(EstadoTransaccion.APROBADA);
+            transaccionRepository.save(t);
+        });
+    }
+
+    @Transactional
+    public void changeTransactionStatus(UUID id, String status) {
+        transaccionRepository.findById(id).ifPresent(t -> {
+            t.setEstado(EstadoTransaccion.valueOf(status));
             transaccionRepository.save(t);
         });
     }

--- a/admin-back/src/main/java/com/example/admin/infrastructure/dto/TransactionDto.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/dto/TransactionDto.java
@@ -3,6 +3,7 @@ package com.example.admin.infrastructure.dto;
 import lombok.Data;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Data
@@ -10,5 +11,8 @@ public class TransactionDto {
     private UUID id;
     private String playerId;
     private BigDecimal amount;
-    private boolean approved;
+    private String type;
+    private String status;
+    private LocalDateTime createdAt;
+    private String receipt;
 }

--- a/admin/src/components/ReviewTransactionDialog.tsx
+++ b/admin/src/components/ReviewTransactionDialog.tsx
@@ -3,7 +3,7 @@ import { Fragment } from 'react';
 import Image from 'next/image';
 
 export interface ReviewTransaction {
-  id: number;
+  id: string;
   origin: string;
   destination: string;
   type: 'DEPOSITO' | 'RETIRO' | 'APUESTA';
@@ -16,8 +16,8 @@ interface Props {
   open: boolean;
   transaction: ReviewTransaction | null;
   onClose: () => void;
-  onReject: (id: number) => void;
-  onApprove: (id: number) => void;
+  onReject: (id: string) => void;
+  onApprove: (id: string) => void;
 }
 
 export default function ReviewTransactionDialog({ open, transaction, onClose, onReject, onApprove }: Props) {

--- a/admin/src/components/TransactionTable.tsx
+++ b/admin/src/components/TransactionTable.tsx
@@ -1,16 +1,26 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { get, post } from '@/lib/api';
+import ReviewTransactionDialog, { ReviewTransaction } from './ReviewTransactionDialog';
+import Toast from './Toast';
 
 interface Transaction {
   id: string;
   playerId: string;
   amount: number;
-  approved: boolean;
+  type: string;
+  status: string;
+  createdAt: string;
+  receipt?: string | null;
 }
 
 export default function TransactionTable() {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [error, setError] = useState('');
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+  const [reviewTx, setReviewTx] = useState<Transaction | null>(null);
+  const [toast, setToast] = useState('');
 
   useEffect(() => {
     get<Transaction[]>('/api/admin/transactions')
@@ -18,49 +28,100 @@ export default function TransactionTable() {
       .catch(err => setError(err.message));
   }, []);
 
-  const approve = async (id: string) => {
+  const changeStatus = async (id: string, status: 'APROBADA' | 'RECHAZADA') => {
     try {
-      await post(`/api/admin/transactions/${id}/approve`);
+      await post(`/api/admin/transactions/${id}/status`, { status });
       setTransactions(prev =>
-        prev.map(t => (t.id === id ? { ...t, approved: true } : t))
+        prev.map(t => (t.id === id ? { ...t, status } : t))
       );
+      setToast('Estado actualizado');
     } catch (err) {
-      console.error('approve failed', err);
-      setError('No se pudo aprobar la transacción');
+      console.error('status failed', err);
+      setError('No se pudo actualizar la transacción');
     }
   };
+
+  const filtered = useMemo(
+    () =>
+      transactions.filter(t =>
+        t.playerId.toLowerCase().includes(search.toLowerCase())
+      )
+        .filter(t => (statusFilter ? t.status === statusFilter : true))
+        .filter(t => (typeFilter ? t.type === typeFilter : true)),
+    [transactions, search, statusFilter, typeFilter]
+  );
 
   return (
     <div className="space-y-4">
       {error && <p className="text-red-500">{error}</p>}
+
+      <div className="flex gap-2">
+        <input
+          className="px-2 py-1 rounded bg-gray-800 border border-gray-700"
+          placeholder="Usuario"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        <select
+          className="px-2 py-1 rounded bg-gray-800 border border-gray-700"
+          value={statusFilter}
+          onChange={e => setStatusFilter(e.target.value)}
+        >
+          <option value="">Todos los estados</option>
+          <option value="PENDIENTE">PENDIENTE</option>
+          <option value="APROBADA">APROBADA</option>
+          <option value="RECHAZADA">RECHAZADA</option>
+        </select>
+        <select
+          className="px-2 py-1 rounded bg-gray-800 border border-gray-700"
+          value={typeFilter}
+          onChange={e => setTypeFilter(e.target.value)}
+        >
+          <option value="">Todos los tipos</option>
+          <option value="DEPOSITO">DEPOSITO</option>
+          <option value="RETIRO">RETIRO</option>
+          <option value="APUESTA">APUESTA</option>
+          <option value="PREMIO">PREMIO</option>
+          <option value="REEMBOLSO">REEMBOLSO</option>
+        </select>
+      </div>
+
       <table className="min-w-full bg-[#1e1e1e] text-white border border-gray-700 text-sm">
         <thead>
           <tr>
-            <th className="border px-2 py-1">Jugador</th>
+            <th className="border px-2 py-1">Usuario Origen</th>
+            <th className="border px-2 py-1">Usuario Destino</th>
+            <th className="border px-2 py-1">Tipo</th>
             <th className="border px-2 py-1">Monto</th>
+            <th className="border px-2 py-1">Fecha</th>
             <th className="border px-2 py-1">Estado</th>
             <th className="border px-2 py-1">Acción</th>
           </tr>
         </thead>
         <tbody>
-          {transactions.map(t => (
+          {filtered.map(t => (
             <tr key={t.id} className="text-center">
               <td className="border px-2 py-1">{t.playerId}</td>
+              <td className="border px-2 py-1">N/A</td>
+              <td className="border px-2 py-1">{t.type}</td>
               <td className="border px-2 py-1">${'' + t.amount}</td>
+              <td className="border px-2 py-1">{new Date(t.createdAt).toLocaleString()}</td>
               <td className="border px-2 py-1">
-                {t.approved ? (
-                  <span className="px-2 py-1 rounded bg-green-600 text-white">Aprobada</span>
+                {t.status === 'APROBADA' ? (
+                  <span className="px-2 py-1 rounded bg-green-600 text-white">APROBADA</span>
+                ) : t.status === 'RECHAZADA' ? (
+                  <span className="px-2 py-1 rounded bg-red-600 text-white">RECHAZADA</span>
                 ) : (
-                  <span className="px-2 py-1 rounded bg-yellow-600 text-white">Pendiente</span>
+                  <span className="px-2 py-1 rounded bg-yellow-600 text-white">PENDIENTE</span>
                 )}
               </td>
               <td className="border px-2 py-1">
-                {!t.approved && (
+                {t.status === 'PENDIENTE' && (
                   <button
                     className="px-2 py-1 bg-blue-600 rounded"
-                    onClick={() => approve(t.id)}
+                    onClick={() => setReviewTx(t)}
                   >
-                    Aprobar
+                    Revisar
                   </button>
                 )}
               </td>
@@ -68,6 +129,16 @@ export default function TransactionTable() {
           ))}
         </tbody>
       </table>
+
+      <ReviewTransactionDialog
+        open={!!reviewTx}
+        transaction={reviewTx as unknown as ReviewTransaction}
+        onClose={() => setReviewTx(null)}
+        onReject={id => changeStatus(id.toString(), 'RECHAZADA')}
+        onApprove={id => changeStatus(id.toString(), 'APROBADA')}
+      />
+
+      {toast && <Toast message={toast} onClose={() => setToast('')} />}
     </div>
   );
 }

--- a/admin/src/pages/index.tsx
+++ b/admin/src/pages/index.tsx
@@ -11,7 +11,7 @@ const Home: NextPage = () => {
 
   useEffect(() => {
     get<any[]>('/api/admin/transactions')
-      .then(res => setTxCount(res.length))
+      .then(res => setTxCount(res.filter((t: any) => t.status === 'PENDIENTE').length))
       .catch(() => {});
     get<any[]>('/api/admin/games/results')
       .then(res => setGameCount(res.length))


### PR DESCRIPTION
## Summary
- extend `TransactionDto` with new fields
- list all transactions and add status update endpoint in admin backend
- adjust admin frontend with filters and review modal
- show pending count using new status field

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_686e49b9e098832d8939f50e00917e1f