### PR TITLE
Annotate historial query as read-only

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -68,6 +68,7 @@ public class PartidaService {
         return partidaRepository.findByApuesta_Id(apuestaId).map(partidaMapper::toDto);
     }
 
+    @Transactional(readOnly = true)
     public java.util.List<PartidaResponse> listarHistorial(String jugadorId) {
         return partidaRepository.findByJugadorAndEstado(jugadorId, EstadoPartida.FINALIZADA)
                 .stream()


### PR DESCRIPTION
## Summary
- mark `listarHistorial` as a read-only transaction

## Testing
- `mvn -q -pl back test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688177fa6a908328a4d16b12154a0163