### PR TITLE
Update gradient colors

### DIFF
--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -30,7 +30,7 @@ const BottomNav = () => {
   const hasActiveChat = chats.some(c => c.activo);
 
   return (
-    <nav className="md:hidden fixed bottom-0 w-full z-50 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 border-t border-blue-800 h-16 animate-gradient-x">
+    <nav className="md:hidden fixed bottom-0 w-full z-50 bg-gradient-to-r from-blue-500 via-blue-700 to-blue-900 border-t border-blue-800 h-16 animate-gradient-x">
       <ul className="flex h-full items-center justify-around">
         {navItems.map(({ id, label, href, icon: Icon }) => {
           const isActive = active === id;

--- a/front/src/components/Navbar.tsx
+++ b/front/src/components/Navbar.tsx
@@ -42,7 +42,7 @@ const Navbar = () => {
   const notifications = 0;
 
   return (
-    <header className="bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 text-white shadow-md animate-gradient-x">
+    <header className="bg-gradient-to-r from-blue-500 via-blue-700 to-blue-900 text-white shadow-md animate-gradient-x">
       <div className="container mx-auto flex items-center justify-between py-3">
         {/* Logo */}
         <Link href="/" className="flex items-center gap-2 font-bold text-lg">

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -16,7 +16,7 @@ const TopNavbar = () => {
   const notifications = 0;
 
   return (
-    <header className="md:hidden fixed top-0 w-full z-50 shadow-sm bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 h-16 px-4 py-3 flex justify-between items-center animate-gradient-x">
+    <header className="md:hidden fixed top-0 w-full z-50 shadow-sm bg-gradient-to-r from-blue-500 via-blue-700 to-blue-900 h-16 px-4 py-3 flex justify-between items-center animate-gradient-x">
       <div className="flex items-center gap-1 text-white font-bold text-lg">
         <Crown className="h-5 w-5" />
         Arena Real


### PR DESCRIPTION
## Summary
- switch navigation gradients to blue tones instead of blue-purple

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_b_686ff7d08a40832d9c3a9f24b9404c16