### PR TITLE
Fix Firebase credential lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ export FIREBASE_SERVICE_ACCOUNT_FILE=/path/to/serviceAccountKey.json
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/serviceAccountKey.json
 ```
 
+These variables can also be defined in a `.env` file because the backend loads
+environment entries via `spring-dotenv` when `dotenv.enabled=true`.
+
 
 If neither variable is set, the backend won't start because Firebase cannot
 locate credentials.
@@ -86,7 +89,8 @@ ADMIN_CREDENTIALS_USER=admin
 ADMIN_CREDENTIALS_PASSWORD=admin
 ```
 The application reads this `.env` file automatically at startup thanks to the
-`dotenv-spring-boot` dependency, so no manual `export` is required. Administrative
+`spring-dotenv` dependency, so no manual `export` is required. Set
+`dotenv.enabled=true` in your configuration to activate it. Administrative
 operations like approving transactions or validating game results are no longer
 available in the main backend. Use the admin API instead.
 Default values are provided in `admin-back/src/main/resources/application.properties`.

--- a/admin-back/pom.xml
+++ b/admin-back/pom.xml
@@ -29,8 +29,8 @@
     </dependency>
     <dependency>
       <groupId>me.paulschwarz</groupId>
-      <artifactId>dotenv-spring-boot</artifactId>
-      <version>3.0.0</version>
+      <artifactId>spring-dotenv</artifactId>
+      <version>4.0.0</version>
     </dependency>
 
     <!-- Replace default logback with log4j2 -->

--- a/admin-back/src/main/resources/application.properties
+++ b/admin-back/src/main/resources/application.properties
@@ -3,3 +3,4 @@ spring.application.name=admin-service
 admin.security.jwt-secret=5e8f0bc1f6c34fdfadcb5c1249eb4d77b91c8f2d0316fabbf90c1aaaf7b39cdd
 admin.credentials.user=admin
 admin.credentials.password=admin
+dotenv.enabled=true

--- a/admin-back/src/main/resources/application.yml
+++ b/admin-back/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+dotenv:
+  enabled: true
+
 spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL}

--- a/back/pom.xml
+++ b/back/pom.xml
@@ -27,8 +27,8 @@
         </dependency>
         <dependency>
             <groupId>me.paulschwarz</groupId>
-            <artifactId>dotenv-spring-boot</artifactId>
-            <version>3.0.0</version>
+            <artifactId>spring-dotenv</artifactId>
+            <version>4.0.0</version>
         </dependency>
         <!-- Validación -->
         <dependency>

--- a/back/src/main/java/co/com/arena/real/config/FirebaseConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/FirebaseConfig.java
@@ -3,6 +3,7 @@ package co.com.arena.real.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,21 +14,25 @@ import java.io.IOException;
 public class FirebaseConfig {
 
     @Bean
-    public FirebaseApp firebaseApp() throws IOException {
+    public FirebaseApp firebaseApp(
+            @Value("${FIREBASE_SERVICE_ACCOUNT_FILE:}") String firebaseServiceAccount,
+            @Value("${GOOGLE_APPLICATION_CREDENTIALS:}") String googleCredentialsPath
+    ) throws IOException {
         if (!FirebaseApp.getApps().isEmpty()) {
             return FirebaseApp.getInstance();
         }
 
-        String serviceAccountPath = System.getenv("FIREBASE_SERVICE_ACCOUNT_FILE");
+        String serviceAccountPath = firebaseServiceAccount;
         if (serviceAccountPath == null || serviceAccountPath.isBlank()) {
-            serviceAccountPath = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
+            serviceAccountPath = googleCredentialsPath;
         }
 
         if (serviceAccountPath == null || serviceAccountPath.isBlank()) {
-            throw new IllegalStateException("❌ No se encontró la ruta del archivo de credenciales de Firebase. Asegúrate de definir FIREBASE_SERVICE_ACCOUNT_FILE o GOOGLE_APPLICATION_CREDENTIALS como variable de entorno.");
+            throw new IllegalStateException(
+                    "Firebase credentials file not found. Set FIREBASE_SERVICE_ACCOUNT_FILE or GOOGLE_APPLICATION_CREDENTIALS.");
         }
 
-        System.out.println("✅ Ruta del archivo de servicio Firebase: " + serviceAccountPath);
+        System.out.println("Firebase service file path: " + serviceAccountPath);
 
         GoogleCredentials credentials;
         try (FileInputStream serviceAccount = new FileInputStream(serviceAccountPath)) {

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 server:
   port: ${PORT:8080}
 
+dotenv:
+  enabled: true
+
 spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL}


### PR DESCRIPTION
## Summary
- load Firebase credential path via Spring properties rather than System.getenv
- document that these variables can be placed in a `.env` file

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*
- `npm run lint` in `front` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870214fe49c832db75fce604f16b12d