### PR TITLE
Update security config for public endpoints

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
         http.csrf(csrf -> csrf.disable())
             .cors(Customizer.withDefaults())
             .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/public/**", "/auth/**", "/api/admin/auth/login").permitAll()
+                    .requestMatchers("/public/**", "/auth/**", "/api/admin/auth/login", "/api/register", "/api/jugadores/**").permitAll()
                     .requestMatchers("/api/admin/**").hasRole("ADMIN")
                     .requestMatchers("/api/**").authenticated()
                     .anyRequest().permitAll())


### PR DESCRIPTION
## Summary
- add `/api/register` and `/api/jugadores/**` to the list of public endpoints in `SecurityConfig`

## Testing
- `mvn spring-boot:run` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68872761429c8328bd6c1bb255582701