### PR TITLE
Fix optional push notification component

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ environment entries via `spring-dotenv` when `dotenv.enabled=true`.
 
 If you do not provide credentials, disable Firebase by setting `firebase.enabled=false`
 (for example in `application.properties` or as `FIREBASE_ENABLED=false`). When
-disabled, chat features will skip Firestore operations.
+disabled, chat features and push notifications will skip all Firebase operations.
 
 Este proyecto usa Firebase en el front-end. Las credenciales deben declararse en un archivo `.env.local` en la carpeta `front`.
 

--- a/back/src/main/java/co/com/arena/real/application/controller/PushTokenController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PushTokenController.java
@@ -4,6 +4,7 @@ import co.com.arena.real.application.service.PushNotificationService;
 import co.com.arena.real.infrastructure.dto.rq.PushTokenRequest;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/push")
 @RequiredArgsConstructor
+@ConditionalOnBean(PushNotificationService.class)
 public class PushTokenController {
 
     private final PushNotificationService pushNotificationService;

--- a/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
@@ -23,7 +23,6 @@ public class MatchSseService {
 
     private static final Logger log = LoggerFactory.getLogger(MatchSseService.class);
 
-    private final PushNotificationService pushNotificationService;
 
     private static class EmitterWrapper {
         final SseEmitter emitter;


### PR DESCRIPTION
## Summary
- only create push token controller when push notifications are enabled
- remove unused dependency from MatchSseService
- document that disabling Firebase also disables push notifications

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_687f2a00891083288822a1e930ab485b