### PR TITLE
Improve chat page error handling and SSE reconnection

### DIFF
--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -170,5 +170,18 @@ export default function useMatchmakingSse(
     };
   }, [playerId, toast]);
 
+  useEffect(() => {
+    if (!playerId) return;
+    const handleResume = () => {
+      reconnect();
+    };
+    document.addEventListener('visibilitychange', handleResume);
+    window.addEventListener('online', handleResume);
+    return () => {
+      document.removeEventListener('visibilitychange', handleResume);
+      window.removeEventListener('online', handleResume);
+    };
+  }, [playerId, reconnect]);
+
   return { reconnect };
 }


### PR DESCRIPTION
## Summary
- reconnect SSE on page visibility changes and online events
- show chat listing errors
- simplify opponents loader dependency

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6878560c1eec832d8fd3f70d3a0d3ac4