### PR TITLE
Add Firestore chat endpoints

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/ChatController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/ChatController.java
@@ -2,13 +2,10 @@ package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.ChatService;
 import co.com.arena.real.application.service.PartidaService;
+import co.com.arena.real.infrastructure.dto.rq.ShareLinkRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 import java.util.UUID;
@@ -35,4 +32,16 @@ public class ChatController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @PostMapping("/{chatId}/start-message")
+    public ResponseEntity<Void> startMessage(@PathVariable UUID chatId) {
+        chatService.enviarMensajeInicio(chatId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{chatId}/share-link")
+    public ResponseEntity<Void> shareLink(@PathVariable UUID chatId,
+                                          @RequestBody ShareLinkRequest request) {
+        chatService.compartirLink(chatId, request.getText());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/ChatService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/ChatService.java
@@ -88,6 +88,35 @@ public class ChatService {
             log.warn("Firestore no configurado, se omite el cierre del chat en Firestore");
         }
     }
+
+    private void enviarMensajeSistema(UUID chatId, String text) {
+        if (firestore == null) {
+            log.warn("Firestore no configurado, se omite el envío del mensaje de sistema");
+            return;
+        }
+        try {
+            java.util.Map<String, Object> msg = new java.util.HashMap<>();
+            msg.put("senderId", "system");
+            msg.put("text", text);
+            msg.put("timestamp", com.google.cloud.Timestamp.now());
+            msg.put("isSystemMessage", true);
+
+            firestore.collection("chats")
+                    .document(chatId.toString())
+                    .collection("messages")
+                    .add(msg);
+        } catch (Exception e) {
+            log.error("Error al enviar mensaje de sistema", e);
+        }
+    }
+
+    public void enviarMensajeInicio(UUID chatId) {
+        enviarMensajeSistema(chatId, "Partida iniciada");
+    }
+
+    public void compartirLink(UUID chatId, String text) {
+        enviarMensajeSistema(chatId, text);
+    }
 }
 
 

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/ShareLinkRequest.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/ShareLinkRequest.java
@@ -1,0 +1,9 @@
+package co.com.arena.real.infrastructure.dto.rq;
+
+import lombok.Data;
+
+@Data
+public class ShareLinkRequest {
+    private String link;
+    private String text;
+}

--- a/front/src/app/register/page.tsx
+++ b/front/src/app/register/page.tsx
@@ -138,13 +138,13 @@ export default function RegisterPage() {
     }
     setIsLoading(true);
 
-    const fullRegistrationData: RegisterWithGoogleData = {
-      googleId: googleAuthData.googleId,
-      email: googleAuthData.email,
-      username: profileData.username,
-      avatarUrl: googleAuthData.avatarUrl,
-      phone: profileData.phone,
-      friendLink: profileData.friendLink,
+      const fullRegistrationData: RegisterWithGoogleData = {
+        googleId: googleAuthData.googleId,
+        email: googleAuthData.email || '',
+        username: profileData.username,
+        avatarUrl: googleAuthData.avatarUrl,
+        phone: profileData.phone,
+        friendLink: profileData.friendLink,
       referralCode: profileData.referralCode || undefined,
     };
 

--- a/front/src/hooks/useFirestoreChat.ts
+++ b/front/src/hooks/useFirestoreChat.ts
@@ -31,12 +31,18 @@ export default function useFirestoreChat(chatId: string | undefined) {
         const msgs: ChatMessage[] = [];
         snapshot.forEach(doc => {
           const data = doc.data();
+          let timestamp: string;
+          if (data.timestamp && typeof (data.timestamp.toDate) === 'function') {
+            timestamp = data.timestamp.toDate().toISOString();
+          } else {
+            timestamp = new Date().toISOString();
+          }
           msgs.push({
             id: doc.id,
             matchId: chatId,
             senderId: data.senderId,
             text: data.text,
-            timestamp: data.timestamp.toDate().toISOString(),
+            timestamp,
             isSystemMessage: data.isSystemMessage || false,
           });
         });


### PR DESCRIPTION
## Summary
- add endpoints for posting start messages and sharing links
- handle optional timestamp in `useFirestoreChat`
- fix register page type error

## Testing
- `npm install`
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run typecheck`
- `mvn -DskipTests package` *(fails: unable to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6880880296888328b683d2e19fc53d45