### PR TITLE
Emit saldo updates via events

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,10 @@ that points to an accessible Maven repository.
 When an admin marks a transaction as **ENTREGADA** in the admin console:
 
 1. `AdminService` calls `TransaccionService.aprobarTransaccion` in the admin backend.
-2. The admin backend sends two requests to the main backend:
-   - `/api/actualizar-saldo` triggers a balance refresh and sends SSE events.
-   - `/api/internal/notify-transaction-approved` emits a `transaccion-aprobada` event over SSE.
+2. The admin backend notifies the main backend via `/api/internal/notify-transaction-approved`.
+   This triggers two SSE events for the player:
+   - `transaccion-aprobada` with the transaction details.
+   - `saldo-actualizar` with the updated balance.
 3. The user client now uses `useTransactionUpdates` to receive these notifications in real time.
    If the connection was lost, the hook refreshes data when the page becomes visible or after reconnecting.
 

--- a/back/src/main/java/co/com/arena/real/application/events/SaldoActualizadoEvent.java
+++ b/back/src/main/java/co/com/arena/real/application/events/SaldoActualizadoEvent.java
@@ -1,0 +1,6 @@
+package co.com.arena.real.application.events;
+
+import java.math.BigDecimal;
+
+public record SaldoActualizadoEvent(String jugadorId, BigDecimal saldo) {
+}

--- a/back/src/main/java/co/com/arena/real/application/events/SaldoActualizadoEventListener.java
+++ b/back/src/main/java/co/com/arena/real/application/events/SaldoActualizadoEventListener.java
@@ -1,0 +1,19 @@
+package co.com.arena.real.application.events;
+
+import co.com.arena.real.application.service.SseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Component
+@RequiredArgsConstructor
+public class SaldoActualizadoEventListener {
+
+    private final SseService sseService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleSaldoActualizado(SaldoActualizadoEvent event) {
+        sseService.notificarSaldoActualizado(event.jugadorId(), event.saldo());
+    }
+}

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -27,6 +27,7 @@ import co.com.arena.real.application.service.MatchProposalService;
 import co.com.arena.real.application.service.MatchService;
 import co.com.arena.real.application.service.MatchSseService;
 import co.com.arena.real.application.events.PartidaValidadaEvent;
+import co.com.arena.real.application.events.SaldoActualizadoEvent;
 import co.com.arena.real.application.service.ReferralRewardService;
 import org.springframework.context.ApplicationEventPublisher;
 import lombok.RequiredArgsConstructor;
@@ -169,7 +170,8 @@ public class PartidaService {
 
             jugadorRepository.findById(partida.getGanador().getId()).ifPresent(u -> {
                 u.setSaldo(u.getSaldo().add(premio.getMonto()));
-                jugadorRepository.save(u);
+                co.com.arena.real.domain.entity.Jugador savedUser = jugadorRepository.save(u);
+                eventPublisher.publishEvent(new SaldoActualizadoEvent(savedUser.getId(), savedUser.getSaldo()));
             });
 
             chatService.cerrarChat(partida.getChatId());
@@ -235,7 +237,8 @@ public class PartidaService {
 
         jugadorRepository.findById(jugador.getId()).ifPresent(u -> {
             u.setSaldo(u.getSaldo().add(monto));
-            jugadorRepository.save(u);
+            co.com.arena.real.domain.entity.Jugador savedUser = jugadorRepository.save(u);
+            eventPublisher.publishEvent(new SaldoActualizadoEvent(savedUser.getId(), savedUser.getSaldo()));
         });
     }
 

--- a/back/src/main/java/co/com/arena/real/application/service/SseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/SseService.java
@@ -96,6 +96,23 @@ public class SseService {
         }
     }
 
+    public void notificarSaldoActualizado(String jugadorId, java.math.BigDecimal saldo) {
+        EmitterWrapper wrapper = emitters.get(jugadorId);
+        if (wrapper == null) {
+            return;
+        }
+
+        try {
+            wrapper.emitter.send(SseEmitter.event()
+                    .name("saldo-actualizar")
+                    .data(saldo));
+            wrapper.lastAccess = System.currentTimeMillis();
+        } catch (IOException e) {
+            removeEmitter(jugadorId);
+            wrapper.emitter.completeWithError(e);
+        }
+    }
+
     public void sendEvent(String jugadorId, String eventName, Object data) {
         EmitterWrapper wrapper = emitters.get(jugadorId);
         if (wrapper == null) {

--- a/back/src/main/java/co/com/arena/real/application/service/TransaccionService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TransaccionService.java
@@ -1,6 +1,7 @@
 package co.com.arena.real.application.service;
 
 import co.com.arena.real.application.events.TransaccionAprobadaEvent;
+import co.com.arena.real.application.events.SaldoActualizadoEvent;
 import co.com.arena.real.domain.entity.EstadoTransaccion;
 import co.com.arena.real.domain.entity.Jugador;
 import co.com.arena.real.domain.entity.Transaccion;
@@ -79,6 +80,7 @@ public class TransaccionService {
             }
         }
 
-        jugadorRepository.save(jugador);
+        Jugador updated = jugadorRepository.save(jugador);
+        eventPublisher.publishEvent(new SaldoActualizadoEvent(updated.getId(), updated.getSaldo()));
     }
 }


### PR DESCRIPTION
## Summary
- remove `SaldoController` endpoint
- introduce `SaldoActualizadoEvent` and listener
- publish balance update events from transaction and match services
- document SSE flow in README

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68815d8cd9d48328958ea2124f2fe320