### PR TITLE
Implement referral rewards tied to validated matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ GET  /api/referrals/earnings/{userId}
 
 Registering accepts an optional `referralCode`. When a referred player finishes a duel,
 the inviter automatically earns COP 1000. Rewards are credited after the admin
-backend validates the duel.
+backend validates the duel. The frontend includes a **Referidos** page at `/referrals` showing your code and total earned.
 ## Firestore chat migration
 
 Some early deployments stored chats under `chats/{chatId}/chats/{subId}`. The frontend only looks at the `chats/` collection, so these documents need to be copied to the root collection. A helper script is available in `front/scripts/migrateChats.ts`.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ When an admin marks a transaction as **ENTREGADA** in the admin console:
    - `/api/internal/notify-transaction-approved` emits a `transaccion-aprobada` SSE event.
 3. The user client listens to these events with `useTransactionUpdates` to update its balance and show a toast.
    If the connection was lost, the hook refreshes data when the page becomes visible or after reconnecting.
+
+## Referral system
+
+Two new endpoints implement a simple referral program:
+
+```http
+POST /api/register
+GET  /api/referrals/earnings/{userId}
+```
+
+Registering accepts an optional `referralCode`. When a referred player finishes a duel,
+the inviter automatically earns COP 1000. Rewards are credited after the admin
+backend validates the duel.
 ## Firestore chat migration
 
 Some early deployments stored chats under `chats/{chatId}/chats/{subId}`. The frontend only looks at the `chats/` collection, so these documents need to be copied to the root collection. A helper script is available in `front/scripts/migrateChats.ts`.

--- a/back/src/main/java/co/com/arena/real/application/controller/ReferralController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/ReferralController.java
@@ -1,0 +1,38 @@
+package co.com.arena.real.application.controller;
+
+import co.com.arena.real.application.service.JugadorService;
+import co.com.arena.real.application.service.ReferralRewardService;
+import co.com.arena.real.infrastructure.dto.rq.JugadorRequest;
+import co.com.arena.real.infrastructure.dto.rs.JugadorResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ReferralController {
+
+    private final JugadorService jugadorService;
+    private final ReferralRewardService rewardService;
+
+    @PostMapping("/register")
+    public ResponseEntity<JugadorResponse> register(@RequestBody JugadorRequest body) {
+        JugadorResponse response = jugadorService.registrarJugador(body);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/referrals/earnings/{userId}")
+    public ResponseEntity<Map<String, Object>> earnings(@PathVariable String userId) {
+        BigDecimal total = rewardService.earningsForUser(userId);
+        return ResponseEntity.ok(Map.of("total", total));
+    }
+}

--- a/back/src/main/java/co/com/arena/real/application/service/JugadorService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/JugadorService.java
@@ -29,6 +29,12 @@ public class JugadorService {
         }
         // Mapeo de DTO A entidad
         Jugador jugador = jugadorMapper.toEntity(dto);
+        jugador.setReferralCode(java.util.UUID.randomUUID().toString());
+        if (dto.getReferralCode() != null && !dto.getReferralCode().isBlank()) {
+            jugadorRepository.findByReferralCode(dto.getReferralCode())
+                    .filter(Jugador::isHasPlayed)
+                    .ifPresent(inviter -> jugador.setReferredBy(inviter.getId()));
+        }
         Jugador saved = jugadorRepository.save(jugador);
         return jugadorMapper.toDto(saved);
     }

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -26,6 +26,7 @@ import co.com.arena.real.application.service.TransaccionService;
 import co.com.arena.real.application.service.MatchProposalService;
 import co.com.arena.real.application.service.MatchService;
 import co.com.arena.real.application.events.PartidaValidadaEvent;
+import co.com.arena.real.application.service.ReferralRewardService;
 import org.springframework.context.ApplicationEventPublisher;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -53,6 +54,7 @@ public class PartidaService {
     private final MatchProposalService matchProposalService;
     private final MatchService matchService;
     private final ApplicationEventPublisher eventPublisher;
+    private final ReferralRewardService referralRewardService;
 
     private static final Logger log = LoggerFactory.getLogger(PartidaService.class);
 
@@ -169,6 +171,7 @@ public class PartidaService {
         chatService.cerrarChat(partida.getChatId());
 
         Partida saved = partidaRepository.save(partida);
+        referralRewardService.processPartida(saved);
         PartidaResponse dto = partidaMapper.toDto(saved);
         eventPublisher.publishEvent(new PartidaValidadaEvent(dto));
         return dto;

--- a/back/src/main/java/co/com/arena/real/application/service/ReferralRewardService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/ReferralRewardService.java
@@ -1,0 +1,53 @@
+package co.com.arena.real.application.service;
+
+import co.com.arena.real.domain.entity.Jugador;
+import co.com.arena.real.domain.entity.partida.Partida;
+import co.com.arena.real.domain.entity.referral.ReferralReward;
+import co.com.arena.real.infrastructure.repository.JugadorRepository;
+import co.com.arena.real.infrastructure.repository.ReferralRewardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ReferralRewardService {
+
+    private static final BigDecimal REWARD_AMOUNT = BigDecimal.valueOf(1000);
+
+    private final ReferralRewardRepository rewardRepository;
+    private final JugadorRepository jugadorRepository;
+
+    @Transactional
+    public void processPartida(Partida partida) {
+        creditForPlayer(partida.getJugador1(), partida);
+        creditForPlayer(partida.getJugador2(), partida);
+    }
+
+    private void creditForPlayer(Jugador jugador, Partida partida) {
+        if (jugador == null || jugador.getReferredBy() == null) {
+            return;
+        }
+        jugadorRepository.findById(jugador.getReferredBy()).ifPresent(inviter -> {
+            ReferralReward reward = ReferralReward.builder()
+                    .inviter(inviter)
+                    .referred(jugador)
+                    .partida(partida)
+                    .amount(REWARD_AMOUNT)
+                    .creditedAt(LocalDateTime.now())
+                    .build();
+            rewardRepository.save(reward);
+        });
+        if (!jugador.isHasPlayed()) {
+            jugador.setHasPlayed(true);
+            jugadorRepository.save(jugador);
+        }
+    }
+
+    public BigDecimal earningsForUser(String jugadorId) {
+        return rewardRepository.totalEarnedByInviter(jugadorId);
+    }
+}

--- a/back/src/main/java/co/com/arena/real/domain/entity/referral/ReferralReward.java
+++ b/back/src/main/java/co/com/arena/real/domain/entity/referral/ReferralReward.java
@@ -1,0 +1,51 @@
+package co.com.arena.real.domain.entity.referral;
+
+import co.com.arena.real.domain.entity.Jugador;
+import co.com.arena.real.domain.entity.partida.Partida;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "referral_rewards")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReferralReward {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviter_id", nullable = false)
+    private Jugador inviter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "referred_id", nullable = false)
+    private Jugador referred;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "partida_id", nullable = false)
+    private Partida partida;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Column(name = "credited_at", nullable = false)
+    private LocalDateTime creditedAt;
+}

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/JugadorRequest.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/JugadorRequest.java
@@ -41,4 +41,6 @@ public class JugadorRequest implements Serializable {
     )
     private String linkAmistad;
 
+    private String referralCode;
+
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/JugadorResponse.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/JugadorResponse.java
@@ -26,4 +26,6 @@ public class JugadorResponse implements Serializable {
     private BigDecimal saldo;
     private Integer reputacion;
 
+    private String referralCode;
+
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/mapper/JugadorMapper.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/mapper/JugadorMapper.java
@@ -24,6 +24,7 @@ public class JugadorMapper {
                 .telefono(jugador.getTelefono())
                 .tagClash(jugador.getTagClash())
                 .linkAmistad(jugador.getLinkAmistad())
+                .referralCode(jugador.getReferralCode())
                 .saldo(jugador.getSaldo())
                 .reputacion(jugador.getReputacion())
                 .build();

--- a/back/src/main/java/co/com/arena/real/infrastructure/repository/ReferralRewardRepository.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/repository/ReferralRewardRepository.java
@@ -1,0 +1,14 @@
+package co.com.arena.real.infrastructure.repository;
+
+import co.com.arena.real.domain.entity.referral.ReferralReward;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+
+public interface ReferralRewardRepository extends JpaRepository<ReferralReward, Long> {
+
+    @Query("SELECT COALESCE(SUM(r.amount), 0) FROM ReferralReward r WHERE r.inviter.id = :inviterId")
+    BigDecimal totalEarnedByInviter(@Param("inviterId") String inviterId);
+}

--- a/front/src/app/referrals/page.tsx
+++ b/front/src/app/referrals/page.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import AppLayout from '@/components/AppLayout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/hooks/useAuth';
+import { useEffect, useState } from 'react';
+import { getReferralEarningsAction } from '@/lib/actions';
+
+export default function ReferralsPage() {
+  const { user } = useAuth();
+  const [total, setTotal] = useState<number | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user) return;
+      const result = await getReferralEarningsAction(user.id);
+      if (result.total !== null) setTotal(result.total);
+    };
+    load();
+  }, [user]);
+
+  if (!user) return <p>Cargando...</p>;
+
+  return (
+    <AppLayout>
+      <Card>
+        <CardHeader>
+          <CardTitle>Mis Referidos</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p className="break-all">Tu código: {user.referralCode}</p>
+          <p>Total ganado: {new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(total ?? 0)}</p>
+        </CardContent>
+      </Card>
+    </AppLayout>
+  );
+}

--- a/front/src/app/register/page.tsx
+++ b/front/src/app/register/page.tsx
@@ -32,6 +32,7 @@ const completeProfileSchema = z.object({
     .refine(link => link.startsWith("https://link.clashroyale.com/"), {
         message: "El link debe ser de Clash Royale (link.clashroyale.com)"
     }),
+  referralCode: z.string().optional(),
 });
 
 export default function RegisterPage() {
@@ -48,6 +49,7 @@ export default function RegisterPage() {
       username: '',
       phone: '',
       friendLink: '',
+      referralCode: '',
     },
   });
 
@@ -80,6 +82,7 @@ export default function RegisterPage() {
         username: googleAuthData.username || '',
         phone: '',
         friendLink: '',
+        referralCode: '',
       });
     }
   }, [step, googleAuthData, form]);
@@ -142,6 +145,7 @@ export default function RegisterPage() {
       avatarUrl: googleAuthData.avatarUrl,
       phone: profileData.phone,
       friendLink: profileData.friendLink,
+      referralCode: profileData.referralCode || undefined,
     };
 
     console.log(fullRegistrationData)
@@ -170,10 +174,10 @@ export default function RegisterPage() {
   };
   
   const handleCancelAndGoBack = () => {
-    setStep(1); 
-    setGoogleAuthData(null); 
+    setStep(1);
+    setGoogleAuthData(null);
     sessionStorage.removeItem('pendingGoogleAuthData');
-    form.reset({ username: '', phone: '', friendLink: '' });
+    form.reset({ username: '', phone: '', friendLink: '', referralCode: '' });
   }
 
   return (
@@ -242,6 +246,19 @@ export default function RegisterPage() {
                       </FormControl>
                       <FormMessage />
                       <p className="text-xs text-muted-foreground mt-1">Tu Tag de jugador (ej. #P01Y2G3R) se extraerá automáticamente de este link.</p>
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="referralCode"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-lg text-foreground">Código de referido (opcional)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="ABCD1234" {...field} className="text-base py-5 border-2 focus:border-primary" />
+                      </FormControl>
+                      <FormMessage />
                     </FormItem>
                   )}
                 />

--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -10,6 +10,7 @@ import {
   ScrollText,
   Trophy,
   Menu as MenuIcon,
+  Users,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -23,6 +24,7 @@ const BottomNav = () => {
     { id: "chat", label: "Chat", href: "/chat", icon: MessageCircle },
     { id: "historial", label: "Historial", href: "/history", icon: ScrollText },
     { id: "torneo", label: "Torneo", href: "/torneos", icon: Trophy },
+    { id: "referidos", label: "Referidos", href: "/referrals", icon: Users },
     { id: "menu", label: "Menú", href: "/menu", icon: MenuIcon },
   ];
 

--- a/front/src/components/Navbar.tsx
+++ b/front/src/components/Navbar.tsx
@@ -10,6 +10,7 @@ import {
   Crown,
   ScrollText,
   MessageCircle,
+  Users,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -37,6 +38,7 @@ const Navbar = () => {
     { href: '/history', label: 'Historial', icon: ScrollText },
     { href: '/chat', label: 'Chats', icon: MessageCircle },
     { href: '/torneos', label: 'Torneos', icon: Trophy },
+    { href: '/referrals', label: 'Referidos', icon: Users },
   ];
 
   // TODO: replace with real notification count

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -29,11 +29,12 @@ export async function registerUserAction(
     email: data.email,
     telefono: data.phone,
     linkAmistad: data.friendLink,
+    referralCode: data.referralCode,
   }
 
   try {
-    const response = await fetch(`${BACKEND_URL}/api/jugadores`, {
-      method: 'PUT',
+    const response = await fetch(`${BACKEND_URL}/api/register`, {
+      method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(backendPayload),
     })
@@ -59,6 +60,7 @@ export async function registerUserAction(
       friendLink: registered.linkAmistad || '',
       avatarUrl: data.avatarUrl || `https://placehold.co/100x100.png?text=${registered.nombre?.[0] ?? 'U'}`,
       reputacion: registered.reputacion ?? 0,
+      referralCode: registered.referralCode,
     }
 
     return { user, error: null }
@@ -103,6 +105,7 @@ export async function getUserDataAction(userId: string): Promise<{ user: User | 
       friendLink: backendUser.linkAmistad,
       avatarUrl: `https://placehold.co/100x100.png?text=${backendUser.nombre?.[0] ?? 'U'}`,
       reputacion: backendUser.reputacion,
+      referralCode: backendUser.referralCode,
     }
 
     return { user, error: null }
@@ -384,5 +387,21 @@ export async function fetchMatchIdByChat(
     return data.id
   } catch {
     return null
+  }
+}
+
+export async function getReferralEarningsAction(
+  userId: string,
+): Promise<{ total: number | null; error: string | null }> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/referrals/earnings/${userId}`)
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      return { total: null, error: err.message || `Error ${res.status}` }
+    }
+    const data = (await res.json()) as { total: number }
+    return { total: data.total, error: null }
+  } catch (err: any) {
+    return { total: null, error: err.message || 'Error de red.' }
   }
 }

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -6,6 +6,7 @@ export interface RegistrarUsuarioRequest {
   email: string;
   telefono: string;
   linkAmistad: string;
+  referralCode?: string;
 }
 
 export interface BackendUsuarioDto {
@@ -17,6 +18,7 @@ export interface BackendUsuarioDto {
   linkAmistad: string;
   saldo: number;
   reputacion: number;
+  referralCode?: string;
 }
 
 export interface BackendTransaccionRequestDto {
@@ -115,6 +117,7 @@ export interface User {
   balance: number;
   friendLink?: string;
   reputacion?: number;
+  referralCode?: string;
 }
 
 // Para el formulario de completar perfil después del login con Google
@@ -122,6 +125,7 @@ export interface CompleteProfileFormValues {
   username: string;
   phone: string;
   friendLink: string;
+  referralCode?: string;
 }
 
 // Valores obtenidos de la simulación de Google Auth
@@ -141,6 +145,7 @@ export type RegisterWithGoogleData = {
   phone: string;
   friendLink: string;
   clashTag?: string;
+  referralCode?: string;
 };
 
 

--- a/shared-core/src/main/java/co/com/arena/real/domain/entity/Jugador.java
+++ b/shared-core/src/main/java/co/com/arena/real/domain/entity/Jugador.java
@@ -43,6 +43,16 @@ public class Jugador {
     @Builder.Default
     private Integer reputacion = 100;
 
+    @Column(name = "referral_code", unique = true)
+    private String referralCode;
+
+    @Column(name = "referred_by")
+    private String referredBy;
+
+    @Builder.Default
+    @Column(name = "has_played")
+    private boolean hasPlayed = false;
+
     public Jugador(String id) {
         this.id = id;
     }

--- a/shared-core/src/main/java/co/com/arena/real/infrastructure/repository/JugadorRepository.java
+++ b/shared-core/src/main/java/co/com/arena/real/infrastructure/repository/JugadorRepository.java
@@ -8,4 +8,6 @@ public interface JugadorRepository extends JpaRepository<Jugador, String> {
 
     boolean existsByTelefono(String telefono);
 
+    java.util.Optional<Jugador> findByReferralCode(String referralCode);
+
 }


### PR DESCRIPTION
## Summary
- store referral info on `Jugador`
- award referral rewards when the admin backend validates a match
- expose simple register and earnings endpoints using `Jugador` data
- document referral reward behavior in README

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_687ec6e98d688328a3277964bdd887d0