### PR TITLE
Fix history match ID

### DIFF
--- a/front/src/app/history/page.tsx
+++ b/front/src/app/history/page.tsx
@@ -89,7 +89,7 @@ const HistoryPageContent = () => {
           <div>
             <CardTitle className="text-xl text-primary">Duelo: {bet.modoJuego}</CardTitle>
             <CardDescription className="text-sm text-muted-foreground">
-              Apuesta ID: {bet.id} <br />
+              Partida ID: {bet.matchId} <br />
               Fecha: {new Date(bet.matchDate).toLocaleDateString()}
             </CardDescription>
           </div>


### PR DESCRIPTION
## Summary
- show match ID instead of bet ID in the history page

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_687e820436a883289d9fed7c9359abbc