### PR TITLE
Enable frontend API interactions

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/ApuestaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/ApuestaController.java
@@ -1,0 +1,45 @@
+package co.com.arena.real.application.controller;
+
+import co.com.arena.real.application.service.ApuestaService;
+import co.com.arena.real.domain.entity.EstadoApuesta;
+import co.com.arena.real.domain.entity.Apuesta;
+import co.com.arena.real.infrastructure.dto.rq.ApuestaRequest;
+import co.com.arena.real.infrastructure.dto.rs.ApuestaResponse;
+import co.com.arena.real.infrastructure.mapper.ApuestaMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/apuestas")
+@Tag(name = "Apuestas", description = "Gestión de apuestas")
+@RequiredArgsConstructor
+public class ApuestaController {
+
+    private final ApuestaService apuestaService;
+
+    @PostMapping
+    @Operation(summary = "Crear apuesta", description = "Crea una nueva apuesta")
+    public ResponseEntity<ApuestaResponse> crear(@Valid @RequestBody ApuestaRequest dto) {
+        Apuesta apuesta = apuestaService.crearApuesta(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApuestaMapper.toDto(apuesta));
+    }
+
+    @PutMapping("/{id}/estado/{estado}")
+    @Operation(summary = "Cambiar estado", description = "Actualiza el estado de la apuesta")
+    public ResponseEntity<ApuestaResponse> cambiarEstado(@PathVariable UUID id, @PathVariable String estado) {
+        ApuestaResponse response = apuestaService.cambiarEstado(id, EstadoApuesta.valueOf(estado));
+        return ResponseEntity.ok(response);
+    }
+}

--- a/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -80,4 +80,12 @@ public class PartidaController {
         java.util.List<PartidaResponse> lista = partidaService.listarHistorial(jugadorId);
         return ResponseEntity.ok(lista);
     }
+
+    @PutMapping("/{id}/ganador/{jugadorId}")
+    @Operation(summary = "Asignar ganador", description = "Asigna manualmente el ganador de la partida")
+    public ResponseEntity<PartidaResponse> asignarGanador(@PathVariable("id") UUID id,
+                                                         @PathVariable("jugadorId") String jugadorId) {
+        PartidaResponse response = partidaService.asignarGanador(id, jugadorId);
+        return ResponseEntity.ok(response);
+    }
 }


### PR DESCRIPTION
## Summary
- expose `ApuestaController` REST endpoints
- add missing winner assignment route to `PartidaController`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_b_686ea99ba364832d9fb6f8605e327f12