### PR TITLE
Update admin match table

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -136,14 +136,19 @@ public class AdminService {
                     if (p.getJugador1() != null) {
                         dto.setJugadorAId(p.getJugador1().getId());
                         dto.setJugadorA(p.getJugador1().getNombre());
+                        dto.setJugadorATag(p.getJugador1().getTagClash());
+                        dto.setResultadoA(p.getResultadoJugador1() != null ? p.getResultadoJugador1().name() : null);
                     }
                     if (p.getJugador2() != null) {
                         dto.setJugadorBId(p.getJugador2().getId());
                         dto.setJugadorB(p.getJugador2().getNombre());
+                        dto.setJugadorBTag(p.getJugador2().getTagClash());
+                        dto.setResultadoB(p.getResultadoJugador2() != null ? p.getResultadoJugador2().name() : null);
                     }
                     dto.setEstado(p.getEstado() != null ? p.getEstado().name() : null);
                     dto.setCapturaA(p.getCapturaJugador1());
                     dto.setCapturaB(p.getCapturaJugador2());
+                    dto.setMonto(p.getMonto());
                     dto.setWinnerId(p.getGanador() != null ? UUID.fromString(p.getGanador().getId()) : null);
                     dto.setDistributed(p.isValidada());
                     return dto;

--- a/admin-back/src/main/java/com/example/admin/infrastructure/dto/GameResultDto.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/dto/GameResultDto.java
@@ -9,11 +9,16 @@ public class GameResultDto {
     private UUID id;
     private String jugadorAId;
     private String jugadorA;
+    private String jugadorATag;
     private String jugadorBId;
     private String jugadorB;
+    private String jugadorBTag;
     private String estado;
     private String capturaA;
     private String capturaB;
+    private String resultadoA;
+    private String resultadoB;
+    private java.math.BigDecimal monto;
     private UUID winnerId;
     private boolean distributed;
 }

--- a/admin/package.json
+++ b/admin/package.json
@@ -22,6 +22,8 @@
   "devDependencies": {
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.0",
+    "eslint": "^9.31.0",
+    "eslint-config-next": "^15.4.1",
     "typescript": "^5.4.5"
   }
 }

--- a/admin/src/components/MatchTable.tsx
+++ b/admin/src/components/MatchTable.tsx
@@ -6,10 +6,15 @@ interface GameResult {
   id: string
   jugadorAId?: string
   jugadorA?: string
+  jugadorATag?: string
   jugadorBId?: string
   jugadorB?: string
+  jugadorBTag?: string
   capturaA?: string | null
   capturaB?: string | null
+  resultadoA?: string | null
+  resultadoB?: string | null
+  monto?: number
   winnerId?: string | null
   distributed: boolean
 }
@@ -70,8 +75,11 @@ export default function MatchTable() {
             <th className="border px-2 py-1">Partida</th>
             <th className="border px-2 py-1">Jugador A</th>
             <th className="border px-2 py-1">Captura A</th>
+            <th className="border px-2 py-1">Resultado A</th>
             <th className="border px-2 py-1">Jugador B</th>
             <th className="border px-2 py-1">Captura B</th>
+            <th className="border px-2 py-1">Resultado B</th>
+            <th className="border px-2 py-1">Apuesta</th>
             <th className="border px-2 py-1">Ganador</th>
             <th className="border px-2 py-1">Estado</th>
             <th className="border px-2 py-1">Acción</th>
@@ -88,7 +96,12 @@ export default function MatchTable() {
           {results.map(r => (
             <tr key={r.id} className="text-center">
               <td className="border px-2 py-1">{r.id}</td>
-              <td className="border px-2 py-1">{r.jugadorA || '-'}</td>
+              <td className="border px-2 py-1">
+                <div>{r.jugadorA || '-'}</div>
+                {r.jugadorATag && (
+                  <div className="text-xs text-gray-400">{r.jugadorATag}</div>
+                )}
+              </td>
               <td className="border px-2 py-1">
                 {r.capturaA && (
                   <img
@@ -99,7 +112,13 @@ export default function MatchTable() {
                   />
                 )}
               </td>
-              <td className="border px-2 py-1">{r.jugadorB || '-'}</td>
+              <td className="border px-2 py-1">{r.resultadoA || '-'}</td>
+              <td className="border px-2 py-1">
+                <div>{r.jugadorB || '-'}</div>
+                {r.jugadorBTag && (
+                  <div className="text-xs text-gray-400">{r.jugadorBTag}</div>
+                )}
+              </td>
               <td className="border px-2 py-1">
                 {r.capturaB && (
                   <img
@@ -109,6 +128,10 @@ export default function MatchTable() {
                     onClick={() => setImage(r.capturaB!)}
                   />
                 )}
+              </td>
+              <td className="border px-2 py-1">{r.resultadoB || '-'}</td>
+              <td className="border px-2 py-1">
+                {r.monto !== undefined ? `$${r.monto}` : '-'}
               </td>
               <td className="border px-2 py-1">{r.winnerId || '-'}</td>
               <td className="border px-2 py-1">


### PR DESCRIPTION
## Summary
- display players' tags below their names
- show each player's reported result and the bet amount
- extend admin backend DTO and service to expose new fields
- add ESLint config so `npm run lint` can run

## Testing
- `npm run lint` *(admin)*
- `mvn -q test` *(admin-back) — failed: Non-resolvable parent POM due to network restrictions*

------
https://chatgpt.com/codex/tasks/task_b_6876d48689d0832daceaa0e95115722a