### PR TITLE
Notify prize distribution via SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ When an admin marks a transaction as **ENTREGADA** in the admin console:
 3. The user client now uses `useTransactionUpdates` to receive these notifications in real time.
    If the connection was lost, the hook refreshes data when the page becomes visible or after reconnecting.
 
+## Prize distribution
+
+When an admin distributes a prize from the admin panel:
+
+1. `AdminService` calls `PartidaService.marcarComoValidada` in the admin backend.
+2. The created `TransaccionResponse` is sent to the main backend via `/api/internal/notify-prize-distributed`.
+3. That endpoint emits `transaccion-aprobada` and `saldo-actualizar` SSE events so the winner's balance updates in real time.
+
 ## Referral system
 
 Two new endpoints implement a simple referral program:

--- a/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
+++ b/admin-back/src/main/java/com/example/admin/application/service/AdminService.java
@@ -154,7 +154,12 @@ public class AdminService {
 
     @Transactional
     public void distributePrize(UUID gameId) {
-        partidaService.marcarComoValidada(gameId);
+        TransaccionResponse premio = partidaService.marcarComoValidada(gameId);
+        if (premio != null) {
+            log.info("➡️ Premio generado. Notificando al backend principal... Jugador ID: {}, Transacción ID: {}",
+                    premio.getJugadorId(), premio.getId());
+            usersBackendClient.notifyPrizeDistributed(premio);
+        }
     }
 
     @Transactional

--- a/admin-back/src/main/java/com/example/admin/infrastructure/client/UsersBackendClient.java
+++ b/admin-back/src/main/java/com/example/admin/infrastructure/client/UsersBackendClient.java
@@ -43,4 +43,23 @@ public class UsersBackendClient {
             log.error("\u274C Error al enviar notificación al backend principal", e);
         }
     }
+
+    public void notifyPrizeDistributed(TransaccionResponse dto) {
+        String url = backendUrl + "/api/internal/notify-prize-distributed";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Admin-Secret", backendToken);
+        HttpEntity<TransaccionResponse> entity = new HttpEntity<>(dto, headers);
+
+        try {
+            retryTemplate.execute(ctx -> {
+                log.info("\uD83D\uDCE4 Enviando notificación de premio al backend: {} -> {}", dto.getId(), url);
+                restTemplate.exchange(url, HttpMethod.POST, entity, Void.class);
+                log.info("\u2705 Notificación de premio enviada correctamente para transacción {}", dto.getId());
+                return null;
+            });
+        } catch (Exception e) {
+            log.error("\u274C Error al enviar notificación de premio al backend principal", e);
+        }
+    }
 }

--- a/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
@@ -40,4 +40,20 @@ public class AdminNotificationController {
                 .ifPresent(saldo -> sseService.sendEvent(dto.getJugadorId(), "saldo-actualizar", saldo));
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/notify-prize-distributed")
+    public ResponseEntity<Void> notifyPrizeDistributed(
+            @RequestHeader(value = "X-Admin-Secret", required = false) String secret,
+            @RequestBody TransaccionResponse dto) {
+        if (adminToken == null || !adminToken.equals(secret)) {
+            log.warn("\uD83D\uDD12 Token admin inválido recibido en notificación de premio.");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        log.info("\uD83C\uDFC6 Backend recibió notificación de premio. Transacción ID: {}, Jugador ID: {}",
+                dto.getId(), dto.getJugadorId());
+        sseService.notificarTransaccionAprobada(dto);
+        jugadorService.obtenerSaldo(dto.getJugadorId())
+                .ifPresent(saldo -> sseService.sendEvent(dto.getJugadorId(), "saldo-actualizar", saldo));
+        return ResponseEntity.ok().build();
+    }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -152,7 +152,7 @@ public class PartidaService {
     }
 
     @Transactional
-    public PartidaResponse marcarComoValidada(UUID partidaId) {
+    public TransaccionResponse marcarComoValidada(UUID partidaId) {
         Partida partida = partidaRepository.findByIdForUpdate(partidaId)
                 .orElseThrow(() -> new ResourceNotFoundException("Partida no encontrada"));
         partida.setValidadaEn(LocalDateTime.now());
@@ -187,7 +187,7 @@ public class PartidaService {
             Partida saved = partidaRepository.save(partida);
             PartidaResponse dto = partidaMapper.toDto(saved);
             eventPublisher.publishEvent(new PartidaValidadaEvent(dto));
-            return dto;
+            return premioDto;
         }
 
         partida.setValidada(false);
@@ -200,7 +200,7 @@ public class PartidaService {
         partida.setAceptadoJugador1(false);
         partida.setAceptadoJugador2(false);
         Partida saved = partidaRepository.save(partida);
-        return partidaMapper.toDto(saved);
+        return null;
     }
   
     @Transactional


### PR DESCRIPTION
## Summary
- push prize distribution events from admin backend to main backend via HTTP
- send SSE events to players when a prize is distributed
- expose `/api/internal/notify-prize-distributed` endpoint in the main backend
- document the prize distribution flow

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_68819d0746c8832893b0bec0dcec6ef5