### PR TITLE
Document transaction approval flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ mvn -U clean install
 If your environment lacks internet access, configure a mirror in `settings.xml`
 that points to an accessible Maven repository.
 
+
+## Transaction approval flow
+
+When an admin marks a transaction as **ENTREGADA** in the admin console:
+
+1. `AdminService` calls `TransaccionService.aprobarTransaccion` in the admin backend.
+2. The admin backend sends two requests to the main backend:
+   - `/api/actualizar-saldo` triggers a balance refresh via SSE.
+   - `/api/internal/notify-transaction-approved` emits a `transaccion-aprobada` SSE event.
+3. The user client listens to these events with `useTransactionUpdates` to update its balance and show a toast.
+   If the connection was lost, the hook refreshes data when the page becomes visible or after reconnecting.
 ## Firestore chat migration
 
 Some early deployments stored chats under `chats/{chatId}/chats/{subId}`. The frontend only looks at the `chats/` collection, so these documents need to be copied to the root collection. A helper script is available in `front/scripts/migrateChats.ts`.

--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -3,6 +3,7 @@ package com.example.admin.application.service;
 import com.example.admin.infrastructure.dto.GameResultDto;
 import com.example.admin.infrastructure.dto.ImageDto;
 import com.example.admin.infrastructure.dto.TransactionDto;
+import lombok.extern.slf4j.Slf4j;
 import co.com.arena.real.domain.entity.EstadoApuesta;
 import co.com.arena.real.domain.entity.EstadoTransaccion;
 import co.com.arena.real.domain.entity.partida.EstadoPartida;
@@ -24,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminService {
@@ -88,6 +90,7 @@ public class AdminService {
     @Transactional
     public void approveTransaction(UUID id) {
         co.com.arena.real.infrastructure.dto.rs.TransaccionResponse resp = transaccionService.aprobarTransaccion(id);
+        log.info("\uD83D\uDD04 Solicitando actualizaci\u00f3n de saldo para jugador {}", resp.getJugadorId());
         usersBackendClient.notifySaldoUpdate(resp.getJugadorId());
         usersBackendClient.notifyTransactionApproved(resp);
     }
@@ -107,7 +110,9 @@ public class AdminService {
             if (newStatus == EstadoTransaccion.APROBADA
                     && !EstadoTransaccion.APROBADA.equals(t.getEstado())) {
                 co.com.arena.real.infrastructure.dto.rs.TransaccionResponse resp = transaccionService.aprobarTransaccion(id);
+                log.info("\uD83D\uDD04 Solicitando actualizaci\u00f3n de saldo para jugador {}", resp.getJugadorId());
                 usersBackendClient.notifySaldoUpdate(resp.getJugadorId());
+                log.info("➡️ Transacción aprobada. Notificando al backend principal... Jugador ID: {}, Transacción ID: {}", resp.getJugadorId(), resp.getId());
                 usersBackendClient.notifyTransactionApproved(resp);
                 return;
             }

--- a/admin-back/src/main/java/com/example/admin/infrastructure/client/UsersBackendClient.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/client/UsersBackendClient.java
@@ -37,12 +37,13 @@ public class UsersBackendClient {
 
         try {
             retryTemplate.execute(ctx -> {
-                log.debug("Sending saldo update for {} to {}", userId, url);
+                log.info("\uD83D\uDD04 Enviando actualizaci\u00f3n de saldo al backend: {} -> {}", userId, url);
                 restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
+                log.info("\u2705 Actualizaci\u00f3n de saldo enviada correctamente para jugador {}", userId);
                 return null;
             });
-        } catch (org.springframework.web.client.RestClientException e) {
-            log.error("Failed to notify saldo update for {}: {}", userId, e.getMessage());
+        } catch (Exception e) {
+            log.error("\u274C Error al notificar actualizaci\u00f3n de saldo", e);
         }
     }
 
@@ -55,12 +56,13 @@ public class UsersBackendClient {
 
         try {
             retryTemplate.execute(ctx -> {
-                log.debug("Sending transaction {} approved to {}", dto.getId(), url);
+                log.info("\uD83D\uDCE4 Enviando notificación de transacción aprobada al backend: {} -> {}", dto.getId(), url);
                 restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
+                log.info("\u2705 Notificación enviada correctamente para transacción {}", dto.getId());
                 return null;
             });
-        } catch (org.springframework.web.client.RestClientException e) {
-            log.error("Failed to notify transaction {} approved: {}", dto.getId(), e.getMessage());
+        } catch (Exception e) {
+            log.error("\u274C Error al enviar notificación al backend principal", e);
         }
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
@@ -3,6 +3,7 @@ package co.com.arena.real.application.controller;
 import co.com.arena.real.application.service.SseService;
 import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/internal")
 @RequiredArgsConstructor
@@ -27,8 +29,10 @@ public class AdminNotificationController {
             @RequestHeader(value = "X-Admin-Secret", required = false) String secret,
             @RequestBody TransaccionResponse dto) {
         if (adminToken == null || !adminToken.equals(secret)) {
+            log.warn("\uD83D\uDD12 Token admin inválido recibido en notificación de transacción.");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+        log.info("\uD83D\uDCE5 Backend recibió notificación de transacción aprobada. Transacción ID: {}, Jugador ID: {}", dto.getId(), dto.getJugadorId());
         sseService.notificarTransaccionAprobada(dto);
         return ResponseEntity.ok().build();
     }

--- a/back/src/main/java/co/com/arena/real/application/controller/JugadorController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/JugadorController.java
@@ -6,6 +6,7 @@ import co.com.arena.real.infrastructure.dto.rs.JugadorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +37,14 @@ public class JugadorController {
     @Operation(summary = "Obtener jugador", description = "Obtiene un jugador por su identificador")
     public ResponseEntity<JugadorResponse> obtener(@PathVariable String id) {
         return jugadorService.obtenerPorId(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}/saldo")
+    @Operation(summary = "Obtener saldo", description = "Devuelve el saldo actual del jugador")
+    public ResponseEntity<BigDecimal> saldo(@PathVariable String id) {
+        return jugadorService.obtenerSaldo(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/back/src/main/java/co/com/arena/real/application/controller/SaldoController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/SaldoController.java
@@ -2,6 +2,8 @@ package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.SseService;
 import co.com.arena.real.infrastructure.dto.rq.SaldoUpdateRequest;
+import co.com.arena.real.infrastructure.repository.JugadorRepository;
+import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -12,12 +14,14 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
 public class SaldoController {
 
     private final SseService sseService;
+    private final JugadorRepository jugadorRepository;
     @Value("${service.auth.token:}")
     private String serviceToken;
 
@@ -28,7 +32,10 @@ public class SaldoController {
         if (serviceToken == null || !serviceToken.equals(auth)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-        sseService.sendEvent(request.getUserId(), "saldo-actualizar", "");
+        var jugadorOpt = jugadorRepository.findById(request.getUserId());
+        Object data = jugadorOpt.map(j -> j.getSaldo()).orElse("");
+        log.info("\uD83D\uDCE4 Enviando evento de saldo actualizado al jugador {}", request.getUserId());
+        sseService.sendEvent(request.getUserId(), "saldo-actualizar", data);
         return ResponseEntity.ok().build();
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/JugadorService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/JugadorService.java
@@ -9,6 +9,7 @@ import co.com.arena.real.infrastructure.repository.JugadorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 @Service
@@ -35,6 +36,11 @@ public class JugadorService {
     public Optional<JugadorResponse> obtenerPorId(String id) {
         return jugadorRepository.findById(id)
                 .map(jugadorMapper::toDto);
+    }
+
+    public Optional<BigDecimal> obtenerSaldo(String id) {
+        return jugadorRepository.findById(id)
+                .map(Jugador::getSaldo);
     }
 
 }

--- a/back/src/main/java/co/com/arena/real/application/service/SseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/SseService.java
@@ -84,11 +84,13 @@ public class SseService {
         }
 
         try {
+            log.info("\uD83D\uDCE1 Enviando evento SSE 'transaccion-aprobada' al jugador {}", dto.getJugadorId());
             wrapper.emitter.send(SseEmitter.event()
                     .name("transaccion-aprobada")
                     .data(dto));
             wrapper.lastAccess = System.currentTimeMillis();
         } catch (IOException e) {
+            log.error("\u274C Error al enviar evento SSE al jugador {}", dto.getJugadorId(), e);
             removeEmitter(jugadorId);
             wrapper.emitter.completeWithError(e);
         }

--- a/front/src/hooks/useTransactionUpdates.ts
+++ b/front/src/hooks/useTransactionUpdates.ts
@@ -10,14 +10,24 @@ import { BACKEND_URL } from '@/lib/config';
  * transaction changes status (e.g., deposit approved).
  */
 export default function useTransactionUpdates() {
-  const { user, refreshUser } = useAuth();
+  const { user, refreshUser, updateUser } = useAuth();
   const { toast } = useToast();
   const eventSourceRef = useRef<EventSource | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const connectedRef = useRef(false);
+  const disconnectedRef = useRef(false);
+  const lastBalanceRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (!user?.id) return;
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible' && disconnectedRef.current) {
+        refreshUser();
+        disconnectedRef.current = false;
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
 
     const connect = () => {
       const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}`;
@@ -26,6 +36,10 @@ export default function useTransactionUpdates() {
 
       es.onopen = () => {
         connectedRef.current = true;
+        if (disconnectedRef.current) {
+          refreshUser();
+          disconnectedRef.current = false;
+        }
       };
 
       const handler = async (event: MessageEvent) => {
@@ -42,7 +56,19 @@ export default function useTransactionUpdates() {
       };
 
       es.addEventListener('transaccion-aprobada', handler as unknown as EventListener);
-      es.addEventListener('saldo-actualizar', async () => {
+      es.addEventListener('saldo-actualizar', async (e: MessageEvent) => {
+        if (e.data) {
+          try {
+            const saldo = JSON.parse(e.data);
+            if (saldo !== lastBalanceRef.current) {
+              lastBalanceRef.current = saldo;
+              await updateUser({ balance: saldo });
+            }
+            return;
+          } catch (err) {
+            console.error('Error actualizando saldo desde SSE', err);
+          }
+        }
         await refreshUser();
       });
 
@@ -54,6 +80,7 @@ export default function useTransactionUpdates() {
             description: 'Conexión interrumpida. Reintentando...',
           });
         }
+        disconnectedRef.current = true;
         es.close();
         reconnectTimeoutRef.current = setTimeout(connect, 3000);
       };
@@ -61,7 +88,7 @@ export default function useTransactionUpdates() {
 
     connect();
 
-      return () => {
+    return () => {
         if (eventSourceRef.current) {
           eventSourceRef.current.close();
         }
@@ -69,6 +96,7 @@ export default function useTransactionUpdates() {
         if (reconnectTimeoutRef.current) {
           clearTimeout(reconnectTimeoutRef.current);
         }
+        document.removeEventListener('visibilitychange', onVisibility);
       };
-  }, [user, refreshUser, toast]);
+  }, [user, refreshUser, updateUser, toast]);
 }


### PR DESCRIPTION
## Summary
- document how admin approval triggers SSE updates
- add endpoint to fetch a player's balance via `/api/jugadores/{id}/saldo`
- return balance from `JugadorService`
- send saldo value with SSE to avoid duplicate refreshes
- refresh user on SSE reconnect or visibility change

## Testing
- `npm run lint` *(failed: interactive prompt)*
- `npm run typecheck`
- `mvn -am -pl back,admin-back test` *(failed to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_687dd148bcb4832898a0c43e66cdd0ed