### PR TITLE
Move PartidaService into arena-real module

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -10,7 +10,7 @@ import co.com.arena.real.infrastructure.repository.ApuestaRepository;
 import co.com.arena.real.infrastructure.repository.TransaccionRepository;
 import co.com.arena.real.infrastructure.repository.PartidaRepository;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
-import co.com.arena.shared.application.service.PartidaService;
+import co.com.arena.real.application.service.PartidaService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/back/src/main/java/co/com/arena/real/application/controller/ChatController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/ChatController.java
@@ -1,7 +1,7 @@
 package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.ChatService;
-import co.com.arena.shared.application.service.PartidaService;
+import co.com.arena.real.application.service.PartidaService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PartidaController.java
@@ -1,6 +1,6 @@
 package co.com.arena.real.application.controller;
 
-import co.com.arena.shared.application.service.PartidaService;
+import co.com.arena.real.application.service.PartidaService;
 import co.com.arena.real.infrastructure.dto.rq.PartidaResultadoRequest;
 import co.com.arena.real.infrastructure.dto.rs.PartidaResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -1,4 +1,4 @@
-package co.com.arena.shared.application.service;
+package co.com.arena.real.application.service;
 
 import co.com.arena.real.domain.entity.Apuesta;
 import co.com.arena.real.domain.entity.EstadoTransaccion;


### PR DESCRIPTION
## Summary
- relocate `PartidaService` from shared to arena-real
- update imports in controllers and admin service
- keep admin-back pom dependency for arena-real

## Testing
- `mvn -q clean install` *(fails: Non-resolvable parent POM)*
- `mvn -q clean spring-boot:run` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68767abb96a4832d946406a77dff5c72