### PR TITLE
Add chat result message endpoint

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/ChatController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/ChatController.java
@@ -3,6 +3,7 @@ package co.com.arena.real.application.controller;
 import co.com.arena.real.application.service.ChatService;
 import co.com.arena.real.application.service.PartidaService;
 import co.com.arena.real.infrastructure.dto.rq.ShareLinkRequest;
+import co.com.arena.real.infrastructure.dto.rq.ResultMessageRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -42,6 +43,13 @@ public class ChatController {
     public ResponseEntity<Void> shareLink(@PathVariable UUID chatId,
                                           @RequestBody ShareLinkRequest request) {
         chatService.compartirLink(chatId, request.getText());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{chatId}/result-message")
+    public ResponseEntity<Void> resultMessage(@PathVariable UUID chatId,
+                                              @RequestBody ResultMessageRequest request) {
+        chatService.enviarMensajeResultado(chatId, request.getText());
         return ResponseEntity.ok().build();
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/ChatService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/ChatService.java
@@ -117,6 +117,10 @@ public class ChatService {
     public void compartirLink(UUID chatId, String text) {
         enviarMensajeSistema(chatId, text);
     }
+
+    public void enviarMensajeResultado(UUID chatId, String text) {
+        enviarMensajeSistema(chatId, text);
+    }
 }
 
 

--- a/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/ResultMessageRequest.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/dto/rq/ResultMessageRequest.java
@@ -1,0 +1,8 @@
+package co.com.arena.real.infrastructure.dto.rq;
+
+import lombok.Data;
+
+@Data
+public class ResultMessageRequest {
+    private String text;
+}

--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -357,7 +357,11 @@ const ChatPageContent = () => {
       timestamp: new Date().toISOString(),
       isSystemMessage: true,
     };
-    sendMessageSafely(resultSystemMessage);
+    fetch(`${BACKEND_URL}/api/chats/${encodeURIComponent(validChatId)}/result-message`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: resultMessageText })
+    }).catch(err => console.error('Error enviando mensaje de resultado', err));
   };
 
 


### PR DESCRIPTION
## Summary
- allow sending result system messages via ChatService
- expose POST `/api/chats/{chatId}/result-message`
- call the new backend endpoint from the chat page

## Testing
- `npm run lint` *(fails: prompts to configure eslint)*
- `npm run typecheck`
- `mvn -q -DskipTests package` *(fails: could not resolve spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_b_688151d88ba88328aafd37c62ff35c73