### PR TITLE
Add logging for transaction notification

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -3,6 +3,7 @@ package com.example.admin.application.service;
 import com.example.admin.infrastructure.dto.GameResultDto;
 import com.example.admin.infrastructure.dto.ImageDto;
 import com.example.admin.infrastructure.dto.TransactionDto;
+import lombok.extern.slf4j.Slf4j;
 import co.com.arena.real.domain.entity.EstadoApuesta;
 import co.com.arena.real.domain.entity.EstadoTransaccion;
 import co.com.arena.real.domain.entity.partida.EstadoPartida;
@@ -24,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminService {
@@ -108,6 +110,7 @@ public class AdminService {
                     && !EstadoTransaccion.APROBADA.equals(t.getEstado())) {
                 co.com.arena.real.infrastructure.dto.rs.TransaccionResponse resp = transaccionService.aprobarTransaccion(id);
                 usersBackendClient.notifySaldoUpdate(resp.getJugadorId());
+                log.info("➡️ Transacción aprobada. Notificando al backend principal... Jugador ID: {}, Transacción ID: {}", resp.getJugadorId(), resp.getId());
                 usersBackendClient.notifyTransactionApproved(resp);
                 return;
             }

--- a/admin-back/src/main/java/com/example/admin/infrastructure/client/UsersBackendClient.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/client/UsersBackendClient.java
@@ -55,12 +55,13 @@ public class UsersBackendClient {
 
         try {
             retryTemplate.execute(ctx -> {
-                log.debug("Sending transaction {} approved to {}", dto.getId(), url);
+                log.info("\uD83D\uDCE4 Enviando notificación de transacción aprobada al backend: {} -> {}", dto.getId(), url);
                 restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
+                log.info("\u2705 Notificación enviada correctamente para transacción {}", dto.getId());
                 return null;
             });
-        } catch (org.springframework.web.client.RestClientException e) {
-            log.error("Failed to notify transaction {} approved: {}", dto.getId(), e.getMessage());
+        } catch (Exception e) {
+            log.error("\u274C Error al enviar notificación al backend principal", e);
         }
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
@@ -3,6 +3,7 @@ package co.com.arena.real.application.controller;
 import co.com.arena.real.application.service.SseService;
 import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/internal")
 @RequiredArgsConstructor
@@ -27,8 +29,10 @@ public class AdminNotificationController {
             @RequestHeader(value = "X-Admin-Secret", required = false) String secret,
             @RequestBody TransaccionResponse dto) {
         if (adminToken == null || !adminToken.equals(secret)) {
+            log.warn("\uD83D\uDD12 Token admin inválido recibido en notificación de transacción.");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+        log.info("\uD83D\uDCE5 Backend recibió notificación de transacción aprobada. Transacción ID: {}, Jugador ID: {}", dto.getId(), dto.getJugadorId());
         sseService.notificarTransaccionAprobada(dto);
         return ResponseEntity.ok().build();
     }

--- a/back/src/main/java/co/com/arena/real/application/service/SseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/SseService.java
@@ -84,11 +84,13 @@ public class SseService {
         }
 
         try {
+            log.info("\uD83D\uDCE1 Enviando evento SSE 'transaccion-aprobada' al jugador {}", dto.getJugadorId());
             wrapper.emitter.send(SseEmitter.event()
                     .name("transaccion-aprobada")
                     .data(dto));
             wrapper.lastAccess = System.currentTimeMillis();
         } catch (IOException e) {
+            log.error("\u274C Error al enviar evento SSE al jugador {}", dto.getJugadorId(), e);
             removeEmitter(jugadorId);
             wrapper.emitter.completeWithError(e);
         }


### PR DESCRIPTION
## Summary
- log when admin approves transactions
- add details when notifying users backend
- log transaction notifications in main backend
- log SSE events for approved transactions

## Testing
- `mvn -am -pl back,admin-back test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687dd148bcb4832898a0c43e66cdd0ed