### PR TITLE
Adjust mobile navigation layout

### DIFF
--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -6,10 +6,9 @@ import { useAuth } from "@/hooks/useAuth";
 import useActiveChat from "@/hooks/useActiveChat";
 import {
   Home,
-  Bell,
-  Gamepad2,
-  User,
   MessageCircle,
+  ScrollText,
+  Trophy,
   Menu as MenuIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -21,10 +20,9 @@ const BottomNav = () => {
   const hasActiveChat = Boolean(activeChatId);
   const navItems = [
     { id: "inicio", label: "Inicio", href: "/", icon: Home },
-    { id: "notificaciones", label: "Notificaciones", href: "/notifications", icon: Bell },
-    { id: "jugar", label: "Jugar", href: "/play", icon: Gamepad2 },
-    { id: "usuario", label: "Usuario", href: "/profile", icon: User },
     { id: "chat", label: "Chat", href: "/chat", icon: MessageCircle },
+    { id: "historial", label: "Historial", href: "/history", icon: ScrollText },
+    { id: "torneo", label: "Torneo", href: "/torneos", icon: Trophy },
     { id: "menu", label: "Menú", href: "/menu", icon: MenuIcon },
   ];
 

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Bell, Crown, MessageCircle } from "lucide-react";
+import { Bell, Crown } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,12 +9,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAuth } from "@/hooks/useAuth";
-import useFirestoreChats from "@/hooks/useFirestoreChats";
 
 const TopNavbar = () => {
   const { user, logout } = useAuth();
-  const { chats } = useFirestoreChats(user?.id);
-  const activeChat = chats.find(c => c.activo);
   const avatarSrc = (user as any)?.image || user?.avatarUrl;
   const notifications = 0;
 
@@ -29,17 +26,6 @@ const TopNavbar = () => {
         <div className="relative">
           <Bell className="h-5 w-5 text-white" />
           {notifications > 0 && (
-            <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full" />
-          )}
-        </div>
-        <div className="relative">
-          <Link
-            href={activeChat ? `/chat/${activeChat.id}` : "/chat"}
-            aria-label="Chat"
-          >
-            <MessageCircle className="h-5 w-5 text-white" />
-          </Link>
-          {activeChat && (
             <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full" />
           )}
         </div>


### PR DESCRIPTION
## Summary
- remove chat shortcut from `TopNavbar`
- simplify `BottomNav` items to home, chat, history, torneo and menu

## Testing
- `npm install`
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_687e7fbdae608328aa9def95ae74cacc