### PR TITLE
Improve transaction SSE hook

### DIFF
--- a/front/src/hooks/useTransactionUpdates.ts
+++ b/front/src/hooks/useTransactionUpdates.ts
@@ -13,37 +13,50 @@ export default function useTransactionUpdates() {
   const { user, refreshUser } = useAuth();
   const { toast } = useToast();
   const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (!user?.id) return;
 
-    const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}`;
-    const es = new EventSource(url);
-    eventSourceRef.current = es;
+    const connect = () => {
+      const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}`;
+      const es = new EventSource(url);
+      eventSourceRef.current = es;
 
-    const handler = async (event: MessageEvent) => {
-      try {
-        const data = JSON.parse(event.data);
+      const handler = async (event: MessageEvent) => {
+        try {
+          const data = JSON.parse(event.data);
+          toast({
+            title: 'Actualización de Transacción',
+            description: `Tu transacción ${data.id} está ahora ${data.estado}.`,
+          });
+          await refreshUser();
+        } catch (err) {
+          console.error('Error procesando evento SSE', err);
+        }
+      };
+
+      es.addEventListener('transaccion-aprobada', handler as unknown as EventListener);
+
+      es.onerror = err => {
+        console.error('SSE error:', err);
         toast({
-          title: 'Actualización de Transacción',
-          description: `Tu transacción ${data.id} está ahora ${data.estado}.`,
+          title: 'Error de Transacciones',
+          description: 'Conexión interrumpida. Reintentando...',
         });
-        await refreshUser();
-      } catch (err) {
-        console.error('Error procesando evento SSE', err);
-      }
+        es.close();
+        reconnectTimeoutRef.current = setTimeout(connect, 3000);
+      };
     };
 
-    es.addEventListener('transaccion-aprobada', handler as unknown as EventListener);
-
-    es.onerror = (err) => {
-      console.error('SSE error:', err);
-    };
+    connect();
 
     return () => {
       if (eventSourceRef.current) {
-        eventSourceRef.current.removeEventListener('transaccion-aprobada', handler as unknown as EventListener);
         eventSourceRef.current.close();
+      }
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
       }
     };
   }, [user, refreshUser, toast]);


### PR DESCRIPTION
## Summary
- add automatic reconnection logic to `useTransactionUpdates` hook for SSE events

## Testing
- `npm run lint` *(fails: interactive configuration prompt)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_6870f2134440832dabb1e6cbdc216d2b