### PR TITLE
Secure SSE controllers with JWT

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/SseController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/SseController.java
@@ -3,11 +3,16 @@ package co.com.arena.real.application.controller;
 import co.com.arena.real.application.service.MatchSseService;
 import co.com.arena.real.application.service.SseService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
@@ -17,19 +22,38 @@ public class SseController {
 
     private final SseService sseService;
     private final MatchSseService matchSseService;
+    private final JwtDecoder jwtDecoder;
 
     @GetMapping("/transacciones/{jugadorId}")
-    public SseEmitter streamTransacciones(@PathVariable String jugadorId) {
+    public SseEmitter streamTransacciones(@PathVariable String jugadorId,
+                                          @RequestParam String token) {
+        validateScope(token);
         return sseService.subscribe(jugadorId);
     }
 
     @GetMapping("/matchmaking/{jugadorId}")
-    public SseEmitter streamMatch(@PathVariable("jugadorId") String jugadorId) {
+    public SseEmitter streamMatch(@PathVariable("jugadorId") String jugadorId,
+                                  @RequestParam String token) {
+        validateScope(token);
         return matchSseService.subscribe(jugadorId);
     }
 
     @GetMapping("/match")
-    public SseEmitter streamMatchLegacy(@RequestParam("jugadorId") String jugadorId) {
+    public SseEmitter streamMatchLegacy(@RequestParam("jugadorId") String jugadorId,
+                                        @RequestParam String token) {
+        validateScope(token);
         return matchSseService.subscribe(jugadorId);
+    }
+
+    private void validateScope(String token) {
+        try {
+            Jwt jwt = jwtDecoder.decode(token);
+            String scope = jwt.getClaimAsString("scope");
+            if (!"USER".equals(scope) && !"ADMIN".equals(scope)) {
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+            }
+        } catch (JwtException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
@@ -9,12 +9,17 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
@@ -28,6 +33,7 @@ public class TransaccionController {
 
     private final TransaccionService transaccionService;
     private final SseService sseService;
+    private final JwtDecoder jwtDecoder;
 
     @PostMapping
     @Operation(summary = "Registrar transacción", description = "Crea una nueva transacción")
@@ -44,7 +50,21 @@ public class TransaccionController {
     }
 
     @GetMapping("/stream/{jugadorId}")
-    public SseEmitter stream(@PathVariable String jugadorId) {
+    public SseEmitter stream(@PathVariable String jugadorId,
+                             @RequestParam String token) {
+        validateScope(token);
         return sseService.subscribe(jugadorId); // <- usando tu SseService refactorizado
+    }
+
+    private void validateScope(String token) {
+        try {
+            Jwt jwt = jwtDecoder.decode(token);
+            String scope = jwt.getClaimAsString("scope");
+            if (!"USER".equals(scope) && !"ADMIN".equals(scope)) {
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+            }
+        } catch (JwtException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
     }
 }

--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/public/**", "/auth/**", "/api/admin/auth/login", "/api/register", "/api/jugadores/**").permitAll()
                     .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                    .requestMatchers("/sse/**").authenticated()
                     .requestMatchers("/api/**").authenticated()
                     .anyRequest().denyAll())
             .oauth2ResourceServer(oauth2 -> oauth2


### PR DESCRIPTION
## Summary
- validate JWT scope in `SseController` and `TransaccionController`
- require `/sse/**` routes to authenticate

## Testing
- `mvn test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6887ff1424508328a97c32afa710f8a3