### PR TITLE
Fix chat badge status

### DIFF
--- a/front/src/hooks/useActiveChat.ts
+++ b/front/src/hooks/useActiveChat.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import useFirestoreChats from './useFirestoreChats';
-import { getLocalStorageItem, setLocalStorageItem } from '@/lib/storage';
+import { setLocalStorageItem, removeLocalStorageItem } from '@/lib/storage';
 
 export const ACTIVE_CHAT_KEY = 'cr_active_chat_id';
 
@@ -14,12 +14,8 @@ export default function useActiveChat(userId: string | undefined) {
       setActiveChatId(active.id);
       setLocalStorageItem(ACTIVE_CHAT_KEY, active.id);
     } else {
-      const stored = getLocalStorageItem<string>(ACTIVE_CHAT_KEY);
-      if (stored) {
-        setActiveChatId(stored);
-      } else {
-        setActiveChatId(null);
-      }
+      setActiveChatId(null);
+      removeLocalStorageItem(ACTIVE_CHAT_KEY);
     }
   }, [chats]);
 


### PR DESCRIPTION
## Summary
- clear stored chat when no active chat to avoid showing badge

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_687875dfff08832dbffc9f8eb07b5cad