### PR TITLE
Enable FCM push notifications

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/PushTokenController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PushTokenController.java
@@ -1,0 +1,30 @@
+package co.com.arena.real.application.controller;
+
+import co.com.arena.real.application.service.PushNotificationService;
+import co.com.arena.real.infrastructure.dto.rq.PushTokenRequest;
+import co.com.arena.real.infrastructure.repository.JugadorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/push")
+@RequiredArgsConstructor
+public class PushTokenController {
+
+    private final PushNotificationService pushNotificationService;
+    private final JugadorRepository jugadorRepository;
+
+    @PostMapping("/register")
+    public ResponseEntity<Void> register(@RequestBody PushTokenRequest request) {
+        return jugadorRepository.findById(request.getJugadorId())
+                .map(jugador -> {
+                    pushNotificationService.registerToken(jugador, request.getToken());
+                    return ResponseEntity.ok().build();
+                })
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -17,9 +18,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CompletableFuture;
 
 @Service
+@RequiredArgsConstructor
 public class MatchSseService {
 
     private static final Logger log = LoggerFactory.getLogger(MatchSseService.class);
+
+    private final PushNotificationService pushNotificationService;
 
     private static class EmitterWrapper {
         final SseEmitter emitter;
@@ -77,6 +81,8 @@ public class MatchSseService {
     public void notifyMatchFound(UUID apuestaId, UUID partidaId, Jugador jugador1, Jugador jugador2) {
         sendMatchFound(jugador1.getId(), apuestaId, partidaId, jugador2);
         sendMatchFound(jugador2.getId(), apuestaId, partidaId, jugador1);
+        pushNotificationService.sendMatchFound(jugador1, jugador2.getNombre() != null ? jugador2.getNombre() : jugador2.getTagClash());
+        pushNotificationService.sendMatchFound(jugador2, jugador1.getNombre() != null ? jugador1.getNombre() : jugador1.getTagClash());
     }
 
     public void notifyMatchFound(Partida partida) {

--- a/back/src/main/java/co/com/arena/real/application/service/PushNotificationService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PushNotificationService.java
@@ -1,0 +1,53 @@
+package co.com.arena.real.application.service;
+
+import co.com.arena.real.domain.entity.Jugador;
+import co.com.arena.real.domain.entity.PushToken;
+import co.com.arena.real.infrastructure.repository.PushTokenRepository;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@ConditionalOnBean(FirebaseApp.class)
+@Slf4j
+public class PushNotificationService {
+
+    private final PushTokenRepository pushTokenRepository;
+    private final FirebaseMessaging firebaseMessaging;
+
+    public void registerToken(Jugador jugador, String token) {
+        pushTokenRepository.findByToken(token).ifPresentOrElse(existing -> {
+            existing.setJugador(jugador);
+            pushTokenRepository.save(existing);
+        }, () -> {
+            PushToken pt = PushToken.builder()
+                    .jugador(jugador)
+                    .token(token)
+                    .build();
+            pushTokenRepository.save(pt);
+        });
+    }
+
+    public void sendMatchFound(Jugador receptor, String oponenteNombre) {
+        List<PushToken> tokens = pushTokenRepository.findAllByJugador(receptor);
+        for (PushToken token : tokens) {
+            Message msg = Message.builder()
+                    .putData("type", "match-found")
+                    .putData("oponente", oponenteNombre)
+                    .setToken(token.getToken())
+                    .build();
+            try {
+                firebaseMessaging.send(msg);
+            } catch (Exception e) {
+                log.error("Error enviando notificación push", e);
+            }
+        }
+    }
+}

--- a/back/src/main/java/co/com/arena/real/config/FirebaseConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/FirebaseConfig.java
@@ -3,8 +3,10 @@ package co.com.arena.real.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -48,5 +50,11 @@ public class FirebaseConfig {
         FirebaseApp app = FirebaseApp.initializeApp(options);
         System.out.println("Firebase inicializado con: " + app.getName());
         return app;
+    }
+
+    @Bean
+    @ConditionalOnBean(FirebaseApp.class)
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        return FirebaseMessaging.getInstance(firebaseApp);
     }
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/PushTokenRequest.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/PushTokenRequest.java
@@ -1,0 +1,9 @@
+package co.com.arena.real.infrastructure.dto.rq;
+
+import lombok.Data;
+
+@Data
+public class PushTokenRequest {
+    private String jugadorId;
+    private String token;
+}

--- a/back/src/main/java/co/com/arena/real/infrastructure/repository/PushTokenRepository.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/repository/PushTokenRepository.java
@@ -1,0 +1,14 @@
+package co.com.arena.real.infrastructure.repository;
+
+import co.com.arena.real.domain.entity.Jugador;
+import co.com.arena.real.domain.entity.PushToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PushTokenRepository extends JpaRepository<PushToken, UUID> {
+    List<PushToken> findAllByJugador(Jugador jugador);
+    Optional<PushToken> findByToken(String token);
+}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -29,3 +29,5 @@ service:
 admin:
   secret:
     token: ${ADMIN_SECRET_TOKEN:changeme}
+firebase:
+  enabled: true

--- a/front/public/firebase-config.js
+++ b/front/public/firebase-config.js
@@ -1,0 +1,12 @@
+import { initializeApp } from 'firebase/app';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+export const firebaseApp = initializeApp(firebaseConfig);

--- a/front/public/firebase-messaging-sw.js
+++ b/front/public/firebase-messaging-sw.js
@@ -1,0 +1,11 @@
+importScripts('/firebase-config.js');
+importScripts('https://www.gstatic.com/firebasejs/9.23.0/firebase-messaging-compat.js');
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage(payload => {
+  const { title, body } = payload.notification || {};
+  if (title) {
+    self.registration.showNotification(title, { body, icon: '/favicon.ico' });
+  }
+});

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { Toaster } from '@/components/ui/toaster';
 import { ReduxProvider } from '@/store/ReduxProvider';
 import TransactionUpdatesListener from '@/components/TransactionUpdatesListener';
+import PushNotificationsInitializer from '@/components/PushNotificationsInitializer';
 
 export const metadata: Metadata = {
   title: 'Arena Real - Torneos CR Colombia',
@@ -23,6 +24,7 @@ export default function RootLayout({
       </head>
       <body className="font-body antialiased">
         <ReduxProvider>
+          <PushNotificationsInitializer />
           <TransactionUpdatesListener />
           {children}
           <Toaster />

--- a/front/src/components/PushNotificationsInitializer.tsx
+++ b/front/src/components/PushNotificationsInitializer.tsx
@@ -1,0 +1,7 @@
+"use client";
+import usePushNotifications from '@/hooks/usePushNotifications';
+
+export default function PushNotificationsInitializer() {
+  usePushNotifications();
+  return null;
+}

--- a/front/src/hooks/usePushNotifications.ts
+++ b/front/src/hooks/usePushNotifications.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from 'react';
+import { messaging } from '@/lib/firebase';
+import { getToken, onMessage } from 'firebase/messaging';
+import { BACKEND_URL } from '@/lib/config';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function usePushNotifications() {
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (!user?.id) return;
+    if (!('Notification' in window)) return;
+
+    navigator.serviceWorker
+      .register('/firebase-messaging-sw.js')
+      .catch(err => console.error('SW registration failed', err));
+
+    Notification.requestPermission().then(async perm => {
+      if (perm !== 'granted') return;
+      try {
+        const token = await getToken(messaging);
+        await fetch(`${BACKEND_URL}/api/push/register`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jugadorId: user.id, token }),
+        });
+      } catch (err) {
+        console.error('FCM registration failed', err);
+      }
+    });
+
+    const unsub = onMessage(messaging, payload => {
+      const { title, body } = payload.notification || {};
+      if (title) new Notification(title, { body });
+    });
+    return () => unsub();
+  }, [user]);
+}

--- a/front/src/lib/firebase.ts
+++ b/front/src/lib/firebase.ts
@@ -3,6 +3,7 @@ import { initializeApp, getApps, getApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
+import { getMessaging } from 'firebase/messaging';
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
@@ -20,5 +21,6 @@ const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const auth = getAuth(app);
 const db = getFirestore(app);
 const storage = getStorage(app);
+const messaging = getMessaging(app);
 
-export { auth, db };
+export { auth, db, messaging };

--- a/shared-core/src/main/java/co/com/arena/real/domain/entity/PushToken.java
+++ b/shared-core/src/main/java/co/com/arena/real/domain/entity/PushToken.java
@@ -1,0 +1,30 @@
+package co.com.arena.real.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "push_tokens")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushToken {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "jugador_id", nullable = false)
+    private Jugador jugador;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+}


### PR DESCRIPTION
## Summary
- add `PushNotificationService` to send match-found notifications through FCM
- persist device tokens in new `PushToken` entity and repository
- expose `/api/push/register` endpoint to register tokens
- export Firebase messaging on the frontend
- register service worker and FCM token via `usePushNotifications`
- include push notification initializer in layout
- enable Firebase in application config

## Testing
- `npm run lint`
- `npm run typecheck`
- `mvn -q -DskipTests package` *(failed: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_687ebe6a5fc08328a04a8f7cc345412b