### PR TITLE
Replace admin secret with JWT

### DIFF
--- a/back/src/main/java/co/com/arena/real/admin/infrastructure/client/UsersBackendClient.java
+++ b/back/src/main/java/co/com/arena/real/admin/infrastructure/client/UsersBackendClient.java
@@ -29,7 +29,7 @@ public class UsersBackendClient {
         String url = backendUrl + "/api/internal/notify-transaction-approved";
 
         HttpHeaders headers = new HttpHeaders();
-        headers.set("X-Admin-Secret", backendToken);
+        headers.setBearerAuth(backendToken);
         HttpEntity<TransaccionResponse> entity = new HttpEntity<>(dto, headers);
 
         try {
@@ -48,7 +48,7 @@ public class UsersBackendClient {
         String url = backendUrl + "/api/internal/notify-prize-distributed";
 
         HttpHeaders headers = new HttpHeaders();
-        headers.set("X-Admin-Secret", backendToken);
+        headers.setBearerAuth(backendToken);
         HttpEntity<TransaccionResponse> entity = new HttpEntity<>(dto, headers);
 
         try {


### PR DESCRIPTION
## Summary
- validate admin notifications with JwtDecoder
- use Bearer auth when calling backend

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6886c1d557448328b188227e31f9f375