### PR TITLE
Add ESLint & Prettier setup for Next.js app

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint", "prettier"],
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "rules": {
+    "prettier/prettier": "error"
+  }
+}

--- a/front/.prettierrc
+++ b/front/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 80,
+  "endOfLine": "lf"
+}

--- a/front/package.json
+++ b/front/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "format": "prettier --write .",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add ESLint configuration using `next/core-web-vitals` and TypeScript rules
- add a Prettier config
- expose `format` script in `front/package.json`
- verified lint and format commands run

## Testing
- `npm run lint` *(shows Prettier errors)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_b_6882b8d8f2248328aaffa89a916fb2a9