### PR TITLE
Fix push token auth

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/PushTokenController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/PushTokenController.java
@@ -1,7 +1,7 @@
 package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.PushNotificationService;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import co.com.arena.real.application.service.TokenValidationService;
 import co.com.arena.real.infrastructure.dto.rq.PushTokenRequest;
 import co.com.arena.real.infrastructure.repository.JugadorRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +10,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,9 +22,17 @@ public class PushTokenController {
 
     private final ObjectProvider<PushNotificationService> pushNotificationService;
     private final JugadorRepository jugadorRepository;
+    private final TokenValidationService tokenValidationService;
 
     @PostMapping("/register")
-    public ResponseEntity<Void> register(@RequestBody PushTokenRequest request) {
+    public ResponseEntity<Void> register(
+            @RequestBody PushTokenRequest request,
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            tokenValidationService.validate(authHeader.substring(7));
+        } else {
+            tokenValidationService.validate(null);
+        }
         return jugadorRepository.findById(request.getJugadorId())
                 .map(jugador -> {
                     PushNotificationService svc = pushNotificationService.getIfAvailable();

--- a/back/src/main/java/co/com/arena/real/application/controller/SseController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/SseController.java
@@ -3,16 +3,12 @@ package co.com.arena.real.application.controller;
 import co.com.arena.real.application.service.MatchSseService;
 import co.com.arena.real.application.service.SseService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
+import co.com.arena.real.application.service.TokenValidationService;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
@@ -22,7 +18,7 @@ public class SseController {
 
     private final SseService sseService;
     private final MatchSseService matchSseService;
-    private final JwtDecoder jwtDecoder;
+    private final TokenValidationService tokenValidationService;
 
     @GetMapping("/transacciones/{jugadorId}")
     public SseEmitter streamTransacciones(@PathVariable String jugadorId,
@@ -46,18 +42,6 @@ public class SseController {
     }
 
     private void validateScope(String token) {
-        try {
-            Jwt jwt = jwtDecoder.decode(token);
-            String scope = jwt.getClaimAsString("scope");
-            if ("ADMIN".equals(scope) || "USER".equals(scope)) {
-                return;
-            }
-            if (jwt.hasClaim("firebase")) {
-                return;
-            }
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
-        } catch (JwtException e) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
-        }
+        tokenValidationService.validate(token);
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
@@ -2,6 +2,7 @@ package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.SseService;
 import co.com.arena.real.application.service.TransaccionService;
+import co.com.arena.real.application.service.TokenValidationService;
 import co.com.arena.real.infrastructure.dto.rq.TransaccionRequest;
 import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,9 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtException;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
@@ -33,7 +31,7 @@ public class TransaccionController {
 
     private final TransaccionService transaccionService;
     private final SseService sseService;
-    private final JwtDecoder jwtDecoder;
+    private final TokenValidationService tokenValidationService;
 
     @PostMapping
     @Operation(summary = "Registrar transacción", description = "Crea una nueva transacción")
@@ -57,18 +55,6 @@ public class TransaccionController {
     }
 
     private void validateScope(String token) {
-        try {
-            Jwt jwt = jwtDecoder.decode(token);
-            String scope = jwt.getClaimAsString("scope");
-            if ("ADMIN".equals(scope) || "USER".equals(scope)) {
-                return;
-            }
-            if (jwt.hasClaim("firebase")) {
-                return;
-            }
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
-        } catch (JwtException e) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
-        }
+        tokenValidationService.validate(token);
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/TokenValidationService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TokenValidationService.java
@@ -1,0 +1,49 @@
+package co.com.arena.real.application.service;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TokenValidationService {
+
+    private final JwtDecoder jwtDecoder;
+    private final ObjectProvider<FirebaseApp> firebaseAppProvider;
+
+    public void validate(String token) {
+        if (token == null || token.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        try {
+            Jwt jwt = jwtDecoder.decode(token);
+            String scope = jwt.getClaimAsString("scope");
+            if ("ADMIN".equals(scope) || "USER".equals(scope)) {
+                return;
+            }
+            if (jwt.hasClaim("firebase")) {
+                return;
+            }
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        } catch (JwtException ex) {
+            FirebaseApp app = firebaseAppProvider.getIfAvailable();
+            if (app != null) {
+                try {
+                    FirebaseAuth.getInstance(app).verifyIdToken(token);
+                    return;
+                } catch (FirebaseAuthException ignore) {
+                }
+            }
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+    }
+}

--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                     .requestMatchers("/public/**", "/auth/**", "/api/admin/auth/login", "/api/register", "/api/jugadores/**").permitAll()
                     .requestMatchers("/api/admin/**").hasRole("ADMIN")
                     .requestMatchers("/api/transacciones/stream/**", "/sse/**").permitAll()
+                    .requestMatchers("/api/push/register").permitAll()
                     .requestMatchers("/api/**").authenticated()
                     .anyRequest().denyAll())
             .oauth2ResourceServer(oauth2 -> oauth2

--- a/front/src/hooks/usePushNotifications.ts
+++ b/front/src/hooks/usePushNotifications.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from 'react';
-import { messaging } from '@/lib/firebase';
+import { messaging, auth } from '@/lib/firebase';
 import { getToken, onMessage } from 'firebase/messaging';
 import { BACKEND_URL } from '@/lib/config';
 import { useAuth } from '@/hooks/useAuth';
@@ -23,9 +23,13 @@ export default function usePushNotifications() {
           const token = await getToken(messaging!, {
             serviceWorkerRegistration: reg
           });
+          const authToken = await auth.currentUser?.getIdToken();
           await fetch(`${BACKEND_URL}/api/push/register`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              'Content-Type': 'application/json',
+              ...(authToken ? { Authorization: `Bearer ${authToken}` } : {})
+            },
             body: JSON.stringify({ jugadorId: user.id, token })
           });
         } catch (err) {


### PR DESCRIPTION
## Summary
- add TokenValidationService and use it to check SSE and transaction tokens
- validate Authorization header on push registration
- remove an unused import

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_688817b82e5083288c1eeebc13a4e0db