### PR TITLE
Add SSE listener globally

### DIFF
--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { Toaster } from '@/components/ui/toaster';
 import { ReduxProvider } from '@/store/ReduxProvider';
+import TransactionUpdatesListener from '@/components/TransactionUpdatesListener';
 
 export const metadata: Metadata = {
   title: 'Arena Real - Torneos CR Colombia',
@@ -22,6 +23,7 @@ export default function RootLayout({
       </head>
       <body className="font-body antialiased">
         <ReduxProvider>
+          <TransactionUpdatesListener />
           {children}
           <Toaster />
         </ReduxProvider>

--- a/front/src/components/TransactionUpdatesListener.tsx
+++ b/front/src/components/TransactionUpdatesListener.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import useTransactionUpdates from '@/hooks/useTransactionUpdates';
+
+export default function TransactionUpdatesListener() {
+  useTransactionUpdates();
+  return null;
+}


### PR DESCRIPTION
## Summary
- add global `TransactionUpdatesListener` component
- include it in root layout so the client always receives balance updates

## Testing
- `npm run typecheck` *(fails: `next lint` requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_b_687c2b232e4c8328be0c7f4cef248e04