### PR TITLE
Implement rematch tracking and vote notifications

### DIFF
--- a/admin-back/src/main/java/com/example/admin/application/controller/AdminController.java
+++ b/admin-back/src/main/java/com/example/admin/application/controller/AdminController.java
@@ -67,6 +67,12 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/games/{id}/rematch")
+    public ResponseEntity<Void> forceRematch(@PathVariable UUID id) {
+        adminService.forceRematch(id);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/bets/{id}/state")
     public ResponseEntity<Void> changeBetState(@PathVariable UUID id,
                                                @RequestParam("state") String state) {

--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -147,6 +147,7 @@ public class AdminService {
                     dto.setMonto(p.getMonto());
                     dto.setWinnerId(p.getGanador() != null ? UUID.fromString(p.getGanador().getId()) : null);
                     dto.setDistributed(p.isValidada());
+                    dto.setRevanchaCount(p.getRevanchaCount());
                     return dto;
                 })
                 .toList();
@@ -167,6 +168,11 @@ public class AdminService {
             chatService.cerrarChat(partida.getChatId());
             partidaRepository.save(partida);
         });
+    }
+
+    @Transactional
+    public void forceRematch(UUID gameId) {
+        partidaService.forzarRevancha(gameId);
     }
 
     @Transactional

--- a/admin-back/src/main/java/com/example/admin/infrastructure/dto/GameResultDto.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/dto/GameResultDto.java
@@ -21,4 +21,5 @@ public class GameResultDto {
     private java.math.BigDecimal monto;
     private UUID winnerId;
     private boolean distributed;
+    private int revanchaCount;
 }

--- a/admin/src/components/MatchTable.tsx
+++ b/admin/src/components/MatchTable.tsx
@@ -17,6 +17,7 @@ interface GameResult {
   monto?: number
   winnerId?: string | null
   distributed: boolean
+  revanchaCount?: number
 }
 
 export default function MatchTable() {
@@ -79,6 +80,7 @@ export default function MatchTable() {
             <th className="border px-2 py-1">Jugador B</th>
             <th className="border px-2 py-1">Captura B</th>
             <th className="border px-2 py-1">Resultado B</th>
+            <th className="border px-2 py-1">Revancha</th>
             <th className="border px-2 py-1">Apuesta</th>
             <th className="border px-2 py-1">Ganador</th>
             <th className="border px-2 py-1">Estado</th>
@@ -130,6 +132,7 @@ export default function MatchTable() {
                 )}
               </td>
               <td className="border px-2 py-1">{r.resultadoB || '-'}</td>
+              <td className="border px-2 py-1">{r.revanchaCount ?? 0}</td>
               <td className="border px-2 py-1">
                 {r.monto !== undefined ? `$${r.monto}` : '-'}
               </td>

--- a/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
@@ -45,6 +45,7 @@ public class MatchmakingController {
                             .jugadorOponenteId(oponente.getId())
                             .jugadorOponenteTag(tag)
                             .jugadorOponenteNombre(nombre)
+                            .revancha(false)
                             .build();
                 })
                 .<ResponseEntity<?>>map(ResponseEntity::ok)

--- a/back/src/main/java/co/com/arena/real/application/service/MatchmakingService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchmakingService.java
@@ -75,7 +75,7 @@ public class MatchmakingService {
 
             MatchProposal proposal = crearPropuesta(partidaEnEspera, partidaEncontrada);
 
-            matchSseService.notifyMatchFound(null, proposal.getId(), jugadorEnEspera, jugadorEncontrado);
+            matchSseService.notifyMatchFound(null, proposal.getId(), null, jugadorEnEspera, jugadorEncontrado);
 
             return proposal;
         });

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/PartidaResultadoRequest.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/PartidaResultadoRequest.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class PartidaResultadoRequest {
     private String jugadorId;
-    private String resultado; // VICTORIA o DERROTA
+    private String resultado; // VICTORIA, DERROTA o EMPATE
     private String captura;
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/MatchSseDto.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/MatchSseDto.java
@@ -23,5 +23,6 @@ public class MatchSseDto implements Serializable {
     private String jugadorOponenteTag;
     private String jugadorOponenteNombre;
     private UUID chatId;
+    private boolean revancha;
 
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/PartidaResponse.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/PartidaResponse.java
@@ -35,4 +35,5 @@ public class PartidaResponse implements Serializable {
     private String capturaJugador2;
     private String resultadoJugador1;
     private String resultadoJugador2;
+    private int revanchaCount;
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/mapper/PartidaMapper.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/mapper/PartidaMapper.java
@@ -28,6 +28,7 @@ public class PartidaMapper {
                 .capturaJugador2(entity.getCapturaJugador2())
                 .resultadoJugador1(entity.getResultadoJugador1() != null ? entity.getResultadoJugador1().name() : null)
                 .resultadoJugador2(entity.getResultadoJugador2() != null ? entity.getResultadoJugador2().name() : null)
+                .revanchaCount(entity.getRevanchaCount())
                 .build();
     }
 }

--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -12,12 +12,13 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
-import { Send, Link as LinkIconLucide, CheckCircle, XCircle, UploadCloud } from 'lucide-react';
+import { Send, Link as LinkIconLucide, CheckCircle, XCircle, UploadCloud, Repeat } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
 import useFirestoreChat from '@/hooks/useFirestoreChat';
 import { BACKEND_URL } from '@/lib/config';
 import type { ChatMessage, User } from '@/types';
 import { submitMatchResultAction, fetchMatchIdByChat } from '@/lib/actions';
+import useMatchmakingSse from '@/hooks/useMatchmakingSse';
 
 import { Label } from '@/components/ui/label';
 import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
@@ -109,6 +110,19 @@ const ChatPageContent = () => {
   const [partidaId, setPartidaId] = useState<string | null>(initialPartidaId);
   const [opponentProfile, setOpponentProfile] = useState<User | null>(null);
   const opponentDisplayName = opponentProfile?.username || validOpponentTag;
+  useMatchmakingSse(
+    user?.id,
+    () => {},
+    () => {},
+    undefined,
+    undefined,
+    undefined,
+    (data) => {
+      if (data.partidaId === partidaId) {
+        setOpponentVoted(true);
+      }
+    }
+  );
   const sendMessageSafely = (msg: Omit<ChatMessage, 'id'>) => {
     if (!chatActive) {
       console.warn('Chat inactivo. No se pueden enviar mensajes.');
@@ -124,6 +138,7 @@ const ChatPageContent = () => {
   const [isSubmittingResult, setIsSubmittingResult] = useState(false);
   const [screenshotFile, setScreenshotFile] = useState<File | null>(null);
   const [resultSubmitted, setResultSubmitted] = useState(false);
+  const [opponentVoted, setOpponentVoted] = useState(false);
 
   const startMessageSentRef = useRef(false);
 
@@ -138,6 +153,22 @@ const ChatPageContent = () => {
   };
 
   useEffect(scrollToBottom, [messages]);
+
+  useEffect(() => {
+    const checkVote = async () => {
+      if (!chatId || !user?.id) return;
+      try {
+        const res = await fetch(`${BACKEND_URL}/api/partidas/chat/${encodeURIComponent(chatId)}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        const opponentResult = data.jugador1Id === user.id ? data.resultadoJugador2 : data.resultadoJugador1;
+        setOpponentVoted(!!opponentResult);
+      } catch {
+        /* ignore */
+      }
+    };
+    checkVote();
+  }, [chatId, user?.id, messages.length]);
 
   useEffect(() => {
     const fetchPartida = async () => {
@@ -274,7 +305,7 @@ const ChatPageContent = () => {
     toast({ title: "Link de Amigo Compartido", description: `Tu link de amigo ${user.friendLink ? '' : '(o un aviso de que no lo tienes) '}ha sido publicado en el chat.` });
   };
 
-  const handleResultSubmission = async (result: 'win' | 'loss') => {
+  const handleResultSubmission = async (result: 'win' | 'loss' | 'draw') => {
     if (!user || !user.id || resultSubmitted) {
       toast({ title: 'Error', description: 'No se puede enviar el resultado sin identificación de usuario.', variant: 'destructive' })
       return
@@ -302,7 +333,7 @@ const ChatPageContent = () => {
     const response = await submitMatchResultAction(
       validPartidaId,
       user.id,
-      result === 'win' ? 'VICTORIA' : 'DERROTA',
+      result === 'win' ? 'VICTORIA' : result === 'loss' ? 'DERROTA' : 'EMPATE',
       screenshotBase64,
     )
 
@@ -313,7 +344,9 @@ const ChatPageContent = () => {
     
     toast({
       title: "¡Resultado Enviado!",
-      description: `Reportaste una ${result === 'win' ? 'victoria' : 'derrota'}. ${screenshotFile ? 'Comprobante adjuntado.' : 'Sin comprobante.'} Esperando al oponente si es necesario, o verificación del administrador.`,
+      description: `Reportaste ${
+        result === 'win' ? 'una victoria' : result === 'loss' ? 'una derrota' : 'un empate'
+      }. ${screenshotFile ? 'Comprobante adjuntado.' : 'Sin comprobante.'} Esperando al oponente si es necesario, o verificación del administrador.`,
       variant: "default",
     });
     
@@ -322,7 +355,9 @@ const ChatPageContent = () => {
     setScreenshotFile(null);
     
      const userDisplayName = user.clashTag || user.username;
-     const resultMessageText = `${userDisplayName} envió el resultado del duelo como ${result === 'win' ? 'VICTORIA' : 'DERROTA'}. ${screenshotFile ? 'Captura de pantalla proporcionada.' : 'No se proporcionó captura.'}`;
+     const resultMessageText = `${userDisplayName} envió el resultado del duelo como ${
+       result === 'win' ? 'VICTORIA' : result === 'loss' ? 'DERROTA' : 'EMPATE'
+     }. ${screenshotFile ? 'Captura de pantalla proporcionada.' : 'No se proporcionó captura.'}`;
     const resultSystemMessage = {
       matchId: validChatId, // ID del chat (UUID)
       senderId: 'system',
@@ -364,6 +399,9 @@ const ChatPageContent = () => {
             {resultSubmitted ? 'Resultado Enviado' : 'Enviar Resultado'}
           </CartoonButton>
         </CardHeader>
+        {!resultSubmitted && opponentVoted && (
+          <p className="text-center text-sm text-yellow-500 py-1">Tu oponente ya envió su resultado.</p>
+        )}
         {!chatActive && (
           <p className="text-center text-sm text-muted-foreground py-2">Chat finalizado. No puedes enviar nuevos mensajes.</p>
         )}
@@ -443,6 +481,15 @@ const ChatPageContent = () => {
                   disabled={!chatActive}
                 >
                   Gané
+                </CartoonButton>
+                <CartoonButton
+                  variant="secondary"
+                  onClick={() => handleResultSubmission('draw')}
+                  className="flex-1"
+                  disabled={!chatActive}
+                  iconLeft={<Repeat />}
+                >
+                  Empate
                 </CartoonButton>
                 <CartoonButton
                   variant="destructive"

--- a/front/src/app/history/page.tsx
+++ b/front/src/app/history/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/hooks/useAuth';
 import type { Bet, BackendPartidaResponseDto } from '@/types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollTextIcon, VictoryIcon, DefeatIcon, InfoIcon } from '@/components/icons/ClashRoyaleIcons';
+import { Repeat } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from '@/components/ui/badge';
 import { getUserDuelsAction } from '@/lib/actions';
@@ -78,6 +79,7 @@ const HistoryPageContent = () => {
 
   const wonBets = bets.filter(bet => bet.result === 'win');
   const lostBets = bets.filter(bet => bet.result === 'loss');
+  const drawBets = bets.filter(bet => bet.result === 'draw');
   const pendingBets = bets.filter(bet => !bet.result);
 
   const BetCard = ({ bet }: { bet: Bet }) => {
@@ -93,11 +95,27 @@ const HistoryPageContent = () => {
               Fecha: {new Date(bet.matchDate).toLocaleDateString()}
             </CardDescription>
           </div>
-          <Badge 
-            variant={bet.result === 'win' ? 'default' : bet.result === 'loss' ? 'destructive' : 'secondary'}
-            className={`capitalize ${bet.result === 'win' ? 'bg-green-500 text-white' : bet.result === 'loss' ? 'bg-destructive text-destructive-foreground' : 'bg-muted text-muted-foreground'}`}
+          <Badge
+            variant={
+              bet.result === 'win'
+                ? 'default'
+                : bet.result === 'loss'
+                ? 'destructive'
+                : bet.result === 'draw'
+                ? 'secondary'
+                : 'secondary'
+            }
+            className={`capitalize ${
+              bet.result === 'win'
+                ? 'bg-green-500 text-white'
+                : bet.result === 'loss'
+                ? 'bg-destructive text-destructive-foreground'
+                : bet.result === 'draw'
+                ? 'bg-secondary text-secondary-foreground'
+                : 'bg-muted text-muted-foreground'
+            }`}
           >
-            {bet.result || bet.status || 'Pendiente'}
+            {bet.result === 'draw' ? 'empate' : bet.result || bet.status || 'Pendiente'}
           </Badge>
         </div>
       </CardHeader>
@@ -109,6 +127,7 @@ const HistoryPageContent = () => {
           </div>
           {bet.result === 'win' && <VictoryIcon className="h-8 w-8 text-green-500" />}
           {bet.result === 'loss' && <DefeatIcon className="h-8 w-8 text-destructive" />}
+          {bet.result === 'draw' && <Repeat className="h-8 w-8 text-secondary" />}
           {!bet.result && <InfoIcon className="h-8 w-8 text-muted-foreground" />}
         </div>
       </CardContent>
@@ -127,10 +146,11 @@ const HistoryPageContent = () => {
       </CardHeader>
       <CardContent className="p-6">
         <Tabs defaultValue="all" className="w-full">
-          <TabsList className="grid w-full grid-cols-3 mb-6 p-1.5 bg-secondary rounded-lg gap-1.5">
+          <TabsList className="grid w-full grid-cols-4 mb-6 p-1.5 bg-secondary rounded-lg gap-1.5">
             <TabsTrigger value="all" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-md hover:bg-primary/20">Todos ({bets.length})</TabsTrigger>
             <TabsTrigger value="ganadas" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-green-500 data-[state=active]:text-white data-[state=active]:shadow-md hover:bg-primary/20">Ganadas ({wonBets.length})</TabsTrigger>
             <TabsTrigger value="perdidas" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-destructive data-[state=active]:text-destructive-foreground data-[state=active]:shadow-md hover:bg-primary/20">Perdidas ({lostBets.length})</TabsTrigger>
+            <TabsTrigger value="empates" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-secondary data-[state=active]:text-secondary-foreground data-[state=active]:shadow-md hover:bg-primary/20">Empates ({drawBets.length})</TabsTrigger>
           </TabsList>
           
           <TabsContent value="all">
@@ -152,6 +172,13 @@ const HistoryPageContent = () => {
               <p className="text-center text-muted-foreground py-8">No has perdido ninguna apuesta todavía.</p>
             ) : (
               lostBets.map((bet) => <BetCard key={bet.id} bet={bet} />)
+            )}
+          </TabsContent>
+          <TabsContent value="empates">
+            {drawBets.length === 0 ? (
+              <p className="text-center text-muted-foreground py-8">No tienes empates registrados.</p>
+            ) : (
+              drawBets.map((bet) => <BetCard key={bet.id} bet={bet} />)
             )}
           </TabsContent>
         </Tabs>

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -42,7 +42,7 @@ const HomePageContent = () => {
 
 
   const [isSearching, setIsSearching] = useState(false);
-  const [pendingMatch, setPendingMatch] = useState<{ apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; jugadorOponenteNombre: string; chatId?: string; } | null>(null);
+  const [pendingMatch, setPendingMatch] = useState<{ apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; jugadorOponenteNombre: string; chatId?: string; revancha?: boolean; } | null>(null);
   const [hasAccepted, setHasAccepted] = useState(false);
   const [opponentAccepted, setOpponentAccepted] = useState(false);
   const [timeLeft, setTimeLeft] = useState(25);
@@ -101,7 +101,8 @@ const HomePageContent = () => {
     handleChatReady,
     handleOpponentAccepted,
     handleMatchCancelled,
-    handleMatchValidated
+    handleMatchValidated,
+    undefined
   );
 
   useEffect(() => {
@@ -499,8 +500,14 @@ const HomePageContent = () => {
         <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4 animate-fade-in-up">
           <Card className="w-full max-w-md shadow-xl border-2 border-accent">
             <CardHeader>
-              <CardTitle className="text-3xl font-headline text-accent text-center">¡Duelo encontrado!</CardTitle>
-              <CardDescription className="text-center text-muted-foreground">Contra {pendingMatch.jugadorOponenteNombre}</CardDescription>
+              <CardTitle className="text-3xl font-headline text-accent text-center">
+                {pendingMatch.revancha ? '¡Revancha!' : '¡Duelo encontrado!'}
+              </CardTitle>
+              <CardDescription className="text-center text-muted-foreground">
+                {pendingMatch.revancha
+                  ? `¿Quieres aceptar la revancha contra ${pendingMatch.jugadorOponenteNombre}?`
+                  : `Contra ${pendingMatch.jugadorOponenteNombre}`}
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="h-3 w-full bg-secondary rounded">

--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -9,6 +9,7 @@ export interface MatchEventData {
   jugadorOponenteTag: string;
   jugadorOponenteNombre: string;
   chatId?: string;
+  revancha?: boolean;
 }
 
 export default function useMatchmakingSse(
@@ -17,7 +18,8 @@ export default function useMatchmakingSse(
   onChatReady: (data: MatchEventData) => void,
   onOpponentAccepted?: (data: MatchEventData) => void,
   onMatchCancelled?: (data: MatchEventData) => void,
-  onMatchValidated?: (data: MatchEventData) => void
+  onMatchValidated?: (data: MatchEventData) => void,
+  onPlayerVoted?: (data: MatchEventData) => void
 ) {
   const { toast } = useToast();
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -27,11 +29,13 @@ export default function useMatchmakingSse(
   const onOpponentAcceptedRef = useRef(onOpponentAccepted);
   const onMatchCancelledRef = useRef(onMatchCancelled);
   const onMatchValidatedRef = useRef(onMatchValidated);
+  const onPlayerVotedRef = useRef(onPlayerVoted);
   const matchHandlerRef = useRef<(event: MessageEvent) => void>();
   const readyHandlerRef = useRef<(event: MessageEvent) => void>();
   const acceptedHandlerRef = useRef<(event: MessageEvent) => void>();
   const cancelledHandlerRef = useRef<(event: MessageEvent) => void>();
   const validatedHandlerRef = useRef<(event: MessageEvent) => void>();
+  const votedHandlerRef = useRef<(event: MessageEvent) => void>();
   const connectRef = useRef<(onOpen?: () => void) => void>();
 
   const removeListeners = () => {
@@ -50,6 +54,9 @@ export default function useMatchmakingSse(
     }
     if (validatedHandlerRef.current) {
       eventSourceRef.current.removeEventListener('match-validated', validatedHandlerRef.current as EventListener);
+    }
+    if (votedHandlerRef.current) {
+      eventSourceRef.current.removeEventListener('player-voted', votedHandlerRef.current as EventListener);
     }
   };
 
@@ -92,6 +99,10 @@ export default function useMatchmakingSse(
   useEffect(() => {
     onMatchValidatedRef.current = onMatchValidated;
   }, [onMatchValidated]);
+
+  useEffect(() => {
+    onPlayerVotedRef.current = onPlayerVoted;
+  }, [onPlayerVoted]);
 
   useEffect(() => {
     if (!playerId) return;
@@ -151,6 +162,17 @@ export default function useMatchmakingSse(
     };
     validatedHandlerRef.current = validatedHandler;
 
+    const votedHandler = (event: MessageEvent) => {
+      try {
+        const data: MatchEventData = JSON.parse(event.data);
+        console.log('Jugador votó:', data);
+        onPlayerVotedRef.current && onPlayerVotedRef.current(data);
+      } catch (err) {
+        console.error('Error al procesar evento SSE de voto:', err);
+      }
+    };
+    votedHandlerRef.current = votedHandler;
+
     const connect = (onOpen?: () => void) => {
       const url = `${BACKEND_URL}/sse/matchmaking/${encodeURIComponent(playerId)}`;
       console.log('Abriendo conexión SSE de matchmaking:', url);
@@ -175,6 +197,9 @@ export default function useMatchmakingSse(
       }
       if (validatedHandlerRef.current) {
         es.addEventListener('match-validated', validatedHandlerRef.current as EventListener);
+      }
+      if (votedHandlerRef.current) {
+        es.addEventListener('player-voted', votedHandlerRef.current as EventListener);
       }
 
       es.onerror = (err) => {

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -352,7 +352,7 @@ export async function assignMatchWinnerAction(
 export async function submitMatchResultAction(
   matchId: string,
   jugadorId: string,
-  result: 'VICTORIA' | 'DERROTA',
+  result: 'VICTORIA' | 'DERROTA' | 'EMPATE',
   screenshot?: string,
 ): Promise<{ duel: BackendPartidaResponseDto | null; error: string | null }> {
   try {

--- a/shared-core/src/main/java/co/com/arena/real/domain/entity/partida/Partida.java
+++ b/shared-core/src/main/java/co/com/arena/real/domain/entity/partida/Partida.java
@@ -94,4 +94,8 @@ public class Partida {
     @Lob
     @Column(name = "captura_jugador2", columnDefinition = "text")
     private String capturaJugador2;
+
+    @Builder.Default
+    @Column(name = "revancha_count")
+    private int revanchaCount = 0;
 }

--- a/shared-core/src/main/java/co/com/arena/real/domain/entity/partida/ResultadoJugador.java
+++ b/shared-core/src/main/java/co/com/arena/real/domain/entity/partida/ResultadoJugador.java
@@ -2,5 +2,6 @@ package co.com.arena.real.domain.entity.partida;
 
 public enum ResultadoJugador {
     VICTORIA,
-    DERROTA
+    DERROTA,
+    EMPATE
 }


### PR DESCRIPTION
## Summary
- record rematch count in `Partida`
- expose the count in responses and admin UI
- notify via SSE when a player submits a result
- show opponent-voted hint in chat
- include chat id when sending rematch notifications

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing type declarations)*
- `mvn -q -DskipTests package` *(fails: couldn't resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_687eed18e1308328a2eab58ca88250cb