### PR TITLE
Fix security config to deny unspecified requests

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                     .requestMatchers("/public/**", "/auth/**", "/api/admin/auth/login", "/api/register", "/api/jugadores/**").permitAll()
                     .requestMatchers("/api/admin/**").hasRole("ADMIN")
                     .requestMatchers("/api/**").authenticated()
-                    .anyRequest().permitAll())
+                    .anyRequest().denyAll())
             .oauth2ResourceServer(oauth2 -> oauth2
                     .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
         return http.build();


### PR DESCRIPTION
## Summary
- deny all unmatched requests in `SecurityConfig`

## Testing
- `mvn -q verify` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6887fdfa6a0c8328b6dfb54a21afd7d0