### PR TITLE
Fix admin-back missing dependency

### DIFF
--- a/admin-back/pom.xml
+++ b/admin-back/pom.xml
@@ -149,11 +149,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-log4j2</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.crduels</groupId>
-      <artifactId>crduels-backend</artifactId>
-      <version>1.0.3</version>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Summary
- remove obsolete crduels-backend dependency from admin-back

## Testing
- `mvn -q test-compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6876c83c5640832db1e74e8677ace6bf