### PR TITLE
Update SecurityConfig for public endpoints

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
             .cors(Customizer.withDefaults())
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/api/admin/auth/login").permitAll()
-                    .anyRequest().hasRole("ADMIN"))
+                    .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                    .anyRequest().permitAll())
             .oauth2ResourceServer(oauth2 -> oauth2
                     .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
         return http.build();


### PR DESCRIPTION
## Summary
- allow all non-admin routes in the security config

## Testing
- `mvn spring-boot:run` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6886f21506848328a62de8f9d8b6b4c8