### PR TITLE
Fix admin winner assignment

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -129,9 +129,11 @@ public class AdminService {
                     GameResultDto dto = new GameResultDto();
                     dto.setId(p.getId());
                     if (p.getJugador1() != null) {
+                        dto.setJugadorAId(p.getJugador1().getId());
                         dto.setJugadorA(p.getJugador1().getNombre());
                     }
                     if (p.getJugador2() != null) {
+                        dto.setJugadorBId(p.getJugador2().getId());
                         dto.setJugadorB(p.getJugador2().getNombre());
                     }
                     dto.setEstado(p.getEstado() != null ? p.getEstado().name() : null);

--- a/admin-back/src/main/java/com/example/admin/infrastructure/dto/GameResultDto.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/dto/GameResultDto.java
@@ -7,7 +7,9 @@ import java.util.UUID;
 @Data
 public class GameResultDto {
     private UUID id;
+    private String jugadorAId;
     private String jugadorA;
+    private String jugadorBId;
     private String jugadorB;
     private String estado;
     private String capturaA;

--- a/admin/src/components/MatchTable.tsx
+++ b/admin/src/components/MatchTable.tsx
@@ -4,7 +4,9 @@ import Modal from './Modal'
 
 interface GameResult {
   id: string
+  jugadorAId?: string
   jugadorA?: string
+  jugadorBId?: string
   jugadorB?: string
   capturaA?: string | null
   capturaB?: string | null
@@ -43,10 +45,10 @@ export default function MatchTable() {
     }
   };
 
-  const assignWinner = async (id: string, player: string) => {
+  const assignWinner = async (id: string, playerId: string) => {
     try {
-      await post(`/api/admin/games/${id}/winner/${player}`);
-      setResults(prev => prev.map(r => (r.id === id ? { ...r, winnerId: player } : r)));
+      await post(`/api/admin/games/${id}/winner/${playerId}`);
+      setResults(prev => prev.map(r => (r.id === id ? { ...r, winnerId: playerId } : r)));
     } catch (err) {
       console.error('❌ Assign winner failed:', err);
       setError('No se pudo asignar el ganador');
@@ -119,18 +121,18 @@ export default function MatchTable() {
               <td className="border px-2 py-1 space-y-1">
                 {!r.winnerId && (
                   <div className="flex flex-col gap-1">
-                    {r.jugadorA && (
+                    {r.jugadorAId && (
                       <button
                         className="px-2 py-1 bg-gray-700 rounded"
-                        onClick={() => assignWinner(r.id, r.jugadorA!)}
+                        onClick={() => assignWinner(r.id, r.jugadorAId!)}
                       >
                         Ganador A
                       </button>
                     )}
-                    {r.jugadorB && (
+                    {r.jugadorBId && (
                       <button
                         className="px-2 py-1 bg-gray-700 rounded"
-                        onClick={() => assignWinner(r.id, r.jugadorB!)}
+                        onClick={() => assignWinner(r.id, r.jugadorBId!)}
                       >
                         Ganador B
                       </button>


### PR DESCRIPTION
## Summary
- include player IDs in GameResultDto
- populate those IDs in AdminService
- use the player IDs when assigning winners from the admin UI

## Testing
- `npm run lint` *(fails: next not found)*
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68711a9f3618832d8cb28c09bfe500f6