### PR TITLE
Implement commission in admin prize payout

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -171,7 +171,7 @@ public class AdminService {
                 if (apuesta != null) {
                     Transaccion premio = new Transaccion();
                     premio.setJugador(partida.getGanador());
-                    premio.setMonto(apuesta.getMonto().multiply(BigDecimal.valueOf(2)));
+                    premio.setMonto(apuesta.getPremio());
                     premio.setTipo(TipoTransaccion.PREMIO);
                     premio.setEstado(EstadoTransaccion.APROBADA);
                     premio.setCreadoEn(LocalDateTime.now());

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -151,7 +151,7 @@ public class PartidaService {
 
             Transaccion premio = new Transaccion();
             premio.setJugador(partida.getGanador());
-            premio.setMonto(apuesta.getMonto().multiply(java.math.BigDecimal.valueOf(2)));
+            premio.setMonto(apuesta.getPremio());
             premio.setTipo(TipoTransaccion.PREMIO);
             premio.setEstado(EstadoTransaccion.APROBADA);
             premio.setCreadoEn(LocalDateTime.now());


### PR DESCRIPTION
## Summary
- use `Apuesta.getPremio()` when distributing prizes from the admin backend so the commission is deducted

## Testing
- `mvn -q -pl back -am test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68772d6ab42c832dada641e5521b561a