### PR TITLE
Fix matchmaking cancellation

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/MatchmakingService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchmakingService.java
@@ -85,6 +85,7 @@ public class MatchmakingService {
         partidaEnEsperaRepository.deleteByJugador(jugador);
     }
 
+    @Transactional
     public void cancelarSolicitudes(String jugadorId) {
         partidaEnEsperaRepository.deleteByJugador(new Jugador(jugadorId));
     }


### PR DESCRIPTION
## Summary
- ensure cancelling matchmaking runs inside a transaction

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870f7e077a4832d8357c47d4943e05f