### PR TITLE
Enable CORS for admin login

### DIFF
--- a/admin-back/src/main/java/com/example/admin/config/AdminWebConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/AdminWebConfig.java
@@ -13,8 +13,8 @@ public class AdminWebConfig {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOriginPatterns("*")
+                registry.addMapping("/api/**")
+                        .allowedOrigins("http://localhost:3001")
                         .allowedMethods("*")
                         .allowedHeaders("*")
                         .exposedHeaders("Authorization")

--- a/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
@@ -15,6 +15,10 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtGra
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.Customizer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import java.util.List;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -34,6 +38,18 @@ public class SecurityConfig {
             .oauth2ResourceServer(oauth2 -> oauth2
                     .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:3001"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 
     private JwtAuthenticationConverter jwtAuthenticationConverter() {

--- a/back/src/main/java/co/com/arena/real/config/WebConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/WebConfig.java
@@ -14,7 +14,7 @@ public class WebConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:3000")
+                        .allowedOrigins("http://localhost:3000", "http://localhost:3001")
                         .allowedMethods("*")
                         .allowedHeaders("*")
                         .allowCredentials(true);


### PR DESCRIPTION
## Summary
- allow requests from `localhost:3001` in backend `WebConfig`
- restrict admin-back CORS to the `/api` endpoints
- define a `CorsConfigurationSource` bean for admin-back security

## Testing
- `mvn -q -DskipTests install` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68786966fcc0832da8b5c74045b38a1f