### PR TITLE
Fix admin-back build

### DIFF
--- a/back/pom.xml
+++ b/back/pom.xml
@@ -206,15 +206,9 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>co.com.arena.real.Application</mainClass>
+                    <!-- Avoid creating a fat jar so this module can be used as a dependency -->
+                    <skip>true</skip>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- prevent Spring Boot from repackaging the back module

## Testing
- `mvn -q clean install` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_687702b86314832dab8baf90dfee2eb5