### PR TITLE
Update SSE hooks

### DIFF
--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { BACKEND_URL } from '@/lib/config';
+import { auth } from '@/lib/firebase';
 
 export interface MatchEventData {
   apuestaId: string;
@@ -172,10 +173,18 @@ export default function useMatchmakingSse(
     };
     votedHandlerRef.current = votedHandler;
 
-    const connect = (onOpen?: () => void) => {
-      const url = `${BACKEND_URL}/sse/matchmaking/${encodeURIComponent(playerId)}`;
+    const connect = async (onOpen?: () => void) => {
+      let token: string | null = null;
+      if (typeof window !== 'undefined') {
+        try {
+          token = await auth.currentUser?.getIdToken() || null;
+        } catch {
+          token = null;
+        }
+      }
+      const url = `${BACKEND_URL}/sse/matchmaking/${encodeURIComponent(playerId)}${token ? `?token=${token}` : ''}`;
       console.log('Abriendo conexión SSE de matchmaking:', url);
-      const es = new EventSource(url, { withCredentials: true });
+      const es = new EventSource(url);
       eventSourceRef.current = es;
 
       es.onopen = () => {

--- a/front/src/hooks/useTransactionUpdates.ts
+++ b/front/src/hooks/useTransactionUpdates.ts
@@ -3,6 +3,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
 import useNotifications from '@/hooks/useNotifications';
 import { BACKEND_URL } from '@/lib/config';
+import { auth } from '@/lib/firebase';
 
 
 /**
@@ -31,9 +32,17 @@ export default function useTransactionUpdates() {
     };
     document.addEventListener('visibilitychange', onVisibility);
 
-    const connect = () => {
-      const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}`;
-      const es = new EventSource(url, { withCredentials: true });
+    const connect = async () => {
+      let token: string | null = null;
+      if (typeof window !== 'undefined') {
+        try {
+          token = await auth.currentUser?.getIdToken() || null;
+        } catch {
+          token = null;
+        }
+      }
+      const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}${token ? `?token=${token}` : ''}`;
+      const es = new EventSource(url);
       eventSourceRef.current = es;
 
       es.onopen = () => {


### PR DESCRIPTION
## Summary
- fetch Firebase token for transaction updates SSE
- append token to matchmaking SSE endpoint

## Testing
- `npm run lint` *(fails: numerous prettier errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_688808c8712c8328b7415729063c2721