### PR TITLE
Implement WebSocket keep‑alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ WebSocket endpoints are enabled on the same port. The frontend connects to
 configured in `NEXT_PUBLIC_BACKEND_WS_URL`.
 When a match ends, a new `rematch-available` event is sent on the matchmaking
 WebSocket so players can start a rematch quickly.
+The backend now sends periodic WebSocket pings every 15 seconds and cleans up
+stale connections to prevent timeouts or reconnection loops.
 
 Build all Java modules in one step:
 

--- a/back/src/main/java/co/com/arena/real/websocket/MatchWsService.java
+++ b/back/src/main/java/co/com/arena/real/websocket/MatchWsService.java
@@ -8,12 +8,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.PingMessage;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -204,6 +207,33 @@ public class MatchWsService {
                 .build();
         latestEvents.put(receptorId, new LatestEvent("rematch-available", dto));
         sendEvent(receptorId, "rematch-available", dto);
+    }
+
+    @Scheduled(fixedRate = 15000)
+    public void sendHeartbeats() {
+        sessions.forEach((id, wrapper) -> {
+            try {
+                if (wrapper.session.isOpen()) {
+                    wrapper.session.sendMessage(new PingMessage(ByteBuffer.allocate(0)));
+                    wrapper.lastAccess = System.currentTimeMillis();
+                }
+            } catch (IOException e) {
+                sessions.remove(id);
+                try { wrapper.session.close(CloseStatus.SERVER_ERROR); } catch (IOException ignored) {}
+            }
+        });
+    }
+
+    @Scheduled(fixedRate = 60000)
+    public void limpiarSesiones() {
+        long now = System.currentTimeMillis();
+        long ttl = 5 * 60 * 1000L;
+        sessions.forEach((id, wrapper) -> {
+            if (!wrapper.session.isOpen() || now - wrapper.lastAccess > ttl) {
+                sessions.remove(id);
+                try { wrapper.session.close(CloseStatus.GOING_AWAY); } catch (IOException ignored) {}
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- keep WebSocket connections alive with scheduled pings
- clean up old WebSocket sessions
- document WebSocket keep-alive in the README

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_688027e655788328bd8d9129257755c7