### PR TITLE
Fix mobile top nav lacks chat link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ npm install
 npm run dev
 ```
 
+3. The `/chat` page shows all your conversations. When a chat is active, both
+   the top and bottom navigation bars include a chat icon that links directly to
+   that conversation. The icon displays a small red badge while the chat is
+   active.
+
 The backend uses Maven (Java 17). A root `pom.xml` aggregates all Java modules:
 
 ```bash

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Bell, Crown } from "lucide-react";
+import { Bell, Crown, MessageCircle } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,9 +9,12 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAuth } from "@/hooks/useAuth";
+import useFirestoreChats from "@/hooks/useFirestoreChats";
 
 const TopNavbar = () => {
   const { user, logout } = useAuth();
+  const { chats } = useFirestoreChats(user?.id);
+  const activeChat = chats.find(c => c.activo);
   const avatarSrc = (user as any)?.image || user?.avatarUrl;
   const notifications = 0;
 
@@ -26,6 +29,17 @@ const TopNavbar = () => {
         <div className="relative">
           <Bell className="h-5 w-5 text-white" />
           {notifications > 0 && (
+            <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full" />
+          )}
+        </div>
+        <div className="relative">
+          <Link
+            href={activeChat ? `/chat/${activeChat.id}` : "/chat"}
+            aria-label="Chat"
+          >
+            <MessageCircle className="h-5 w-5 text-white" />
+          </Link>
+          {activeChat && (
             <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full" />
           )}
         </div>


### PR DESCRIPTION
## Summary
- show active chat link in `TopNavbar`
- add docs about active chat navigation
- document badge behavior and add ARIA label for the chat icon

## Testing
- `npm run typecheck` *(fails: cannot find module declarations)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878069c72cc832db7d2fae0e8b36780