### PR TITLE
Fix withdrawal phone display

### DIFF
--- a/admin/src/components/ReviewTransactionDialog.tsx
+++ b/admin/src/components/ReviewTransactionDialog.tsx
@@ -85,7 +85,7 @@ export default function ReviewTransactionDialog({
                   <div className="grid grid-cols-2 gap-2 text-sm">
                     <span className="font-semibold">Usuario:</span>
                     <span>{transaction.origin}</span>
-                    {transaction.type === 'DEPOSITO' && (
+                    {['DEPOSITO', 'RETIRO'].includes(transaction.type) && (
                       <>
                         <span className="font-semibold">Teléfono:</span>
                         <span>{transaction.phone}</span>

--- a/admin/src/components/TransactionTable.tsx
+++ b/admin/src/components/TransactionTable.tsx
@@ -115,7 +115,7 @@ export default function TransactionTable() {
           {filtered.map(t => (
             <tr key={t.id} className="text-center">
               <td className="border px-2 py-1">{t.playerId}</td>
-              <td className="border px-2 py-1">{t.type === 'DEPOSITO' ? t.phone : '-'}</td>
+              <td className="border px-2 py-1">{t.type === 'DEPOSITO' || t.type === 'RETIRO' ? t.phone : '-'}</td>
               <td className="border px-2 py-1">{t.type}</td>
               <td className="border px-2 py-1">${'' + t.amount}</td>
               <td className="border px-2 py-1">{new Date(t.createdAt).toLocaleString()}</td>


### PR DESCRIPTION
## Summary
- show the phone number for withdrawals in the transaction table
- display the phone in the review transaction dialog for withdrawals too

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687873e06558832da038b1407dae4817