### PR TITLE
Implement saldo update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ When an admin marks a transaction as **ENTREGADA** in the admin console:
 
 1. `AdminService` calls `TransaccionService.aprobarTransaccion` in the admin backend.
 2. The admin backend sends two requests to the main backend:
-   - `/api/actualizar-saldo` triggers a balance refresh and sends SSE events.
+   - `POST /api/actualizar-saldo` looks up the player's balance and emits a `saldo-actualizar` SSE event.
    - `/api/internal/notify-transaction-approved` emits a `transaccion-aprobada` event over SSE.
 3. The user client now uses `useTransactionUpdates` to receive these notifications in real time.
    If the connection was lost, the hook refreshes data when the page becomes visible or after reconnecting.

--- a/back/src/main/java/co/com/arena/real/application/controller/SaldoController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/SaldoController.java
@@ -1,0 +1,27 @@
+package co.com.arena.real.application.controller;
+
+import co.com.arena.real.application.service.JugadorService;
+import co.com.arena.real.application.service.SseService;
+import co.com.arena.real.infrastructure.dto.rq.SaldoUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class SaldoController {
+
+    private final JugadorService jugadorService;
+    private final SseService sseService;
+
+    @PostMapping("/actualizar-saldo")
+    public ResponseEntity<Void> actualizarSaldo(@RequestBody SaldoUpdateRequest request) {
+        jugadorService.obtenerSaldo(request.getUserId())
+                .ifPresent(saldo -> sseService.sendEvent(request.getUserId(), "saldo-actualizar", saldo));
+        return ResponseEntity.ok().build();
+    }
+}


### PR DESCRIPTION
## Summary
- add `SaldoController` to notify balance updates via SSE
- document the `/api/actualizar-saldo` endpoint

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68815d8cd9d48328958ea2124f2fe320