### PR TITLE
Add SSE balance update events

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/SseController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/SseController.java
@@ -1,7 +1,7 @@
 package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.MatchSseService;
-import co.com.arena.real.application.service.SseService;
+import co.com.arena.real.application.service.TransaccionSseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,12 +15,12 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequiredArgsConstructor
 public class SseController {
 
-    private final SseService sseService;
+    private final TransaccionSseService transaccionSseService;
     private final MatchSseService matchSseService;
 
     @GetMapping("/transacciones/{jugadorId}")
     public SseEmitter streamTransacciones(@PathVariable String jugadorId) {
-        return sseService.subscribe(jugadorId);
+        return transaccionSseService.subscribe(jugadorId);
     }
 
     @GetMapping("/matchmaking/{jugadorId}")

--- a/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
@@ -1,6 +1,6 @@
 package co.com.arena.real.application.controller;
 
-import co.com.arena.real.application.service.SseService;
+import co.com.arena.real.application.service.TransaccionSseService;
 import co.com.arena.real.application.service.TransaccionService;
 import co.com.arena.real.infrastructure.dto.rq.TransaccionRequest;
 import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
@@ -27,7 +27,7 @@ import java.util.UUID;
 public class TransaccionController {
 
     private final TransaccionService transaccionService;
-    private final SseService sseService;
+    private final TransaccionSseService transaccionSseService;
 
     @PostMapping
     @Operation(summary = "Registrar transacción", description = "Crea una nueva transacción")
@@ -45,7 +45,7 @@ public class TransaccionController {
 
     @GetMapping("/stream/{jugadorId}")
     public SseEmitter stream(@PathVariable String jugadorId) {
-        return sseService.subscribe(jugadorId); // <- usando tu SseService refactorizado
+        return transaccionSseService.subscribe(jugadorId);
     }
 
     @PostMapping("/{id}/aprobar")

--- a/back/src/main/java/co/com/arena/real/application/events/TransaccionAprobadaEventListener.java
+++ b/back/src/main/java/co/com/arena/real/application/events/TransaccionAprobadaEventListener.java
@@ -1,6 +1,6 @@
 package co.com.arena.real.application.events;
 
-import co.com.arena.real.application.service.SseService;
+import co.com.arena.real.application.service.TransaccionSseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TransaccionAprobadaEventListener {
 
-    private final SseService sseService;
+    private final TransaccionSseService transaccionSseService;
 
     @EventListener
     public void handleTransaccionAprobada(TransaccionAprobadaEvent event) {
-        sseService.notificarTransaccionAprobada(event.transaccion());
+        transaccionSseService.sendTransaccionAprobada(event.transaccion());
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -13,6 +13,7 @@ import co.com.arena.real.infrastructure.repository.PartidaRepository;
 import co.com.arena.real.infrastructure.repository.TransaccionRepository;
 import co.com.arena.real.domain.entity.partida.EstadoPartida;
 import co.com.arena.real.application.service.ChatService;
+import co.com.arena.real.application.service.TransaccionSseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +32,7 @@ public class PartidaService {
     private final JugadorRepository jugadorRepository;
     private final TransaccionRepository transaccionRepository;
     private final ChatService chatService;
+    private final TransaccionSseService transaccionSseService;
 
     public Optional<PartidaResponse> obtenerPorApuestaId(UUID apuestaId) {
         return partidaRepository.findByApuesta_Id(apuestaId).map(partidaMapper::toDto);
@@ -71,6 +73,7 @@ public class PartidaService {
             jugadorRepository.findById(partida.getGanador().getId()).ifPresent(u -> {
                 u.setSaldo(u.getSaldo().add(premio.getMonto()));
                 jugadorRepository.save(u);
+                transaccionSseService.sendSaldoActualizado(u.getId(), u.getSaldo());
             });
         }
 

--- a/back/src/main/java/co/com/arena/real/application/service/TransaccionSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TransaccionSseService.java
@@ -1,18 +1,17 @@
 package co.com.arena.real.application.service;
 
 import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
-@RequiredArgsConstructor
-public class SseService {
+public class TransaccionSseService {
 
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
@@ -23,7 +22,6 @@ public class SseService {
         }
 
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
-
         emitter.onCompletion(() -> removeEmitter(jugadorId));
         emitter.onTimeout(() -> removeEmitter(jugadorId));
         emitter.onError(e -> removeEmitter(jugadorId));
@@ -43,18 +41,31 @@ public class SseService {
         });
     }
 
-    public void notificarTransaccionAprobada(TransaccionResponse dto) {
+    public void sendTransaccionAprobada(TransaccionResponse dto) {
         String jugadorId = dto.getJugadorId();
-
         SseEmitter emitter = emitters.get(jugadorId);
         if (emitter == null) {
             return;
         }
-
         try {
             emitter.send(SseEmitter.event()
                     .name("transaccion-aprobada")
                     .data(dto));
+        } catch (IOException e) {
+            removeEmitter(jugadorId);
+            emitter.completeWithError(e);
+        }
+    }
+
+    public void sendSaldoActualizado(String jugadorId, BigDecimal saldo) {
+        SseEmitter emitter = emitters.get(jugadorId);
+        if (emitter == null) {
+            return;
+        }
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("saldo-actualizar")
+                    .data(saldo));
         } catch (IOException e) {
             removeEmitter(jugadorId);
             emitter.completeWithError(e);

--- a/front/src/hooks/useTransactionUpdates.ts
+++ b/front/src/hooks/useTransactionUpdates.ts
@@ -34,7 +34,16 @@ export default function useTransactionUpdates() {
       }
     };
 
+    const saldoHandler = async () => {
+      try {
+        await refreshUser();
+      } catch (err) {
+        console.error('Error procesando evento SSE', err);
+      }
+    };
+
     es.addEventListener('transaccion-aprobada', handler as EventListener);
+    es.addEventListener('saldo-actualizar', saldoHandler as EventListener);
 
     es.onerror = (err) => {
       console.error('SSE error:', err);
@@ -43,6 +52,7 @@ export default function useTransactionUpdates() {
     return () => {
       if (eventSourceRef.current) {
         eventSourceRef.current.removeEventListener('transaccion-aprobada', handler as EventListener);
+        eventSourceRef.current.removeEventListener('saldo-actualizar', saldoHandler as EventListener);
         eventSourceRef.current.close();
       }
     };


### PR DESCRIPTION
## Summary
- notify front-end balance via `TransaccionSseService`
- send SSE when approving transactions and awarding prizes
- update hooks to listen to `saldo-actualizar`

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve Spring parent)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881cfe18eb083288d3224a5d464b1b5