### PR TITLE
Fix admin API json error

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -32,10 +32,16 @@ export async function post<T = void>(path: string, body?: unknown): Promise<T> {
     credentials: 'include',
   });
 
+  const text = await res.text();
+
   if (!res.ok) {
     console.error(`❌ POST ${path} → ${res.status}`);
-    throw new Error(await res.text());
+    throw new Error(text);
   }
 
-  return res.status === 204 ? (undefined as T) : res.json();
+  if (!text) {
+    return undefined as T;
+  }
+
+  return JSON.parse(text) as T;
 }


### PR DESCRIPTION
## Summary
- handle empty POST responses in the admin API client

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: many missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_687102cd2d1c832db673378911183858