### PR TITLE
Handle balance update after admin notifications

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
@@ -1,6 +1,7 @@
 package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.SseService;
+import co.com.arena.real.application.service.JugadorService;
 import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminNotificationController {
 
     private final SseService sseService;
+    private final JugadorService jugadorService;
 
     @Value("${admin.secret.token:}")
     private String adminToken;
@@ -34,6 +36,8 @@ public class AdminNotificationController {
         }
         log.info("\uD83D\uDCE5 Backend recibió notificación de transacción aprobada. Transacción ID: {}, Jugador ID: {}", dto.getId(), dto.getJugadorId());
         sseService.notificarTransaccionAprobada(dto);
+        jugadorService.obtenerSaldo(dto.getJugadorId())
+                .ifPresent(saldo -> sseService.sendEvent(dto.getJugadorId(), "saldo-actualizar", saldo));
         return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
## Summary
- inject JugadorService in AdminNotificationController
- send a `saldo-actualizar` SSE event after notifying transaction approval

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688181efab908328ad6e2c94adfbca56