### PR TITLE
Remove rematch and draw logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ mvn spring-boot:run
 
 
 The backend exposes Server-Sent Event (SSE) endpoints for real-time
-notifications. When a match ends, a `rematch-available` event is sent so
-players can start a rematch quickly.
+notifications.
 
 Build all Java modules in one step:
 

--- a/admin-back/src/main/java/com/example/admin/application/controller/AdminController.java
+++ b/admin-back/src/main/java/com/example/admin/application/controller/AdminController.java
@@ -67,12 +67,6 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/games/{id}/rematch")
-    public ResponseEntity<Void> forceRematch(@PathVariable UUID id) {
-        adminService.forceRematch(id);
-        return ResponseEntity.ok().build();
-    }
-
     @PostMapping("/bets/{id}/state")
     public ResponseEntity<Void> changeBetState(@PathVariable UUID id,
                                                @RequestParam("state") String state) {

--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -172,11 +172,6 @@ public class AdminService {
     }
 
     @Transactional
-    public void forceRematch(UUID gameId) {
-        partidaService.forzarRevancha(gameId);
-    }
-
-    @Transactional
     public void changeBetState(UUID betId, String state) {
         apuestaRepository.findById(betId).ifPresent(a -> {
             a.setEstado(EstadoApuesta.valueOf(state));

--- a/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/MatchmakingController.java
@@ -45,7 +45,6 @@ public class MatchmakingController {
                             .jugadorOponenteId(oponente.getId())
                             .jugadorOponenteTag(tag)
                             .jugadorOponenteNombre(nombre)
-                            .revancha(false)
                             .build();
                 })
                 .<ResponseEntity<?>>map(ResponseEntity::ok)

--- a/back/src/main/java/co/com/arena/real/application/events/PartidaValidadaEventListener.java
+++ b/back/src/main/java/co/com/arena/real/application/events/PartidaValidadaEventListener.java
@@ -15,6 +15,5 @@ public class PartidaValidadaEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePartidaValidada(PartidaValidadaEvent event) {
         matchSseService.notifyMatchValidated(event.partida());
-        matchSseService.notifyRematchAvailable(event.partida());
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -124,25 +124,6 @@ public class PartidaService {
             throw new IllegalArgumentException("Jugador no pertenece a la partida");
         }
 
-        boolean ambosVotaron = partida.getResultadoJugador1() != null && partida.getResultadoJugador2() != null;
-        if (ambosVotaron) {
-            if (partida.getResultadoJugador1() == ResultadoJugador.EMPATE && partida.getResultadoJugador2() == ResultadoJugador.EMPATE) {
-                partida.setValidada(false);
-                partida.setEstado(EstadoPartida.PENDIENTE);
-                partida.setGanador(null);
-                partida.setResultadoJugador1(null);
-                partida.setResultadoJugador2(null);
-                partida.setCapturaJugador1(null);
-                partida.setCapturaJugador2(null);
-                partida.setAceptadoJugador1(false);
-                partida.setAceptadoJugador2(false);
-                partida.setRevanchaCount(partida.getRevanchaCount() + 1);
-
-                Partida saved = partidaRepository.save(partida);
-                matchSseService.notifyMatchFound(saved, true);
-                return partidaMapper.toDto(saved);
-            }
-        }
         partida.setEstado(EstadoPartida.POR_APROBAR);
 
         Partida saved = partidaRepository.save(partida);
@@ -208,11 +189,7 @@ public class PartidaService {
         partida.setCapturaJugador2(null);
         partida.setAceptadoJugador1(false);
         partida.setAceptadoJugador2(false);
-        partida.setRevanchaCount(partida.getRevanchaCount() + 1);
-
         Partida saved = partidaRepository.save(partida);
-        matchSseService.notifyMatchFound(saved, true);
-
         return partidaMapper.toDto(saved);
     }
   
@@ -243,27 +220,6 @@ public class PartidaService {
         return partidaMapper.toDto(saved);
     }
 
-    @Transactional
-    public PartidaResponse forzarRevancha(UUID partidaId) {
-        Partida partida = partidaRepository.findByIdForUpdate(partidaId)
-                .orElseThrow(() -> new ResourceNotFoundException("Partida no encontrada"));
-
-        partida.setValidada(false);
-        partida.setEstado(EstadoPartida.PENDIENTE);
-        partida.setGanador(null);
-        partida.setResultadoJugador1(null);
-        partida.setResultadoJugador2(null);
-        partida.setCapturaJugador1(null);
-        partida.setCapturaJugador2(null);
-        partida.setAceptadoJugador1(false);
-        partida.setAceptadoJugador2(false);
-        partida.setRevanchaCount(partida.getRevanchaCount() + 1);
-
-        Partida saved = partidaRepository.save(partida);
-        matchSseService.notifyMatchFound(saved, true);
-
-        return partidaMapper.toDto(saved);
-    }
 
     private void registrarReembolso(co.com.arena.real.domain.entity.Jugador jugador, java.math.BigDecimal monto) {
         if (jugador == null) {

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/PartidaResultadoRequest.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/PartidaResultadoRequest.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class PartidaResultadoRequest {
     private String jugadorId;
-    private String resultado; // VICTORIA, DERROTA o EMPATE
+    private String resultado; // VICTORIA o DERROTA
     private String captura;
 }

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/MatchSseDto.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rs/MatchSseDto.java
@@ -23,6 +23,5 @@ public class MatchSseDto implements Serializable {
     private String jugadorOponenteTag;
     private String jugadorOponenteNombre;
     private UUID chatId;
-    private boolean revancha;
 
 }

--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -12,7 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
-import { Send, Link as LinkIconLucide, CheckCircle, XCircle, UploadCloud, Repeat } from 'lucide-react';
+import { Send, Link as LinkIconLucide, CheckCircle, XCircle, UploadCloud } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
 import useFirestoreChat from '@/hooks/useFirestoreChat';
 import { BACKEND_URL } from '@/lib/config';
@@ -297,7 +297,7 @@ const ChatPageContent = () => {
     toast({ title: "Link de Amigo Compartido", description: `Tu link de amigo ${user.friendLink ? '' : '(o un aviso de que no lo tienes) '}ha sido publicado en el chat.` });
   };
 
-  const handleResultSubmission = async (result: 'win' | 'loss' | 'draw') => {
+  const handleResultSubmission = async (result: 'win' | 'loss') => {
     if (!user || !user.id || resultSubmitted) {
       toast({ title: 'Error', description: 'No se puede enviar el resultado sin identificación de usuario.', variant: 'destructive' })
       return
@@ -325,7 +325,7 @@ const ChatPageContent = () => {
     const response = await submitMatchResultAction(
       validPartidaId,
       user.id,
-      result === 'win' ? 'VICTORIA' : result === 'loss' ? 'DERROTA' : 'EMPATE',
+      result === 'win' ? 'VICTORIA' : 'DERROTA',
       screenshotBase64,
     )
 
@@ -337,7 +337,7 @@ const ChatPageContent = () => {
     toast({
       title: "¡Resultado Enviado!",
       description: `Reportaste ${
-        result === 'win' ? 'una victoria' : result === 'loss' ? 'una derrota' : 'un empate'
+        result === 'win' ? 'una victoria' : 'una derrota'
       }. ${screenshotFile ? 'Comprobante adjuntado.' : 'Sin comprobante.'} Esperando al oponente si es necesario, o verificación del administrador.`,
       variant: "default",
     });
@@ -348,7 +348,7 @@ const ChatPageContent = () => {
     
      const userDisplayName = user.clashTag || user.username;
      const resultMessageText = `${userDisplayName} envió el resultado del duelo como ${
-       result === 'win' ? 'VICTORIA' : result === 'loss' ? 'DERROTA' : 'EMPATE'
+       result === 'win' ? 'VICTORIA' : 'DERROTA'
      }. ${screenshotFile ? 'Captura de pantalla proporcionada.' : 'No se proporcionó captura.'}`;
     const resultSystemMessage = {
       matchId: validChatId, // ID del chat (UUID)
@@ -473,15 +473,6 @@ const ChatPageContent = () => {
                   disabled={!chatActive}
                 >
                   Gané
-                </CartoonButton>
-                <CartoonButton
-                  variant="secondary"
-                  onClick={() => handleResultSubmission('draw')}
-                  className="flex-1"
-                  disabled={!chatActive}
-                  iconLeft={<Repeat />}
-                >
-                  Empate
                 </CartoonButton>
                 <CartoonButton
                   variant="destructive"

--- a/front/src/app/history/page.tsx
+++ b/front/src/app/history/page.tsx
@@ -7,7 +7,6 @@ import { useAuth } from '@/hooks/useAuth';
 import type { Bet, BackendPartidaResponseDto } from '@/types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollTextIcon, VictoryIcon, DefeatIcon, InfoIcon } from '@/components/icons/ClashRoyaleIcons';
-import { Repeat } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from '@/components/ui/badge';
 import { getUserDuelsAction } from '@/lib/actions';
@@ -79,7 +78,6 @@ const HistoryPageContent = () => {
 
   const wonBets = bets.filter(bet => bet.result === 'win');
   const lostBets = bets.filter(bet => bet.result === 'loss');
-  const drawBets = bets.filter(bet => bet.result === 'draw');
   const pendingBets = bets.filter(bet => !bet.result);
 
   const BetCard = ({ bet }: { bet: Bet }) => {
@@ -101,8 +99,6 @@ const HistoryPageContent = () => {
                 ? 'default'
                 : bet.result === 'loss'
                 ? 'destructive'
-                : bet.result === 'draw'
-                ? 'secondary'
                 : 'secondary'
             }
             className={`capitalize ${
@@ -110,12 +106,10 @@ const HistoryPageContent = () => {
                 ? 'bg-green-500 text-white'
                 : bet.result === 'loss'
                 ? 'bg-destructive text-destructive-foreground'
-                : bet.result === 'draw'
-                ? 'bg-secondary text-secondary-foreground'
                 : 'bg-muted text-muted-foreground'
             }`}
           >
-            {bet.result === 'draw' ? 'empate' : bet.result || bet.status || 'Pendiente'}
+            {bet.result || bet.status || 'Pendiente'}
           </Badge>
         </div>
       </CardHeader>
@@ -127,7 +121,6 @@ const HistoryPageContent = () => {
           </div>
           {bet.result === 'win' && <VictoryIcon className="h-8 w-8 text-green-500" />}
           {bet.result === 'loss' && <DefeatIcon className="h-8 w-8 text-destructive" />}
-          {bet.result === 'draw' && <Repeat className="h-8 w-8 text-secondary" />}
           {!bet.result && <InfoIcon className="h-8 w-8 text-muted-foreground" />}
         </div>
       </CardContent>
@@ -150,7 +143,6 @@ const HistoryPageContent = () => {
             <TabsTrigger value="all" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-md hover:bg-primary/20">Todos ({bets.length})</TabsTrigger>
             <TabsTrigger value="ganadas" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-green-500 data-[state=active]:text-white data-[state=active]:shadow-md hover:bg-primary/20">Ganadas ({wonBets.length})</TabsTrigger>
             <TabsTrigger value="perdidas" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-destructive data-[state=active]:text-destructive-foreground data-[state=active]:shadow-md hover:bg-primary/20">Perdidas ({lostBets.length})</TabsTrigger>
-            <TabsTrigger value="empates" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-secondary data-[state=active]:text-secondary-foreground data-[state=active]:shadow-md hover:bg-primary/20">Empates ({drawBets.length})</TabsTrigger>
           </TabsList>
           
           <TabsContent value="all">
@@ -172,13 +164,6 @@ const HistoryPageContent = () => {
               <p className="text-center text-muted-foreground py-8">No has perdido ninguna apuesta todavía.</p>
             ) : (
               lostBets.map((bet) => <BetCard key={bet.id} bet={bet} />)
-            )}
-          </TabsContent>
-          <TabsContent value="empates">
-            {drawBets.length === 0 ? (
-              <p className="text-center text-muted-foreground py-8">No tienes empates registrados.</p>
-            ) : (
-              drawBets.map((bet) => <BetCard key={bet.id} bet={bet} />)
             )}
           </TabsContent>
         </Tabs>

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -42,7 +42,7 @@ const HomePageContent = () => {
 
 
   const [isSearching, setIsSearching] = useState(false);
-  const [pendingMatch, setPendingMatch] = useState<{ apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; jugadorOponenteNombre: string; chatId?: string; revancha?: boolean; } | null>(null);
+  const [pendingMatch, setPendingMatch] = useState<{ apuestaId: string; partidaId: string; jugadorOponenteId: string; jugadorOponenteTag: string; jugadorOponenteNombre: string; chatId?: string; } | null>(null);
   const [hasAccepted, setHasAccepted] = useState(false);
   const [opponentAccepted, setOpponentAccepted] = useState(false);
   const [timeLeft, setTimeLeft] = useState(25);
@@ -501,12 +501,10 @@ const HomePageContent = () => {
           <Card className="w-full max-w-md shadow-xl border-2 border-accent">
             <CardHeader>
               <CardTitle className="text-3xl font-headline text-accent text-center">
-                {pendingMatch.revancha ? '¡Revancha!' : '¡Duelo encontrado!'}
+                ¡Duelo encontrado!
               </CardTitle>
               <CardDescription className="text-center text-muted-foreground">
-                {pendingMatch.revancha
-                  ? `¿Quieres aceptar la revancha contra ${pendingMatch.jugadorOponenteNombre}?`
-                  : `Contra ${pendingMatch.jugadorOponenteNombre}`}
+                Contra {pendingMatch.jugadorOponenteNombre}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">

--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -9,7 +9,6 @@ export interface MatchEventData {
   jugadorOponenteTag: string;
   jugadorOponenteNombre: string;
   chatId?: string;
-  revancha?: boolean;
 }
 
 export default function useMatchmakingSse(

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -355,7 +355,7 @@ export async function assignMatchWinnerAction(
 export async function submitMatchResultAction(
   matchId: string,
   jugadorId: string,
-  result: 'VICTORIA' | 'DERROTA' | 'EMPATE',
+  result: 'VICTORIA' | 'DERROTA',
   screenshot?: string,
 ): Promise<{ duel: BackendPartidaResponseDto | null; error: string | null }> {
   try {

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -150,7 +150,7 @@ export type RegisterWithGoogleData = {
 
 
 export type MatchStatus = 'pending' | 'active' | 'completed' | 'cancelled';
-export type MatchResult = 'win' | 'loss' | 'draw';
+export type MatchResult = 'win' | 'loss';
 
 export interface Bet {
   id: string; // ID de la apuesta (del backend, UUID)

--- a/shared-core/src/main/java/co/com/arena/real/domain/entity/partida/ResultadoJugador.java
+++ b/shared-core/src/main/java/co/com/arena/real/domain/entity/partida/ResultadoJugador.java
@@ -2,6 +2,5 @@ package co.com.arena.real.domain.entity.partida;
 
 public enum ResultadoJugador {
     VICTORIA,
-    DERROTA,
-    EMPATE
+    DERROTA
 }


### PR DESCRIPTION
## Summary
- drop rematch SSE event and related admin endpoint
- disallow EMPATE result in backend and frontend
- update matchmaking hooks and pages
- simplify history view

## Testing
- `npm run lint` *(fails: next not found)*
- `mvn -q -pl back -am test -DskipTests` *(fails: repository unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_688079f81218832893dae3a1f0ba1ccd