### PR TITLE
Improve chat document logging

### DIFF
--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -72,6 +72,7 @@ const ChatPageContent = () => {
     const ref = doc(db, 'chats', chatId);
     const ensure = async () => {
       try {
+        console.log('Fetching chat doc', { chatId, uid, opponentGoogleId });
         const snap = await getDoc(ref);
         if (!snap.exists()) {
           await setDoc(ref, {
@@ -93,7 +94,7 @@ const ChatPageContent = () => {
             activo: true,
           });
         } catch (creationErr) {
-          console.error('Error creando documento de chat', creationErr);
+          console.error('Error creando documento de chat', { chatId, uid, opponentGoogleId, error: creationErr });
         }
       }
     };


### PR DESCRIPTION
## Summary
- log `chatId`, `uid`, and `opponentGoogleId` before fetching the chat document
- include those values if chat document creation fails

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_6881d9815880832894db8b8802b927ae