### PR TITLE
Secure admin endpoints

### DIFF
--- a/back/src/main/java/co/com/arena/real/admin/application/controller/AdminController.java
+++ b/back/src/main/java/co/com/arena/real/admin/application/controller/AdminController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.util.Map;
 
@@ -27,22 +28,26 @@ public class AdminController {
     private final AdminService adminService;
 
     @GetMapping("/images")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<ImageDto>> pendingImages() {
         return ResponseEntity.ok(adminService.listPendingImages());
     }
 
     @PostMapping("/images/{id}/approve")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> approveImage(@PathVariable UUID id) {
         adminService.approveImage(id);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/transactions")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<TransactionDto>> transactions() {
         return ResponseEntity.ok(adminService.listTransactions());
     }
 
     @PostMapping("/transactions/{id}/status")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> changeTransactionStatus(@PathVariable UUID id,
                                                        @RequestBody Map<String, String> body) {
         adminService.changeTransactionStatus(id, body.get("status"));
@@ -50,17 +55,20 @@ public class AdminController {
     }
 
     @GetMapping("/games/results")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Map<String, List<GameResultDto>>> gameResults() {
         return ResponseEntity.ok(Map.of("results", adminService.listGameResults()));
     }
 
     @PostMapping("/games/{id}/distribute")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> distributePrize(@PathVariable UUID id) {
         adminService.distributePrize(id);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/games/{id}/winner/{playerId}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> assignWinner(@PathVariable UUID id,
                                              @PathVariable String playerId) {
         adminService.assignWinner(id, playerId);
@@ -68,6 +76,7 @@ public class AdminController {
     }
 
     @PostMapping("/bets/{id}/state")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> changeBetState(@PathVariable UUID id,
                                                @RequestParam("state") String state) {
         adminService.changeBetState(id, state);

--- a/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @Slf4j
 @RestController
@@ -28,6 +29,7 @@ public class AdminNotificationController {
     private final JwtDecoder jwtDecoder;
 
     @PostMapping("/notify-transaction-approved")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> notifyTransactionApproved(
             @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization,
             @RequestBody TransaccionResponse dto) {
@@ -43,6 +45,7 @@ public class AdminNotificationController {
     }
 
     @PostMapping("/notify-prize-distributed")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> notifyPrizeDistributed(
             @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization,
             @RequestBody TransaccionResponse dto) {


### PR DESCRIPTION
## Summary
- enforce ADMIN role on AdminController endpoints
- enforce ADMIN role on admin notification endpoints

## Testing
- `mvn -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6888025602cc8328999fef2fbeff35f1