### PR TITLE
Improve SSE hooks

### DIFF
--- a/front/src/hooks/useApprovedTransactionsSse.ts
+++ b/front/src/hooks/useApprovedTransactionsSse.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { BACKEND_URL } from '@/lib/config';
 
@@ -15,31 +15,44 @@ export interface ApprovedTransaction {
 export default function useApprovedTransactionsSse() {
   const [transactions, setTransactions] = useState<ApprovedTransaction[]>([]);
   const { user } = useAuth();
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!user?.id) return;
 
-    const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}`;
-    const es = new EventSource(url);
+    const connect = () => {
+      const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}`;
+      const es = new EventSource(url, { withCredentials: true });
+      eventSourceRef.current = es;
 
-    const handler = (event: MessageEvent) => {
-      try {
-        const data = JSON.parse(event.data) as ApprovedTransaction;
-        setTransactions(prev => [data, ...prev]);
-      } catch (err) {
-        console.error('Error parsing SSE event', err);
-      }
+      const handler = (event: MessageEvent) => {
+        try {
+          const data = JSON.parse(event.data) as ApprovedTransaction;
+          setTransactions(prev => [data, ...prev]);
+        } catch (err) {
+          console.error('Error parsing SSE event', err);
+        }
+      };
+
+      es.addEventListener('transaccion-aprobada', handler as EventListener);
+
+      es.onerror = (err) => {
+        console.error('SSE error:', err);
+        es.close();
+        reconnectTimeoutRef.current = setTimeout(connect, 3000);
+      };
     };
 
-    es.addEventListener('transaccion-aprobada', handler as EventListener);
-
-    es.onerror = (err) => {
-      console.error('SSE error:', err);
-    };
+    connect();
 
     return () => {
-      es.removeEventListener('transaccion-aprobada', handler as EventListener);
-      es.close();
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+      }
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
     };
   }, [user]);
 

--- a/front/src/hooks/useTransactionUpdates.ts
+++ b/front/src/hooks/useTransactionUpdates.ts
@@ -20,7 +20,7 @@ export default function useTransactionUpdates() {
 
     const connect = () => {
       const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}`;
-      const es = new EventSource(url);
+      const es = new EventSource(url, { withCredentials: true });
       eventSourceRef.current = es;
 
       const handler = async (event: MessageEvent) => {


### PR DESCRIPTION
## Summary
- refactor matchmaking SSE hook
- reconnect approved transactions SSE events
- enable credentials for transaction updates SSE

## Testing
- `npm run typecheck`
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_b_68784229d4b4832d8914988f47d2b8cd