### PR TITLE
Remove redundant matchmaking reconnection

### DIFF
--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -92,7 +92,7 @@ const HomePageContent = () => {
     }
   };
 
-  const { reconnect: reconnectMatchmaking } = useMatchmakingSse(
+  useMatchmakingSse(
     user?.id,
     handleMatchFound,
     handleChatReady,
@@ -339,7 +339,6 @@ const HomePageContent = () => {
   };
 
   // Matchmaking Modal Logic
-  const reconnectPromiseRef = React.useRef<Promise<void> | null>(null);
   const handleOpenModeModal = () => {
     if (user.balance < 6000) {
       toast({
@@ -349,16 +348,10 @@ const HomePageContent = () => {
       });
       return;
     }
-    await reconnectMatchmaking();
     setIsModeModalOpen(true);
-    reconnectPromiseRef.current = reconnectMatchmaking();
   };
 
   const handleModeSelect = async (mode: 'CLASICO' | 'TRIPLE_ELECCION') => {
-    if (reconnectPromiseRef.current) {
-      await reconnectPromiseRef.current;
-      reconnectPromiseRef.current = null;
-    }
     setIsModeModalOpen(false);
     await handleFindMatch(mode);
   };

--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -29,35 +29,6 @@ export default function useMatchmakingSse(
   const readyHandlerRef = useRef<(event: MessageEvent) => void>();
   const acceptedHandlerRef = useRef<(event: MessageEvent) => void>();
   const cancelledHandlerRef = useRef<(event: MessageEvent) => void>();
-  const [connectKey, setConnectKey] = useState(0);
-  const connectResolveRef = useRef<(() => void) | null>(null);
-
-  const disconnect = () => {
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-      eventSourceRef.current = null;
-    }
-  };
-
-  const reconnect = () => {
-    if (!playerId) {
-      return Promise.resolve();
-    }
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-    disconnect();
-    return new Promise<void>((resolve) => {
-      connectResolveRef.current = resolve;
-      setConnectKey((k) => k + 1);
-    });
-  };
-
   const disconnect = () => {
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
@@ -178,10 +149,7 @@ export default function useMatchmakingSse(
       eventSourceRef.current = es;
 
       es.onopen = () => {
-        if (connectResolveRef.current) {
-          connectResolveRef.current();
-          connectResolveRef.current = null;
-        }
+        // Conexión abierta
       };
 
       if (matchHandlerRef.current) {


### PR DESCRIPTION
## Summary
- stop reconnecting SSE when opening the matchmaking modal
- clean up unused reconnect logic in matchmaking hook

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68783f83bbc0832dab63d4f5b475b92b