### PR TITLE
Add SaldoService for balance updates

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/ReferralRewardService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/ReferralRewardService.java
@@ -5,6 +5,7 @@ import co.com.arena.real.domain.entity.partida.Partida;
 import co.com.arena.real.domain.entity.referral.ReferralReward;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
 import co.com.arena.real.infrastructure.repository.ReferralRewardRepository;
+import co.com.arena.real.application.service.SaldoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ public class ReferralRewardService {
 
     private final ReferralRewardRepository rewardRepository;
     private final JugadorRepository jugadorRepository;
+    private final SaldoService saldoService;
 
     @Transactional
     public void processPartida(Partida partida) {
@@ -40,6 +42,7 @@ public class ReferralRewardService {
                     .creditedAt(LocalDateTime.now())
                     .build();
             rewardRepository.save(reward);
+            saldoService.acreditarSaldo(inviter.getId(), REWARD_AMOUNT);
         });
         if (!jugador.isHasPlayed()) {
             jugador.setHasPlayed(true);

--- a/back/src/main/java/co/com/arena/real/application/service/SaldoService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/SaldoService.java
@@ -1,0 +1,40 @@
+package co.com.arena.real.application.service;
+
+import co.com.arena.real.application.events.SaldoActualizadoEvent;
+import co.com.arena.real.domain.entity.Jugador;
+import co.com.arena.real.infrastructure.repository.JugadorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class SaldoService {
+
+    private final JugadorRepository jugadorRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void acreditarSaldo(String jugadorId, BigDecimal monto) {
+        Jugador jugador = jugadorRepository.findById(jugadorId)
+                .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado"));
+        jugador.setSaldo(jugador.getSaldo().add(monto));
+        Jugador saved = jugadorRepository.save(jugador);
+        eventPublisher.publishEvent(new SaldoActualizadoEvent(jugadorId, saved.getSaldo()));
+    }
+
+    @Transactional
+    public void debitarSaldo(String jugadorId, BigDecimal monto) {
+        Jugador jugador = jugadorRepository.findById(jugadorId)
+                .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado"));
+        if (jugador.getSaldo().compareTo(monto) < 0) {
+            throw new IllegalArgumentException("Saldo insuficiente para realizar la transacción");
+        }
+        jugador.setSaldo(jugador.getSaldo().subtract(monto));
+        Jugador saved = jugadorRepository.save(jugador);
+        eventPublisher.publishEvent(new SaldoActualizadoEvent(jugadorId, saved.getSaldo()));
+    }
+}

--- a/back/src/main/java/co/com/arena/real/application/service/TransaccionService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TransaccionService.java
@@ -2,13 +2,13 @@ package co.com.arena.real.application.service;
 
 import co.com.arena.real.application.events.TransaccionAprobadaEvent;
 import co.com.arena.real.domain.entity.EstadoTransaccion;
-import co.com.arena.real.domain.entity.Jugador;
 import co.com.arena.real.domain.entity.Transaccion;
 import co.com.arena.real.infrastructure.dto.rq.TransaccionRequest;
 import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
 import co.com.arena.real.infrastructure.mapper.TransaccionMapper;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
 import co.com.arena.real.infrastructure.repository.TransaccionRepository;
+import co.com.arena.real.application.service.SaldoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -26,6 +26,7 @@ public class TransaccionService {
     private final TransaccionMapper transaccionMapper;
     private final JugadorRepository jugadorRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final SaldoService saldoService;
 
     public TransaccionResponse registrarTransaccion(TransaccionRequest dto) {
         Jugador jugador = jugadorRepository.findById(dto.getJugadorId())
@@ -66,19 +67,11 @@ public class TransaccionService {
     }
 
     private void modificarSaldoJugador(Transaccion transaccion) {
-        Jugador jugador = jugadorRepository.findById(transaccion.getJugador().getId())
-                .orElseThrow(() -> new IllegalArgumentException("Jugador no encontrado"));
-
         switch (transaccion.getTipo()) {
-            case DEPOSITO, PREMIO, REEMBOLSO -> jugador.setSaldo(jugador.getSaldo().add(transaccion.getMonto()));
-            case RETIRO, APUESTA -> {
-                if (!(jugador.getSaldo().compareTo(transaccion.getMonto()) >= 0)) {
-                    throw new IllegalArgumentException("Saldo insuficiente para realizar la transacción");
-                }
-                jugador.setSaldo(jugador.getSaldo().subtract(transaccion.getMonto()));
-            }
+            case DEPOSITO, PREMIO, REEMBOLSO ->
+                    saldoService.acreditarSaldo(transaccion.getJugador().getId(), transaccion.getMonto());
+            case RETIRO, APUESTA ->
+                    saldoService.debitarSaldo(transaccion.getJugador().getId(), transaccion.getMonto());
         }
-
-        jugadorRepository.save(jugador);
     }
 }


### PR DESCRIPTION
## Summary
- create `SaldoService` for centralized balance updates
- use `SaldoService` in `TransaccionService`, `PartidaService` and `ReferralRewardService`
- publish balance events through new service

## Testing
- `mvn -pl back -am test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6882a269130c8328b4cda5cdfb525926