### PR TITLE
Reconnect SSE on new match search

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -42,6 +42,8 @@ const HomePageContent = () => {
 
   const [isModeModalOpen, setIsModeModalOpen] = useState(false);
 
+  const [matchmakingKey, setMatchmakingKey] = useState(0);
+
   const [isSearching, setIsSearching] = useState(false);
   const [pendingMatch, setPendingMatch] = useState<{ apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; jugadorOponenteNombre: string; chatId?: string; } | null>(null);
   const [hasAccepted, setHasAccepted] = useState(false);
@@ -91,7 +93,14 @@ const HomePageContent = () => {
     }
   };
 
-  useMatchmakingSse(user?.id, handleMatchFound, handleChatReady, handleOpponentAccepted, handleMatchCancelled);
+  useMatchmakingSse(
+    user?.id,
+    handleMatchFound,
+    handleChatReady,
+    handleOpponentAccepted,
+    handleMatchCancelled,
+    matchmakingKey
+  );
 
   useEffect(() => {
     console.log("¡La página de inicio se ha cargado en el frontend! Puedes ver este mensaje en la consola del navegador.");
@@ -140,6 +149,7 @@ const HomePageContent = () => {
   }
 
   const handleFindMatch = async (mode: 'CLASICO' | 'TRIPLE_ELECCION') => {
+    setMatchmakingKey((k) => k + 1);
     if (!user.id) {
       toast({
         title: "Error de Usuario",

--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -16,7 +16,8 @@ export default function useMatchmakingSse(
   onMatchFound: (data: MatchEventData) => void,
   onChatReady: (data: MatchEventData) => void,
   onOpponentAccepted?: (data: MatchEventData) => void,
-  onMatchCancelled?: (data: MatchEventData) => void
+  onMatchCancelled?: (data: MatchEventData) => void,
+  connectSignal?: unknown
 ) {
   const { toast } = useToast();
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -141,5 +142,5 @@ export default function useMatchmakingSse(
       }
 
     };
-  }, [playerId, toast]);
+  }, [playerId, toast, connectSignal]);
 }


### PR DESCRIPTION
## Summary
- add `connectSignal` parameter to `useMatchmakingSse`
- trigger SSE reconnection when starting a new search

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_687810a7df18832da1e936e7b27beb4a