### PR TITLE
Adjust mobile navigation layout

### DIFF
--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -6,10 +6,9 @@ import { useAuth } from "@/hooks/useAuth";
 import useActiveChat from "@/hooks/useActiveChat";
 import {
   Home,
-  Bell,
-  Gamepad2,
-  User,
   MessageCircle,
+  ScrollText,
+  Trophy,
   Menu as MenuIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -21,10 +20,9 @@ const BottomNav = () => {
   const hasActiveChat = Boolean(activeChatId);
   const navItems = [
     { id: "inicio", label: "Inicio", href: "/", icon: Home },
-    { id: "notificaciones", label: "Notificaciones", href: "/notifications", icon: Bell },
-    { id: "jugar", label: "Jugar", href: "/play", icon: Gamepad2 },
-    { id: "usuario", label: "Usuario", href: "/profile", icon: User },
     { id: "chat", label: "Chat", href: "/chat", icon: MessageCircle },
+    { id: "historial", label: "Historial", href: "/history", icon: ScrollText },
+    { id: "torneo", label: "Torneo", href: "/torneos", icon: Trophy },
     { id: "menu", label: "Menú", href: "/menu", icon: MenuIcon },
   ];
 

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -1,22 +1,22 @@
 "use client";
 
 import Link from "next/link";
-import { Bell, Crown, MessageCircle } from "lucide-react";
+import { Bell, Crown } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useAuth } from "@/hooks/useAuth";
-import useFirestoreChats from "@/hooks/useFirestoreChats";
+import useNotifications from "@/hooks/useNotifications";
 
 const TopNavbar = () => {
   const { user, logout } = useAuth();
-  const { chats } = useFirestoreChats(user?.id);
-  const activeChat = chats.find(c => c.activo);
+  const { notifications, unreadCount, markAsRead, markAllRead } =
+    useNotifications();
   const avatarSrc = (user as any)?.image || user?.avatarUrl;
-  const notifications = 0;
 
   return (
     <header className="md:hidden fixed top-0 w-full z-50 shadow-sm bg-gradient-to-r from-blue-500 via-blue-700 to-blue-900 h-16 px-4 py-3 flex justify-between items-center animate-gradient-x">
@@ -26,23 +26,36 @@ const TopNavbar = () => {
       </div>
 
       <div className="flex items-center gap-4">
-        <div className="relative">
-          <Bell className="h-5 w-5 text-white" />
-          {notifications > 0 && (
-            <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full" />
-          )}
-        </div>
-        <div className="relative">
-          <Link
-            href={activeChat ? `/chat/${activeChat.id}` : "/chat"}
-            aria-label="Chat"
-          >
-            <MessageCircle className="h-5 w-5 text-white" />
-          </Link>
-          {activeChat && (
-            <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full" />
-          )}
-        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button aria-label="Notificaciones" className="relative">
+              <Bell className="h-5 w-5 text-white" />
+              {unreadCount > 0 && (
+                <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full" />
+              )}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-64">
+            <DropdownMenuItem onSelect={markAllRead} className="text-xs justify-center text-blue-600">
+              Marcar todas como leídas
+            </DropdownMenuItem>
+            <ScrollArea className="h-40">
+              {notifications.length === 0 ? (
+                <div className="p-2 text-sm text-center text-muted-foreground">Sin notificaciones</div>
+              ) : (
+                notifications.map(n => (
+                  <DropdownMenuItem
+                    key={n.id}
+                    onSelect={() => markAsRead(n.id)}
+                    className={n.read ? '' : 'font-bold'}
+                  >
+                    {n.message}
+                  </DropdownMenuItem>
+                ))
+              )}
+            </ScrollArea>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button className="flex items-center gap-2 focus-visible:outline-none transition-transform hover:scale-105">

--- a/front/src/hooks/useNotifications.ts
+++ b/front/src/hooks/useNotifications.ts
@@ -1,0 +1,31 @@
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import {
+  addNotification as addNotificationAction,
+  markAsRead as markAsReadAction,
+  markAllRead as markAllReadAction,
+  clearNotifications as clearNotificationsAction,
+} from '@/store/notificationsSlice';
+
+export const useNotifications = () => {
+  const dispatch = useAppDispatch();
+  const notifications = useAppSelector(state => state.notifications.list);
+  const unreadCount = notifications.filter(n => !n.read).length;
+
+  const addNotification = (message: string) =>
+    dispatch(addNotificationAction({ message }));
+
+  const markAsRead = (id: string) => dispatch(markAsReadAction(id));
+  const markAllRead = () => dispatch(markAllReadAction());
+  const clearNotifications = () => dispatch(clearNotificationsAction());
+
+  return {
+    notifications,
+    unreadCount,
+    addNotification,
+    markAsRead,
+    markAllRead,
+    clearNotifications,
+  };
+};
+
+export default useNotifications;

--- a/front/src/store/index.ts
+++ b/front/src/store/index.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './authSlice';
+import notificationsReducer from './notificationsSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    notifications: notificationsReducer,
   },
 });
 

--- a/front/src/store/notificationsSlice.ts
+++ b/front/src/store/notificationsSlice.ts
@@ -1,0 +1,64 @@
+import { createSlice, PayloadAction, nanoid } from '@reduxjs/toolkit';
+import type { Notification } from '@/types';
+
+export interface NotificationsState {
+  list: Notification[];
+}
+
+const STORAGE_KEY = 'arena_notifications';
+
+const loadState = (): Notification[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as Notification[];
+  } catch {
+    return [];
+  }
+};
+
+const saveState = (state: Notification[]) => {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+};
+
+const initialState: NotificationsState = {
+  list: loadState(),
+};
+
+const notificationsSlice = createSlice({
+  name: 'notifications',
+  initialState,
+  reducers: {
+    addNotification: (state, action: PayloadAction<{ message: string }>) => {
+      const newNotif: Notification = {
+        id: nanoid(),
+        message: action.payload.message,
+        read: false,
+        createdAt: new Date().toISOString(),
+      };
+      state.list.unshift(newNotif);
+      saveState(state.list);
+    },
+    markAsRead: (state, action: PayloadAction<string>) => {
+      const notif = state.list.find(n => n.id === action.payload);
+      if (notif) {
+        notif.read = true;
+        saveState(state.list);
+      }
+    },
+    markAllRead: state => {
+      state.list.forEach(n => (n.read = true));
+      saveState(state.list);
+    },
+    clearNotifications: state => {
+      state.list = [];
+      saveState(state.list);
+    },
+  },
+});
+
+export const { addNotification, markAsRead, markAllRead, clearNotifications } = notificationsSlice.actions;
+
+export default notificationsSlice.reducer;

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -174,3 +174,10 @@ export interface BackendMatchDeclineRequestDto {
   jugadorId: string;
   oponenteId: string;
 }
+
+export interface Notification {
+  id: string;
+  message: string;
+  read: boolean;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- remove chat shortcut from `TopNavbar`
- simplify `BottomNav` items to home, chat, history, torneo and menu
- add redux-based notifications system and dropdown in `TopNavbar`

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_687e7fbdae608328aa9def95ae74cacc