### PR TITLE
Fix Firestore rule for chat listing

### DIFF
--- a/firebase.rules
+++ b/firebase.rules
@@ -11,8 +11,12 @@ service cloud.firestore {
         get(/databases/$(database)/documents/chats/$(chatId)).data.jugadores;
     }
 
+    function isParticipantFromDoc() {
+      return request.auth.uid in resource.data.jugadores;
+    }
+
     match /chats/{chatId} {
-      allow read, write: if signedIn() && isParticipant(chatId);
+      allow read, write: if signedIn() && isParticipantFromDoc();
 
       match /messages/{messageId} {
         allow read, write: if signedIn() && isParticipant(chatId);


### PR DESCRIPTION
## Summary
- allow users to read chat documents by checking the document data instead of loading it through `get`

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_687ead3d8a108328b73c05441ccbea4e