### PR TITLE
Fix SSE service bean creation

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/PushTokenController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PushTokenController.java
@@ -1,6 +1,7 @@
 package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.PushNotificationService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import co.com.arena.real.infrastructure.dto.rq.PushTokenRequest;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/push")
 @RequiredArgsConstructor
+@ConditionalOnBean(PushNotificationService.class)
 public class PushTokenController {
 
     private final PushNotificationService pushNotificationService;

--- a/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
@@ -23,7 +23,6 @@ public class MatchSseService {
 
     private static final Logger log = LoggerFactory.getLogger(MatchSseService.class);
 
-    private final PushNotificationService pushNotificationService;
 
     private static class EmitterWrapper {
         final SseEmitter emitter;


### PR DESCRIPTION
## Summary
- avoid creating PushTokenController when notifications disabled

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_687f2a00891083288822a1e930ab485b