### PR TITLE
Fix matchmaking SSE reconnection

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -42,7 +42,6 @@ const HomePageContent = () => {
 
   const [isModeModalOpen, setIsModeModalOpen] = useState(false);
 
-  const [matchmakingKey, setMatchmakingKey] = useState(0);
 
   const [isSearching, setIsSearching] = useState(false);
   const [pendingMatch, setPendingMatch] = useState<{ apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; jugadorOponenteNombre: string; chatId?: string; } | null>(null);
@@ -93,13 +92,12 @@ const HomePageContent = () => {
     }
   };
 
-  useMatchmakingSse(
+  const { reconnect: reconnectMatchmaking } = useMatchmakingSse(
     user?.id,
     handleMatchFound,
     handleChatReady,
     handleOpponentAccepted,
-    handleMatchCancelled,
-    matchmakingKey
+    handleMatchCancelled
   );
 
   useEffect(() => {
@@ -149,7 +147,7 @@ const HomePageContent = () => {
   }
 
   const handleFindMatch = async (mode: 'CLASICO' | 'TRIPLE_ELECCION') => {
-    setMatchmakingKey((k) => k + 1);
+    await reconnectMatchmaking();
     if (!user.id) {
       toast({
         title: "Error de Usuario",


### PR DESCRIPTION
## Summary
- add reconnect method to matchmaking SSE hook
- reconnect SSE before sending matchmaking request

## Testing
- `npm install`
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_68781e6eaf60832d9ba7d0764648b9fd