### PR TITLE
Secure Firestore rules

### DIFF
--- a/firebase.rules
+++ b/firebase.rules
@@ -1,11 +1,21 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+
+    function signedIn() {
+      return request.auth != null;
+    }
+
+    function isParticipant(chatId) {
+      return request.auth.uid in
+        get(/databases/$(database)/documents/chats/$(chatId)).data.jugadores;
+    }
+
     match /chats/{chatId} {
-      allow read, write: if request.auth != null;
+      allow read, write: if signedIn() && isParticipant(chatId);
 
       match /messages/{messageId} {
-        allow read, write: if request.auth != null;
+        allow read, write: if signedIn() && isParticipant(chatId);
       }
     }
   }


### PR DESCRIPTION
## Summary
- tighten Firestore security
- restrict reads and writes to authenticated chat participants

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687e77bcd32c83289b32045e439aa8f2