### PR TITLE
Fix admin JWT scope

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AuthService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AuthService.java
@@ -34,7 +34,7 @@ public class AuthService {
                     .subject(username)
                     .issuedAt(Instant.now())
                     .expiresAt(Instant.now().plus(1, ChronoUnit.HOURS))
-                    .claim("scope", "ROLE_ADMIN")
+                    .claim("scope", "ADMIN")
                     .build();
             JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
             String token = encoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();


### PR DESCRIPTION
## Summary
- generate admin token with correct scope `ADMIN`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_686f7dece1fc832d85571f17317df450