### PR TITLE
Implement admin transaction SSE

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -89,6 +89,7 @@ public class AdminService {
     public void approveTransaction(UUID id) {
         co.com.arena.real.infrastructure.dto.rs.TransaccionResponse resp = transaccionService.aprobarTransaccion(id);
         usersBackendClient.notifySaldoUpdate(resp.getJugadorId());
+        usersBackendClient.notifyTransactionApproved(resp);
     }
 
     @Transactional
@@ -107,6 +108,7 @@ public class AdminService {
                     && !EstadoTransaccion.APROBADA.equals(t.getEstado())) {
                 co.com.arena.real.infrastructure.dto.rs.TransaccionResponse resp = transaccionService.aprobarTransaccion(id);
                 usersBackendClient.notifySaldoUpdate(resp.getJugadorId());
+                usersBackendClient.notifyTransactionApproved(resp);
                 return;
             }
 

--- a/admin-back/src/main/java/com/example/admin/infrastructure/client/UsersBackendClient.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/client/UsersBackendClient.java
@@ -1,6 +1,7 @@
 package com.example.admin.infrastructure.client;
 
 import com.example.admin.infrastructure.dto.SaldoUpdateRequest;
+import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,6 +37,20 @@ public class UsersBackendClient {
 
         retryTemplate.execute(ctx -> {
             log.debug("Sending saldo update for {} to {}", userId, url);
+            restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
+            return null;
+        });
+    }
+
+    public void notifyTransactionApproved(TransaccionResponse dto) {
+        String url = backendUrl + "/api/internal/notify-transaction-approved";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Admin-Secret", backendToken);
+        HttpEntity<TransaccionResponse> entity = new HttpEntity<>(dto, headers);
+
+        retryTemplate.execute(ctx -> {
+            log.debug("Sending transaction {} approved to {}", dto.getId(), url);
             restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
             return null;
         });

--- a/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
@@ -1,0 +1,35 @@
+package co.com.arena.real.application.controller;
+
+import co.com.arena.real.application.service.SseService;
+import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/internal")
+@RequiredArgsConstructor
+public class AdminNotificationController {
+
+    private final SseService sseService;
+
+    @Value("${admin.secret.token:}")
+    private String adminToken;
+
+    @PostMapping("/notify-transaction-approved")
+    public ResponseEntity<Void> notifyTransactionApproved(
+            @RequestHeader(value = "X-Admin-Secret", required = false) String secret,
+            @RequestBody TransaccionResponse dto) {
+        if (adminToken == null || !adminToken.equals(secret)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        sseService.notificarTransaccionAprobada(dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/back/src/main/resources/application-dev.yml
+++ b/back/src/main/resources/application-dev.yml
@@ -5,3 +5,6 @@ spring:
 service:
   auth:
     token: ${SERVICE_AUTH_TOKEN:changeme}
+  admin:
+    secret:
+      token: ${ADMIN_SECRET_TOKEN:changeme}

--- a/back/src/main/resources/application-prod.yml
+++ b/back/src/main/resources/application-prod.yml
@@ -7,3 +7,6 @@ spring:
 service:
   auth:
     token: ${SERVICE_AUTH_TOKEN:changeme}
+  admin:
+    secret:
+      token: ${ADMIN_SECRET_TOKEN:changeme}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -26,3 +26,6 @@ logging:
 service:
   auth:
     token: ${SERVICE_AUTH_TOKEN:changeme}
+admin:
+  secret:
+    token: ${ADMIN_SECRET_TOKEN:changeme}


### PR DESCRIPTION
## Summary
- add internal endpoint to forward approved transactions via SSE
- secure admin communication with `ADMIN_SECRET_TOKEN`
- notify user backend when admin approves a transaction

## Testing
- `mvn -q -pl back,admin-back,shared-core test` *(fails: unable to resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687c646aa3f483288c4b6c04d9399d0f