### PR TITLE
Fix duplicate SSE hooks

### DIFF
--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { Toaster } from '@/components/ui/toaster';
 import { ReduxProvider } from '@/store/ReduxProvider';
+import TransactionUpdatesListener from '@/components/TransactionUpdatesListener';
 
 export const metadata: Metadata = {
   title: 'Arena Real - Torneos CR Colombia',
@@ -22,6 +23,7 @@ export default function RootLayout({
       </head>
       <body className="font-body antialiased">
         <ReduxProvider>
+          <TransactionUpdatesListener />
           {children}
           <Toaster />
         </ReduxProvider>

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -14,7 +14,6 @@ import { SaldoIcon, FindMatchIcon } from '@/components/icons/ClashRoyaleIcons';
 import { useToast } from "@/hooks/use-toast";
 import { Coins, UploadCloud, Swords, Layers, Banknote, Loader2 } from 'lucide-react';
 import { requestTransactionAction, matchmakingAction, cancelMatchmakingAction, declineMatchAction, acceptMatchAction } from '@/lib/actions';
-import useTransactionUpdates from '@/hooks/useTransactionUpdates';
 import useMatchmakingSse, { MatchEventData } from '@/hooks/useMatchmakingSse';
 import { setLocalStorageItem } from '@/lib/storage';
 import { ACTIVE_CHAT_KEY } from '@/hooks/useActiveChat';
@@ -24,7 +23,6 @@ const HomePageContent = () => {
   const { user, refreshUser } = useAuth();
   const router = useRouter();
   const { toast } = useToast();
-  useTransactionUpdates();
 
   const storedUserId =
     typeof window !== 'undefined'

--- a/front/src/components/TransactionUpdatesListener.tsx
+++ b/front/src/components/TransactionUpdatesListener.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import useTransactionUpdates from '@/hooks/useTransactionUpdates';
+
+export default function TransactionUpdatesListener() {
+  useTransactionUpdates();
+  return null;
+}


### PR DESCRIPTION
## Summary
- remove `useTransactionUpdates` call from the home page
- keep single global listener via `TransactionUpdatesListener`

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: interactive setup needed)*

------
https://chatgpt.com/codex/tasks/task_b_687c2b232e4c8328be0c7f4cef248e04