### PR TITLE
Implement SSE events for prize transactions

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/events/SaldoActualizadoEvent.java
+++ b/back/src/main/java/co/com/arena/real/application/events/SaldoActualizadoEvent.java
@@ -1,0 +1,6 @@
+package co.com.arena.real.application.events;
+
+import java.math.BigDecimal;
+
+public record SaldoActualizadoEvent(String jugadorId, BigDecimal saldo) {
+}

--- a/back/src/main/java/co/com/arena/real/application/events/SaldoActualizadoEventListener.java
+++ b/back/src/main/java/co/com/arena/real/application/events/SaldoActualizadoEventListener.java
@@ -1,0 +1,19 @@
+package co.com.arena.real.application.events;
+
+import co.com.arena.real.application.service.SseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Component
+@RequiredArgsConstructor
+public class SaldoActualizadoEventListener {
+
+    private final SseService sseService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleSaldoActualizado(SaldoActualizadoEvent event) {
+        sseService.sendEvent(event.jugadorId(), "saldo-actualizar", event.saldo());
+    }
+}

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -27,7 +27,10 @@ import co.com.arena.real.application.service.MatchProposalService;
 import co.com.arena.real.application.service.MatchService;
 import co.com.arena.real.application.service.MatchSseService;
 import co.com.arena.real.application.events.PartidaValidadaEvent;
+import co.com.arena.real.application.events.TransaccionAprobadaEvent;
+import co.com.arena.real.application.events.SaldoActualizadoEvent;
 import co.com.arena.real.application.service.ReferralRewardService;
+import co.com.arena.real.infrastructure.mapper.TransaccionMapper;
 import org.springframework.context.ApplicationEventPublisher;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -57,6 +60,7 @@ public class PartidaService {
     private final MatchSseService matchSseService;
     private final ApplicationEventPublisher eventPublisher;
     private final ReferralRewardService referralRewardService;
+    private final TransaccionMapper transaccionMapper;
 
     private static final Logger log = LoggerFactory.getLogger(PartidaService.class);
 
@@ -165,12 +169,21 @@ public class PartidaService {
             premio.setTipo(TipoTransaccion.PREMIO);
             premio.setEstado(EstadoTransaccion.APROBADA);
             premio.setCreadoEn(LocalDateTime.now());
-            transaccionRepository.save(premio);
+            Transaccion savedPremio = transaccionRepository.save(premio);
 
-            jugadorRepository.findById(partida.getGanador().getId()).ifPresent(u -> {
-                u.setSaldo(u.getSaldo().add(premio.getMonto()));
-                jugadorRepository.save(u);
-            });
+            java.math.BigDecimal nuevoSaldo = null;
+            co.com.arena.real.domain.entity.Jugador ganador = jugadorRepository.findById(partida.getGanador().getId()).orElse(null);
+            if (ganador != null) {
+                ganador.setSaldo(ganador.getSaldo().add(savedPremio.getMonto()));
+                ganador = jugadorRepository.save(ganador);
+                nuevoSaldo = ganador.getSaldo();
+            }
+
+            TransaccionResponse premioDto = transaccionMapper.toDto(savedPremio);
+            eventPublisher.publishEvent(new TransaccionAprobadaEvent(premioDto));
+            if (nuevoSaldo != null) {
+                eventPublisher.publishEvent(new SaldoActualizadoEvent(premioDto.getJugadorId(), nuevoSaldo));
+            }
 
             chatService.cerrarChat(partida.getChatId());
 


### PR DESCRIPTION
## Summary
- notify users of prize transactions via `TransaccionAprobadaEvent`
- publish updated balance with new `SaldoActualizadoEvent`
- handle balance notifications after commit

## Testing
- `mvn -q -DskipTests=true package` *(failed: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68815d8cc72c8328808a70a10f9d0661