### PR TITLE
Enable old chat deletion

### DIFF
--- a/front/src/app/chat/page.tsx
+++ b/front/src/app/chat/page.tsx
@@ -2,11 +2,15 @@
 
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { Trash2 } from 'lucide-react';
 import AppLayout from '@/components/AppLayout';
 import { useAuth } from '@/hooks/useAuth';
 import useFirestoreChats from '@/hooks/useFirestoreChats';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { deleteDoc, doc } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
 import { BACKEND_URL } from '@/lib/config';
 
 interface OpponentInfo { id: string; name: string; }
@@ -15,6 +19,16 @@ const ChatListPageContent = () => {
   const { user } = useAuth();
   const { chats } = useFirestoreChats(user?.id);
   const [opponents, setOpponents] = useState<Record<string, OpponentInfo>>({});
+
+  const handleDeleteChat = async (chatId: string) => {
+    const confirmDelete = window.confirm('¿Eliminar este chat?');
+    if (!confirmDelete) return;
+    try {
+      await deleteDoc(doc(db, 'chats', chatId));
+    } catch (err) {
+      console.error('Error deleting chat', err);
+    }
+  };
 
   useEffect(() => {
     const loadOpponents = async () => {
@@ -38,6 +52,9 @@ const ChatListPageContent = () => {
 
   if (!user) return <p>Cargando chats...</p>;
 
+  const activeChats = chats.filter(c => c.activo);
+  const pastChats = chats.filter(c => !c.activo);
+
   return (
     <Card className="shadow-card-medieval border-2 border-primary-dark overflow-hidden">
       <CardHeader className="bg-primary/10">
@@ -46,28 +63,58 @@ const ChatListPageContent = () => {
           Conversaciones de tus partidas
         </CardDescription>
       </CardHeader>
-      <CardContent className="p-4">
-        {chats.length === 0 ? (
+      <CardContent className="p-4 space-y-6">
+        {activeChats.length === 0 && pastChats.length === 0 ? (
           <p className="text-center text-muted-foreground py-8">No tienes chats todavía.</p>
         ) : (
-          <ul className="space-y-3">
-            {chats.map(chat => {
-              const opponentId = chat.jugadores.find(j => j !== user.id) as string | undefined;
-              const opponent = opponentId ? opponents[opponentId] : undefined;
-              const name = opponent ? opponent.name : opponentId || 'Oponente';
-              const href = `/chat/${chat.id}?opponentTag=${encodeURIComponent(name)}&opponentGoogleId=${encodeURIComponent(opponentId ?? '')}`;
-              return (
-                <li key={chat.id}>
-                  <Link href={href} className="block border rounded-lg p-3 hover:bg-primary/10">
-                    <div className="flex justify-between items-center">
-                      <span className="font-medium">{name}</span>
-                      {chat.activo && <Badge className="ml-2">En curso</Badge>}
-                    </div>
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
+          <>
+            {activeChats.length > 0 && (
+              <div>
+                <h3 className="text-xl font-semibold mb-2">Chat activo</h3>
+                <ul className="space-y-3">
+                  {activeChats.map(chat => {
+                    const opponentId = chat.jugadores.find(j => j !== user.id) as string | undefined;
+                    const opponent = opponentId ? opponents[opponentId] : undefined;
+                    const name = opponent ? opponent.name : opponentId || 'Oponente';
+                    const href = `/chat/${chat.id}?opponentTag=${encodeURIComponent(name)}&opponentGoogleId=${encodeURIComponent(opponentId ?? '')}`;
+                    return (
+                      <li key={chat.id}>
+                        <Link href={href} className="block border rounded-lg p-3 hover:bg-primary/10">
+                          <div className="flex justify-between items-center">
+                            <span className="font-medium">{name}</span>
+                            {chat.activo && <Badge className="ml-2">En curso</Badge>}
+                          </div>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+            {pastChats.length > 0 && (
+              <div>
+                <h3 className="text-xl font-semibold mb-2">Chats anteriores</h3>
+                <ul className="space-y-3">
+                  {pastChats.map(chat => {
+                    const opponentId = chat.jugadores.find(j => j !== user.id) as string | undefined;
+                    const opponent = opponentId ? opponents[opponentId] : undefined;
+                    const name = opponent ? opponent.name : opponentId || 'Oponente';
+                    const href = `/chat/${chat.id}?opponentTag=${encodeURIComponent(name)}&opponentGoogleId=${encodeURIComponent(opponentId ?? '')}`;
+                    return (
+                      <li key={chat.id} className="flex items-center justify-between gap-2">
+                        <Link href={href} className="flex-1 border rounded-lg p-3 hover:bg-primary/10">
+                          <span className="font-medium">{name}</span>
+                        </Link>
+                        <Button variant="ghost" size="icon" onClick={() => handleDeleteChat(chat.id)} aria-label="Eliminar chat">
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+          </>
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- show active and past chats separately
- add a delete button for past chats

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6878158ca16c832d90adf4256f0d3414