### PR TITLE
Close chat when admin distributes prize

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ cd back
 mvn install
 ```
 
+If the admin backend fails with errors like `package co.com.arena.real.application.service does not exist`,
+verify that the main backend was installed locally:
+
+```bash
+cd back
+mvn install -DskipTests
+```
+
 Before starting the backend, set the path to your Firebase service account
 credentials using either the custom `FIREBASE_SERVICE_ACCOUNT_FILE` variable or
 the standard `GOOGLE_APPLICATION_CREDENTIALS`:

--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -10,6 +10,7 @@ import co.com.arena.real.infrastructure.repository.ApuestaRepository;
 import co.com.arena.real.infrastructure.repository.TransaccionRepository;
 import co.com.arena.real.infrastructure.repository.PartidaRepository;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
+import co.com.arena.real.application.service.ChatService;
 import co.com.arena.real.domain.entity.Jugador;
 import co.com.arena.real.domain.entity.Apuesta;
 import co.com.arena.real.domain.entity.Transaccion;
@@ -31,6 +32,7 @@ public class AdminService {
     private final TransaccionRepository transaccionRepository;
     private final ApuestaRepository apuestaRepository;
     private final JugadorRepository jugadorRepository;
+    private final ChatService chatService;
 
     @Transactional(readOnly = true)
     public List<ImageDto> listPendingImages() {
@@ -176,6 +178,8 @@ public class AdminService {
                     });
                 }
             }
+
+            chatService.cerrarChat(partida.getChatId());
 
             partidaRepository.save(partida);
         });


### PR DESCRIPTION
## Summary
- call `ChatService.cerrarChat` when the admin distributes the prize
- document how to resolve missing `ChatService` compilation errors

## Testing
- `mvn -q -DskipTests package` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6876d67caefc832d923827982d1fd9e8