### PR TITLE
Publish saldo update after transaction approval

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/TransaccionService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TransaccionService.java
@@ -1,6 +1,7 @@
 package co.com.arena.real.application.service;
 
 import co.com.arena.real.application.events.TransaccionAprobadaEvent;
+import co.com.arena.real.application.events.SaldoActualizadoEvent;
 import co.com.arena.real.domain.entity.EstadoTransaccion;
 import co.com.arena.real.domain.entity.Jugador;
 import co.com.arena.real.domain.entity.Transaccion;
@@ -64,6 +65,10 @@ public class TransaccionService {
 
         TransaccionResponse dto = transaccionMapper.toDto(saved);
         eventPublisher.publishEvent(new TransaccionAprobadaEvent(dto));
+        eventPublisher.publishEvent(new SaldoActualizadoEvent(
+                saved.getJugador().getId(),
+                saved.getJugador().getSaldo()
+        ));
         return dto;
     }
 


### PR DESCRIPTION
## Summary
- emit `SaldoActualizadoEvent` when a transaction is approved so the
  player's balance update is sent after `TransaccionAprobadaEvent`

## Testing
- `mvn -pl back -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6882b444966c8328828c2c2b409db125