### PR TITLE
Restore WebSocket transactions hook

### DIFF
--- a/front/src/hooks/useApprovedTransactionsWs.ts
+++ b/front/src/hooks/useApprovedTransactionsWs.ts
@@ -48,7 +48,9 @@ export default function useApprovedTransactionsWs() {
 
       ws.onmessage = handleMessage;
       ws.onclose = () => {
-        reconnectTimeoutRef.current = setTimeout(connect, 3000);
+        if (socketRef.current === ws) {
+          reconnectTimeoutRef.current = setTimeout(connect, 3000);
+        }
       };
       ws.onerror = (err) => {
         console.error('WS error:', err);
@@ -60,9 +62,11 @@ export default function useApprovedTransactionsWs() {
     return () => {
       if (socketRef.current) {
         socketRef.current.close();
+        socketRef.current = null;
       }
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
       }
     };
   }, [user]);


### PR DESCRIPTION
## Summary
- revert to WebSocket listener on the transactions page
- handle stale sockets when reconnecting

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: interactive setup prompt)*
- `mvn -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68802454d1a08328b844a2f690dd5eb3