### PR TITLE
Fix compilation errors

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/PushTokenController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PushTokenController.java
@@ -23,8 +23,8 @@ public class PushTokenController {
         return jugadorRepository.findById(request.getJugadorId())
                 .map(jugador -> {
                     pushNotificationService.registerToken(jugador, request.getToken());
-                    return ResponseEntity.ok().build();
+                    return ResponseEntity.ok().<Void>build();
                 })
-                .orElseGet(() -> ResponseEntity.notFound().build());
+                .orElseGet(() -> ResponseEntity.notFound().<Void>build());
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
@@ -129,7 +129,7 @@ public class MatchSseService {
         sendRematchAvailable(partida.getJugador2Id(), partida);
     }
 
-    private void sendMatchFound(String receptorId, UUID apuestaId, UUID partidaId, Jugador oponente) {
+    private void sendMatchFound(String receptorId, UUID apuestaId, UUID partidaId, Jugador oponente, boolean revancha) {
         String tag = oponente.getTagClash() != null ? oponente.getTagClash() : oponente.getNombre();
         String nombre = oponente.getNombre() != null ? oponente.getNombre() : tag;
         MatchSseDto dto = MatchSseDto.builder()


### PR DESCRIPTION
## Summary
- fix SSE match event signature so revancha flag compiles
- specify generics when building `ResponseEntity` in push token registration

## Testing
- `mvn -q -DskipTests install` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_687f23020164832888ebee2fdaae0273