### PR TITLE
Add torneos placeholder

### DIFF
--- a/front/src/app/torneos/page.tsx
+++ b/front/src/app/torneos/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import AppLayout from '@/components/AppLayout';
+
+export default function TorneosPage() {
+  return (
+    <AppLayout>
+      <div className="flex items-center justify-center h-full">
+        <p className="text-2xl font-headline">Próximamente</p>
+      </div>
+    </AppLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- create Torneos page under `/torneos`
- display "Próximamente" message

## Testing
- `npm run lint` *(fails: prompts about configuring ESLint)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6871049aee54832dafbac509aed8b161