### PR TITLE
Fix admin CORS configuration

### DIFF
--- a/admin-back/src/main/java/com/example/admin/config/AdminWebConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/AdminWebConfig.java
@@ -14,7 +14,7 @@ public class AdminWebConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/api/**")
-                        .allowedOrigins("http://localhost:3001")
+                        .allowedOrigins("http://localhost:3000", "http://localhost:3001")
                         .allowedMethods("*")
                         .allowedHeaders("*")
                         .exposedHeaders("Authorization")

--- a/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
+++ b/admin-back/src/main/java/com/example/admin/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3001"));
+        config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:3001"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
## Summary
- allow port 3000 origin for the admin backend CORS configuration

## Testing
- `mvn -q install -DskipTests` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent.pom)*

------
https://chatgpt.com/codex/tasks/task_b_687aea437ef4832880822d712402c98f