### PR TITLE
Fix 500 errors when notifying users backend

### DIFF
--- a/admin-back/src/main/java/com/example/admin/infrastructure/client/UsersBackendClient.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/client/UsersBackendClient.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClientException;
 
 @Slf4j
 @Service
@@ -35,11 +36,15 @@ public class UsersBackendClient {
         headers.set("X-Service-Auth", backendToken);
         HttpEntity<SaldoUpdateRequest> entity = new HttpEntity<>(request, headers);
 
-        retryTemplate.execute(ctx -> {
-            log.debug("Sending saldo update for {} to {}", userId, url);
-            restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
-            return null;
-        });
+        try {
+            retryTemplate.execute(ctx -> {
+                log.debug("Sending saldo update for {} to {}", userId, url);
+                restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
+                return null;
+            });
+        } catch (RestClientException ex) {
+            log.error("Failed to notify saldo update for {}: {}", userId, ex.getMessage());
+        }
     }
 
     public void notifyTransactionApproved(TransaccionResponse dto) {
@@ -49,10 +54,14 @@ public class UsersBackendClient {
         headers.set("X-Admin-Secret", backendToken);
         HttpEntity<TransaccionResponse> entity = new HttpEntity<>(dto, headers);
 
-        retryTemplate.execute(ctx -> {
-            log.debug("Sending transaction {} approved to {}", dto.getId(), url);
-            restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
-            return null;
-        });
+        try {
+            retryTemplate.execute(ctx -> {
+                log.debug("Sending transaction {} approved to {}", dto.getId(), url);
+                restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
+                return null;
+            });
+        } catch (RestClientException ex) {
+            log.error("Failed to notify transaction {} approved: {}", dto.getId(), ex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- prevent notification failures from crashing admin backend

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.6)*

------
https://chatgpt.com/codex/tasks/task_b_687dcd5c13ac83289b7c3e86bec6b600