### PR TITLE
Fix SSE service bean creation

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
@@ -23,7 +23,6 @@ public class MatchSseService {
 
     private static final Logger log = LoggerFactory.getLogger(MatchSseService.class);
 
-    private final PushNotificationService pushNotificationService;
 
     private static class EmitterWrapper {
         final SseEmitter emitter;


### PR DESCRIPTION
## Summary
- remove unused PushNotificationService field from MatchSseService

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_687f2a00891083288822a1e930ab485b