### PR TITLE
Handle active chat persistence

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -16,6 +16,8 @@ import { Coins, UploadCloud, Swords, Layers, Banknote, Loader2 } from 'lucide-re
 import { requestTransactionAction, matchmakingAction, cancelMatchmakingAction, declineMatchAction, acceptMatchAction } from '@/lib/actions';
 import useTransactionUpdates from '@/hooks/useTransactionUpdates';
 import useMatchmakingSse, { MatchEventData } from '@/hooks/useMatchmakingSse';
+import { setLocalStorageItem } from '@/lib/storage';
+import { ACTIVE_CHAT_KEY } from '@/hooks/useActiveChat';
 
 
 const HomePageContent = () => {
@@ -60,6 +62,7 @@ const HomePageContent = () => {
     if (hasAccepted && pendingMatch && pendingMatch.partidaId === data.partidaId) {
       if (data.chatId) {
         toast({ title: 'Duelo encontrado', description: 'Abriendo chat con tu oponente...' });
+        setLocalStorageItem(ACTIVE_CHAT_KEY, data.chatId);
         router.push(
           `/chat/${data.chatId}?partidaId=${data.partidaId}&opponentTag=${encodeURIComponent(data.jugadorOponenteNombre)}&opponentGoogleId=${encodeURIComponent(data.jugadorOponenteId)}`
         );
@@ -188,6 +191,7 @@ const HomePageContent = () => {
     const result = await acceptMatchAction(pendingMatch.partidaId, user.id);
     if (result.duel && result.duel.chatId) {
       toast({ title: 'Duelo encontrado', description: 'Abriendo chat con tu oponente...' });
+      setLocalStorageItem(ACTIVE_CHAT_KEY, result.duel.chatId);
       router.push(
         `/chat/${result.duel.chatId}?partidaId=${result.duel.id}&opponentTag=${encodeURIComponent(pendingMatch.jugadorOponenteNombre)}&opponentGoogleId=${encodeURIComponent(pendingMatch.jugadorOponenteId)}`
       );

--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
-import useFirestoreChats from "@/hooks/useFirestoreChats";
+import useActiveChat from "@/hooks/useActiveChat";
 import {
   Home,
   Bell,
@@ -17,15 +17,14 @@ import { cn } from "@/lib/utils";
 const BottomNav = () => {
   const pathname = usePathname();
   const { user } = useAuth();
-  const { chats } = useFirestoreChats(user?.id);
-  const activeChat = chats.find(c => c.activo);
-  const hasActiveChat = Boolean(activeChat);
+  const { activeChatId } = useActiveChat(user?.id);
+  const hasActiveChat = Boolean(activeChatId);
   const navItems = [
     { id: "inicio", label: "Inicio", href: "/", icon: Home },
     { id: "notificaciones", label: "Notificaciones", href: "/notifications", icon: Bell },
     { id: "jugar", label: "Jugar", href: "/play", icon: Gamepad2 },
     { id: "usuario", label: "Usuario", href: "/profile", icon: User },
-    { id: "chat", label: "Chat", href: activeChat ? `/chat/${activeChat.id}` : "/chat", icon: MessageCircle },
+    { id: "chat", label: "Chat", href: activeChatId ? `/chat/${activeChatId}` : "/chat", icon: MessageCircle },
     { id: "menu", label: "Menú", href: "/menu", icon: MenuIcon },
   ];
 

--- a/front/src/components/Navbar.tsx
+++ b/front/src/components/Navbar.tsx
@@ -24,19 +24,18 @@ import ActiveLink from './ActiveLink';
 
 // Simple auth hook to access user data
 import { useAuth } from '@/hooks/useAuth';
-import useFirestoreChats from '@/hooks/useFirestoreChats';
+import useActiveChat from '@/hooks/useActiveChat';
 
 const Navbar = () => {
   const { user, logout, isAuthenticated } = useAuth();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const { chats } = useFirestoreChats(user?.id);
-  const activeChat = chats.find(c => c.activo);
-  const hasActiveChat = Boolean(activeChat);
+  const { activeChatId } = useActiveChat(user?.id);
+  const hasActiveChat = Boolean(activeChatId);
 
   const navItems = [
     { href: '/', label: 'Home', icon: Home },
     { href: '/history', label: 'Historial', icon: ScrollText },
-    { href: activeChat ? `/chat/${activeChat.id}` : '/chat', label: 'Chats', icon: MessageCircle },
+    { href: activeChatId ? `/chat/${activeChatId}` : '/chat', label: 'Chats', icon: MessageCircle },
     { href: '/torneos', label: 'Torneos', icon: Trophy },
   ];
 

--- a/front/src/hooks/useActiveChat.ts
+++ b/front/src/hooks/useActiveChat.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import useFirestoreChats from './useFirestoreChats';
+import { getLocalStorageItem, setLocalStorageItem } from '@/lib/storage';
+
+export const ACTIVE_CHAT_KEY = 'cr_active_chat_id';
+
+export default function useActiveChat(userId: string | undefined) {
+  const { chats } = useFirestoreChats(userId);
+  const [activeChatId, setActiveChatId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const active = chats.find(c => c.activo);
+    if (active) {
+      setActiveChatId(active.id);
+      setLocalStorageItem(ACTIVE_CHAT_KEY, active.id);
+    } else {
+      const stored = getLocalStorageItem<string>(ACTIVE_CHAT_KEY);
+      if (stored) {
+        setActiveChatId(stored);
+      } else {
+        setActiveChatId(null);
+      }
+    }
+  }, [chats]);
+
+  return { activeChatId };
+}


### PR DESCRIPTION
## Summary
- persist active chat ID in local storage
- read local storage in navigation components
- store active chat on match events

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_687805a97434832d8af32755f77d98d2