### PR TITLE
Improve websocket session handling

### DIFF
--- a/back/src/main/java/co/com/arena/real/websocket/WsService.java
+++ b/back/src/main/java/co/com/arena/real/websocket/WsService.java
@@ -34,7 +34,13 @@ public class WsService {
     private final Map<String, SessionWrapper> sessions = new ConcurrentHashMap<>();
 
     public void register(String jugadorId, WebSocketSession session) {
-        sessions.put(jugadorId, new SessionWrapper(session));
+        SessionWrapper previous = sessions.put(jugadorId, new SessionWrapper(session));
+        if (previous != null && previous.session.isOpen()) {
+            try {
+                previous.session.close(new CloseStatus(1001, "nueva conexion"));
+            } catch (IOException ignored) {
+            }
+        }
         log.info("Nueva conexión WS para jugador: {}", jugadorId);
     }
 


### PR DESCRIPTION
## Summary
- close previous websocket sessions when a player reconnects
- remove sessions safely when closed

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_687fe2e64228832881acaea279ffe67f