### PR TITLE
Fix admin chat state

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -157,6 +157,7 @@ public class AdminService {
                     .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado"));
             partida.setGanador(jugador);
             partida.setEstado(EstadoPartida.FINALIZADA);
+            chatService.cerrarChat(partida.getChatId());
             partidaRepository.save(partida);
         });
     }


### PR DESCRIPTION
## Summary
- ensure admin backend closes chats when a winner is assigned

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_b_687c0813a3f08328a37fb0efb4fed5a2