### PR TITLE
Fix transaction dialog props and add select labels

### DIFF
--- a/admin/src/components/ReviewTransactionDialog.tsx
+++ b/admin/src/components/ReviewTransactionDialog.tsx
@@ -15,6 +15,7 @@ export interface ReviewTransaction {
 }
 
 interface Props {
+  open: boolean;
   transaction: ReviewTransaction | null;
   onClose: () => void;
   onReject: (id: string) => void;

--- a/admin/src/components/TransactionTable.tsx
+++ b/admin/src/components/TransactionTable.tsx
@@ -63,6 +63,7 @@ export default function TransactionTable() {
           onChange={e => setSearch(e.target.value)}
         />
         <select
+          aria-label="Filtrar por estado"
           className="px-2 py-1 rounded bg-gray-800 border border-gray-700"
           value={statusFilter}
           onChange={e => setStatusFilter(e.target.value)}
@@ -73,6 +74,7 @@ export default function TransactionTable() {
           <option value="CANCELADA">CANCELADA</option>
         </select>
         <select
+          aria-label="Filtrar por tipo"
           className="px-2 py-1 rounded bg-gray-800 border border-gray-700"
           value={typeFilter}
           onChange={e => setTypeFilter(e.target.value)}


### PR DESCRIPTION
## Summary
- add missing `open` prop in `ReviewTransactionDialog`
- label selects in `TransactionTable`

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_686e6d94bd7c832da878010509c2ca34