### PR TITLE
Allow Firebase tokens

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/SseController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/SseController.java
@@ -49,9 +49,13 @@ public class SseController {
         try {
             Jwt jwt = jwtDecoder.decode(token);
             String scope = jwt.getClaimAsString("scope");
-            if (!"USER".equals(scope) && !"ADMIN".equals(scope)) {
-                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+            if ("ADMIN".equals(scope) || "USER".equals(scope)) {
+                return;
             }
+            if (jwt.hasClaim("firebase")) {
+                return;
+            }
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         } catch (JwtException e) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }

--- a/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
@@ -60,9 +60,13 @@ public class TransaccionController {
         try {
             Jwt jwt = jwtDecoder.decode(token);
             String scope = jwt.getClaimAsString("scope");
-            if (!"USER".equals(scope) && !"ADMIN".equals(scope)) {
-                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+            if ("ADMIN".equals(scope) || "USER".equals(scope)) {
+                return;
             }
+            if (jwt.hasClaim("firebase")) {
+                return;
+            }
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         } catch (JwtException e) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }


### PR DESCRIPTION
## Summary
- accept Firebase tokens in SSE and transaction controllers

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68880da93e188328ae1a5ae6884b6dcb