### PR TITLE
Enable SSE updates on game validation

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/events/PartidaValidadaEvent.java
+++ b/back/src/main/java/co/com/arena/real/application/events/PartidaValidadaEvent.java
@@ -1,0 +1,6 @@
+package co.com.arena.real.application.events;
+
+import co.com.arena.real.infrastructure.dto.rs.PartidaResponse;
+
+public record PartidaValidadaEvent(PartidaResponse partida) {
+}

--- a/back/src/main/java/co/com/arena/real/application/events/PartidaValidadaEventListener.java
+++ b/back/src/main/java/co/com/arena/real/application/events/PartidaValidadaEventListener.java
@@ -1,0 +1,19 @@
+package co.com.arena.real.application.events;
+
+import co.com.arena.real.application.service.MatchSseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PartidaValidadaEventListener {
+
+    private final MatchSseService matchSseService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePartidaValidada(PartidaValidadaEvent event) {
+        matchSseService.notifyMatchValidated(event.partida());
+    }
+}

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -25,6 +25,8 @@ import co.com.arena.real.application.service.ApuestaService;
 import co.com.arena.real.application.service.TransaccionService;
 import co.com.arena.real.application.service.MatchProposalService;
 import co.com.arena.real.application.service.MatchService;
+import co.com.arena.real.application.events.PartidaValidadaEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +52,7 @@ public class PartidaService {
     private final TransaccionService transaccionService;
     private final MatchProposalService matchProposalService;
     private final MatchService matchService;
+    private final ApplicationEventPublisher eventPublisher;
 
     private static final Logger log = LoggerFactory.getLogger(PartidaService.class);
 
@@ -166,7 +169,9 @@ public class PartidaService {
         chatService.cerrarChat(partida.getChatId());
 
         Partida saved = partidaRepository.save(partida);
-        return partidaMapper.toDto(saved);
+        PartidaResponse dto = partidaMapper.toDto(saved);
+        eventPublisher.publishEvent(new PartidaValidadaEvent(dto));
+        return dto;
     }
   
     @Transactional

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -92,12 +92,18 @@ const HomePageContent = () => {
     }
   };
 
+  const handleMatchValidated = (data: MatchEventData) => {
+    toast({ title: 'Partida validada', description: 'Revisa tu historial para ver el resultado.' });
+    refreshUser();
+  };
+
   useMatchmakingSse(
     user?.id,
     handleMatchFound,
     handleChatReady,
     handleOpponentAccepted,
-    handleMatchCancelled
+    handleMatchCancelled,
+    handleMatchValidated
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- publish `PartidaValidadaEvent` when a match is validated
- notify clients through `MatchSseService`
- listen for `match-validated` events in the frontend
- update home page to refresh when a match is validated
- use backend services from admin module to trigger events

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck`
- `mvn -q -DskipTests package` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_687aa765133c8328a5673e29d4b12f29