### PR TITLE
Add full match info in admin game results

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -104,6 +104,15 @@ public class AdminService {
                 .map(p -> {
                     GameResultDto dto = new GameResultDto();
                     dto.setId(p.getId());
+                    if (p.getJugador1() != null) {
+                        dto.setJugadorA(p.getJugador1().getNombre());
+                    }
+                    if (p.getJugador2() != null) {
+                        dto.setJugadorB(p.getJugador2().getNombre());
+                    }
+                    dto.setEstado(p.getEstado() != null ? p.getEstado().name() : null);
+                    dto.setCapturaA(p.getCapturaJugador1());
+                    dto.setCapturaB(p.getCapturaJugador2());
                     dto.setWinnerId(p.getGanador() != null ? UUID.fromString(p.getGanador().getId()) : null);
                     dto.setDistributed(p.isValidada());
                     return dto;

--- a/admin-back/src/main/java/com/example/admin/infrastructure/dto/GameResultDto.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/dto/GameResultDto.java
@@ -7,6 +7,11 @@ import java.util.UUID;
 @Data
 public class GameResultDto {
     private UUID id;
+    private String jugadorA;
+    private String jugadorB;
+    private String estado;
+    private String capturaA;
+    private String capturaB;
     private UUID winnerId;
     private boolean distributed;
 }


### PR DESCRIPTION
## Summary
- extend `GameResultDto` with match fields
- expose those fields in `AdminService.listGameResults`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68705949501c832da7a8d2e437c889b1