### PR TITLE
Fix matchmaking button hang when user not loaded

### DIFF
--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -32,6 +32,9 @@ export default function useMatchmakingSse(
   const connectResolveRef = useRef<(() => void) | null>(null);
 
   const reconnect = () => {
+    if (!playerId) {
+      return Promise.resolve();
+    }
     return new Promise<void>((resolve) => {
       connectResolveRef.current = resolve;
       setConnectKey((k) => k + 1);


### PR DESCRIPTION
## Summary
- avoid waiting on SSE reconnection when no user ID is available

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_687832a3e654832da3ff2ff6a6699ee4