### PR TITLE
Fix chat migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,17 @@ mvn -U clean install
 
 If your environment lacks internet access, configure a mirror in `settings.xml`
 that points to an accessible Maven repository.
+
+## Firestore chat migration
+
+Some early deployments stored chats under `chats/{chatId}/chats/{subId}`. The frontend only looks at the `chats/` collection, so these documents need to be copied to the root collection. A helper script is available in `front/scripts/migrateChats.ts`.
+
+Run it once with your Firebase service account credentials:
+
+```bash
+cd front
+npm install
+FIREBASE_SERVICE_ACCOUNT_FILE=/path/to/serviceAccount.json npx ts-node scripts/migrateChats.ts
+```
+
+It creates each `chats/{subId}` document with the original fields (adding `createdAt` when missing) and copies the `messages` subcollection. Each migrated path is printed when finished.

--- a/front/scripts/migrateChats.ts
+++ b/front/scripts/migrateChats.ts
@@ -1,0 +1,42 @@
+import { initializeApp, cert, getApps } from 'firebase-admin/app'
+import { getFirestore, Timestamp } from 'firebase-admin/firestore'
+import fs from 'fs'
+
+async function main() {
+  const credentialPath = process.env.FIREBASE_SERVICE_ACCOUNT_FILE || process.env.GOOGLE_APPLICATION_CREDENTIALS
+  if (!credentialPath) {
+    throw new Error('Set FIREBASE_SERVICE_ACCOUNT_FILE or GOOGLE_APPLICATION_CREDENTIALS')
+  }
+  const serviceAccount = JSON.parse(fs.readFileSync(credentialPath, 'utf8'))
+  const app = getApps().length ? getApps()[0] : initializeApp({ credential: cert(serviceAccount) })
+  const db = getFirestore(app)
+
+  const parentChats = await db.collection('chats').listDocuments()
+  for (const parent of parentChats) {
+    const subRef = parent.collection('chats')
+    const subSnap = await subRef.get()
+    if (subSnap.empty) continue
+
+    for (const doc of subSnap.docs) {
+      const data = doc.data()
+      if (!data.createdAt) {
+        data.createdAt = Timestamp.now()
+      }
+      const newDocRef = db.collection('chats').doc(doc.id)
+      await newDocRef.set(data, { merge: true })
+
+      const msgsSnap = await doc.ref.collection('messages').get()
+      for (const msg of msgsSnap.docs) {
+        await newDocRef.collection('messages').doc(msg.id).set(msg.data())
+      }
+      console.log(`Migrated ${doc.ref.path} -> ${newDocRef.path}`)
+    }
+  }
+
+  console.log('Migration finished')
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- ensure chat documents are created with their original IDs
- set `createdAt` if missing
- clarify README migration instructions

## Testing
- `npm install`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_68793151885c832d90af49bb438cb27c