### PR TITLE
Add admin dashboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ NEXT_PUBLIC_FIREBASE_APP_ID=tu-app-id
 
 Recuerda reiniciar el servidor de desarrollo después de modificar este archivo.
 
+
+## Admin Dashboard
+
+Las páginas de administración están en `front/src/app/admin` y utilizan un layout independiente con un sidebar y tarjetas de resumen. Ejecuta el frontend y navega a `/admin` para acceder al panel. Estas vistas no afectan el sitio público de Arena Real.

--- a/front/src/app/admin/layout.tsx
+++ b/front/src/app/admin/layout.tsx
@@ -1,0 +1,10 @@
+import Sidebar from '@/components/admin/Sidebar';
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen bg-neutral-900 text-gray-100">
+      <Sidebar />
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+  );
+}

--- a/front/src/app/admin/page.tsx
+++ b/front/src/app/admin/page.tsx
@@ -1,0 +1,27 @@
+import DashboardCard from '@/components/admin/DashboardCard';
+import { Clock, Shield, Users } from 'lucide-react';
+
+export default function AdminDashboard() {
+  return (
+    <div className="grid gap-6 sm:grid-cols-3">
+      <DashboardCard
+        icon={<Clock className="h-6 w-6" />}
+        title="Transacciones Pendientes"
+        subtitle="Transacciones esperando aprobación"
+        count={3}
+      />
+      <DashboardCard
+        icon={<Shield className="h-6 w-6" />}
+        title="Partidas Pendientes"
+        subtitle="Partidas esperando validación"
+        count={2}
+      />
+      <DashboardCard
+        icon={<Users className="h-6 w-6" />}
+        title="Usuarios Totales"
+        subtitle="Total de usuarios activos en la plataforma"
+        count={6}
+      />
+    </div>
+  );
+}

--- a/front/src/app/admin/partidas/page.tsx
+++ b/front/src/app/admin/partidas/page.tsx
@@ -1,0 +1,5 @@
+export default function PartidasPage() {
+  return (
+    <div className="text-gray-100">Partidas pendientes...</div>
+  );
+}

--- a/front/src/app/admin/transacciones/page.tsx
+++ b/front/src/app/admin/transacciones/page.tsx
@@ -1,0 +1,5 @@
+export default function TransaccionesPage() {
+  return (
+    <div className="text-gray-100">Transacciones pendientes...</div>
+  );
+}

--- a/front/src/components/admin/DashboardCard.tsx
+++ b/front/src/components/admin/DashboardCard.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { ReactNode } from 'react';
+
+interface DashboardCardProps {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  count: number;
+}
+
+export default function DashboardCard({ icon, title, subtitle, count }: DashboardCardProps) {
+  return (
+    <Card className="bg-neutral-900 text-white shadow-lg rounded-2xl flex-1">
+      <CardHeader className="flex-row items-center gap-4">
+        <div className="text-yellow-400">{icon}</div>
+        <div>
+          <CardTitle className="text-base">{title}</CardTitle>
+          <CardDescription className="text-sm text-gray-400">{subtitle}</CardDescription>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-4xl font-bold text-center">{count}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/front/src/components/admin/Sidebar.tsx
+++ b/front/src/components/admin/Sidebar.tsx
@@ -1,0 +1,34 @@
+"use client";
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LayoutDashboard, CreditCard, Shield } from 'lucide-react';
+
+const navItems = [
+  { href: '/admin', label: 'Panel', icon: LayoutDashboard },
+  { href: '/admin/transacciones', label: 'Transacciones', icon: CreditCard },
+  { href: '/admin/partidas', label: 'Partidas', icon: Shield },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+  return (
+    <aside className="bg-neutral-950 text-gray-300 w-64 p-6 space-y-6 hidden sm:block">
+      <h1 className="text-xl font-bold text-yellow-400">Panel de Admin</h1>
+      <nav className="space-y-2">
+        {navItems.map(({ href, label, icon: Icon }) => {
+          const active = pathname === href;
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-yellow-400 ${active ? 'bg-neutral-800 text-yellow-400' : 'hover:bg-neutral-800'}`}
+            >
+              <Icon className="h-4 w-4" />
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- implement admin dashboard page with sidebar
- add DashboardCard component
- create placeholder pages for transacciones and partidas
- document admin dashboard usage in README

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run typecheck` *(fails: TS errors in existing hooks)*

------
https://chatgpt.com/codex/tasks/task_b_686e543e2270832d989f62f05e5a772e