### PR TITLE
Improve security rules

### DIFF
--- a/firebase.rules
+++ b/firebase.rules
@@ -2,21 +2,86 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
+    // --- Helper functions ---
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    // Checks Firestore directly if the user is part of the chat
+    function isParticipant(chatId) {
+      return isSignedIn() &&
+        request.auth.uid in get(/databases/$(database)/documents/chats/$(chatId)).data.jugadores;
+    }
+
+    // Checks current document data
+    function isParticipantInResource() {
+      return isSignedIn() && request.auth.uid in resource.data.jugadores;
+    }
+
+    // Checks the document data being created
+    function isParticipantInRequest() {
+      return isSignedIn() && request.auth.uid in request.resource.data.jugadores;
+    }
+
+    match /chats/{chatId} {
+      // A participant can read the chat
+      allow read: if isParticipantInResource();
+
+      // Creating a chat requires the creator to be part of the players list and
+      // enforces allowed fields and values
+      allow create: if isParticipantInRequest()
+                    && request.resource.data.jugadores.size() == 2
+                    && request.resource.data.activo == true
+                    && request.resource.data.keys().hasOnly(['jugadores', 'activo']);
+
+      // Chats can be updated by participants but players list is immutable
+      allow update: if isParticipantInResource()
+                    && request.resource.data.jugadores == resource.data.jugadores;
+
+      // Deleting chats is not allowed
+      allow delete: if false;
+
+      match /messages/{messageId} {
+        // Participants can read messages
+        allow read: if isParticipant(chatId);
+
+        // Creating a message requires the sender to be the authenticated user
+        // and validates text length, timestamp and absence of system flag
+        allow create: if isParticipant(chatId)
+                      && request.resource.data.senderId == request.auth.uid
+                      && request.resource.data.text is string
+                      && request.resource.data.text.size() > 0
+                      && request.resource.data.text.size() < 500
+                      && request.resource.data.timestamp == request.time
+                      && (!('isSystemMessage' in request.resource.data) || request.resource.data.isSystemMessage == false);
+
+        // Messages cannot be modified or removed
+        allow update, delete: if false;
+      }
+    }
+  }
+}
+service firebase.storage {
+  match /b/{bucket}/o {
+
     function signedIn() {
       return request.auth != null;
     }
 
-    function isParticipant(chatId) {
-      return request.auth.uid in
-        get(/databases/$(database)/documents/chats/$(chatId)).data.jugadores;
+    function isOwner(userId) {
+      return request.auth != null && request.auth.uid == userId;
     }
 
-    match /chats/{chatId} {
-      allow read, write: if signedIn() && isParticipant(chatId);
+    match /users/{userId}/{fileName} {
+      allow read: if isOwner(userId);
+      allow write: if isOwner(userId)
+                   && request.resource.size < 5 * 1024 * 1024
+                   && request.resource.contentType.matches('image/.*');
+    }
 
-      match /messages/{messageId} {
-        allow read, write: if signedIn() && isParticipant(chatId);
-      }
+    match /public/{fileName} {
+      allow read: if signedIn();
+      allow write: if signedIn() && request.resource.size < 5 * 1024 * 1024;
     }
   }
 }

--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -20,7 +20,7 @@ import type { ChatMessage, User } from '@/types';
 import { submitMatchResultAction, fetchMatchIdByChat } from '@/lib/actions';
 
 import { Label } from '@/components/ui/label';
-import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
+import { doc, getDoc, setDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 
 
@@ -224,17 +224,11 @@ const ChatPageContent = () => {
   useEffect(() => {
     if (incompleteData || isLoading || !user || !opponentProfile || startMessageSentRef.current) return;
     if (messages.length === 0) {
-      const startMsg = {
-        matchId: validChatId,
-        senderId: 'system',
-        text: `Chat iniciado para el duelo (Chat ID: ${validChatId}) con ${opponentDisplayName}.`,
-        timestamp: new Date().toISOString(),
-        isSystemMessage: true,
-      };
-      sendMessageSafely(startMsg);
       startMessageSentRef.current = true;
+      fetch(`${BACKEND_URL}/api/chats/${encodeURIComponent(validChatId)}/start-message`, { method: 'POST' })
+        .catch(err => console.error('Error solicitando mensaje inicial', err));
     }
-  }, [user, opponentProfile, validChatId, validOpponentTag, opponentDisplayName, messages.length, incompleteData, isLoading]);
+  }, [user, opponentProfile, validChatId, validOpponentTag, opponentDisplayName, messages.length, incompleteData, isLoading, BACKEND_URL]);
 
   const handleSendMessage = (e: FormEvent) => {
     e.preventDefault();
@@ -244,7 +238,7 @@ const ChatPageContent = () => {
       matchId: validChatId, // ID del chat (UUID)
       senderId: user.id, // googleId del remitente
       text: newMessage,
-      timestamp: new Date().toISOString(),
+      timestamp: serverTimestamp(),
     };
     sendMessageSafely(message);
     setNewMessage('');
@@ -263,14 +257,12 @@ const ChatPageContent = () => {
       friendLinkMessage = `${userDisplayName} intentó compartir su link de amigo, pero no lo tiene configurado en su perfil.`;
     }
     
-    const message = {
-      matchId: validChatId, // ID del chat (UUID)
-      senderId: 'system',
-      text: friendLinkMessage,
-      timestamp: new Date().toISOString(),
-      isSystemMessage: true,
-    };
-    sendMessageSafely(message);
+    fetch(`${BACKEND_URL}/api/chats/${encodeURIComponent(validChatId)}/share-link`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ link: linkToShare, text: friendLinkMessage }),
+    }).catch(err => console.error('Error compartiendo link de amigo', err));
+
     toast({ title: "Link de Amigo Compartido", description: `Tu link de amigo ${user.friendLink ? '' : '(o un aviso de que no lo tienes) '}ha sido publicado en el chat.` });
   };
 
@@ -318,19 +310,14 @@ const ChatPageContent = () => {
     });
     
     setResultSubmitted(true);
-    setIsSubmittingResult(false); 
+    setIsSubmittingResult(false);
     setScreenshotFile(null);
-    
-     const userDisplayName = user.clashTag || user.username;
-     const resultMessageText = `${userDisplayName} envió el resultado del duelo como ${result === 'win' ? 'VICTORIA' : 'DERROTA'}. ${screenshotFile ? 'Captura de pantalla proporcionada.' : 'No se proporcionó captura.'}`;
-    const resultSystemMessage = {
-      matchId: validChatId, // ID del chat (UUID)
-      senderId: 'system',
-      text: resultMessageText,
-      timestamp: new Date().toISOString(),
-      isSystemMessage: true,
-    };
-    sendMessageSafely(resultSystemMessage);
+
+    fetch(`${BACKEND_URL}/api/chats/${encodeURIComponent(validChatId)}/result-message`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ result }),
+    }).catch(err => console.error('Error enviando mensaje de resultado', err));
   };
 
 
@@ -383,7 +370,7 @@ const ChatPageContent = () => {
                 <div className={`max-w-xs md:max-w-md lg:max-w-lg p-3 rounded-2xl shadow-md ${msg.senderId === user.id ? 'bg-primary text-primary-foreground rounded-br-none ml-auto' : 'bg-card text-card-foreground rounded-bl-none mr-auto'}`}>
                   <p className="text-base break-words">{msg.text}</p>
                   <p className={`text-xs mt-1 ${msg.senderId === user.id ? 'text-primary-foreground/70 text-right' : 'text-muted-foreground/70 text-left'}`}>
-                    {new Date(msg.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    {new Date(msg.timestamp as string).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                   </p>
                 </div>
               )}

--- a/front/src/hooks/useFirestoreChat.ts
+++ b/front/src/hooks/useFirestoreChat.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { collection, addDoc, onSnapshot, query, orderBy, Timestamp, doc } from 'firebase/firestore';
+import { collection, addDoc, onSnapshot, query, orderBy, Timestamp, doc, serverTimestamp } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import type { ChatMessage } from '@/types';
 
@@ -62,7 +62,7 @@ export default function useFirestoreChat(chatId: string | undefined) {
       await addDoc(collection(db, 'chats', chatId, 'messages'), {
         senderId: message.senderId,
         text: message.text,
-        timestamp: Timestamp.now(),
+        timestamp: serverTimestamp(),
         isSystemMessage: message.isSystemMessage || false,
       });
     } catch (err) {

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -166,7 +166,7 @@ export interface ChatMessage {
   matchId: string; // Este es el ID de la apuesta del backend (UUID)
   senderId: string;
   text: string;
-  timestamp: string;
+  timestamp: string | import('firebase/firestore').FieldValue;
   isSystemMessage?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- rewrite Firestore rules with stricter checks for chats and messages
- use server timestamps and delegate system messages to backend
- update chat hook to send timestamps from server

## Testing
- `npm --prefix front run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_687ead3d8a108328b73c05441ccbea4e