### PR TITLE
Fix WebSocketConfig constructor

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/WebSocketConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/WebSocketConfig.java
@@ -1,7 +1,8 @@
 package co.com.arena.real.config;
 
-import co.com.arena.real.websocket.MatchWsHandler;
+import co.com.arena.real.websocket.MatchmakingHandler;
 import co.com.arena.real.websocket.TransaccionWsHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
@@ -9,22 +10,18 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 
 @Configuration
 @EnableWebSocket
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketConfigurer {
 
     private final TransaccionWsHandler transaccionWsHandler;
-    private final MatchWsHandler matchWsHandler;
-
-    public WebSocketConfig(TransaccionWsHandler transaccionWsHandler, MatchWsHandler matchWsHandler) {
-        this.transaccionWsHandler = transaccionWsHandler;
-        this.matchWsHandler = matchWsHandler;
-    }
+    private final MatchmakingHandler matchmakingHandler;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(transaccionWsHandler, "/ws/transacciones/{jugadorId}")
                 .setAllowedOrigins("http://localhost:3000", "http://localhost:3001")
                 .addInterceptors(new PlayerIdHandshakeInterceptor());
-        registry.addHandler(matchWsHandler, "/ws/matchmaking/{jugadorId}")
+        registry.addHandler(matchmakingHandler, "/ws/matchmaking/{jugadorId}")
                 .setAllowedOrigins("http://localhost:3000", "http://localhost:3001")
                 .addInterceptors(new PlayerIdHandshakeInterceptor());
     }

--- a/back/src/main/java/co/com/arena/real/websocket/MatchmakingHandler.java
+++ b/back/src/main/java/co/com/arena/real/websocket/MatchmakingHandler.java
@@ -8,7 +8,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 @Component
 @RequiredArgsConstructor
-public class MatchWsHandler extends TextWebSocketHandler {
+public class MatchmakingHandler extends TextWebSocketHandler {
 
     private final MatchWsService matchWsService;
 
@@ -28,4 +28,3 @@ public class MatchWsHandler extends TextWebSocketHandler {
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- rely on Lombok `@RequiredArgsConstructor` in `WebSocketConfig`

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68801743ef1c83289f5017f9c1eb4161