### PR TITLE
Fix COOP header pattern

### DIFF
--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -20,7 +20,7 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        source: '/(login|register|)',
+        source: '/:path(login|register)',
         headers: [
           {
             key: 'Cross-Origin-Opener-Policy',


### PR DESCRIPTION
## Summary
- adjust `next.config.ts` header pattern so `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` apply to `/login` and `/register`

## Testing
- `npm run typecheck` *(fails: CI lint step requires interactive config)*

------
https://chatgpt.com/codex/tasks/task_b_687c583a213c8328b94c608e3a03bf67