### PR TITLE
Handle admin API 401

### DIFF
--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -17,6 +17,10 @@ export async function get<T>(path: string): Promise<T> {
   });
 
   if (!res.ok) {
+    if (res.status === 401 && typeof window !== 'undefined') {
+      localStorage.removeItem('adminToken');
+      window.location.href = '/login';
+    }
     console.error(`❌ GET ${path} → ${res.status}`);
     throw new Error(await res.text());
   }
@@ -35,6 +39,10 @@ export async function post<T = void>(path: string, body?: unknown): Promise<T> {
   const text = await res.text();
 
   if (!res.ok) {
+    if (res.status === 401 && typeof window !== 'undefined') {
+      localStorage.removeItem('adminToken');
+      window.location.href = '/login';
+    }
     console.error(`❌ POST ${path} → ${res.status}`);
     throw new Error(text);
   }


### PR DESCRIPTION
## Summary
- redirect to login when admin API requests return 401

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687c5fb720948328a4cf8a24f1a78b2c