### PR TITLE
Fix docs for user role

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,36 +35,36 @@ notifications.
 
 ## API overview
 
-The following table lists the available REST and SSE endpoints, the required HTTP method, expected role and whether a JWT token is required. Public endpoints can be called without authentication, while ADMIN routes expect an `Authorization` header with a valid token.
+The following table lists the available REST and SSE endpoints, the required HTTP method, expected role and whether a JWT token is required. Public endpoints can be called without authentication. ADMIN routes expect an `Authorization` header with a valid token and all other `/api` routes now require a token granting the `USER` role.
 
 | Route | Method | Role | JWT required |
 |-------|--------|------|--------------|
 | `/api/register` | POST | Public | No |
-| `/api/referrals/earnings/{userId}` | GET | Public | No |
+| `/api/referrals/earnings/{userId}` | GET | User | Yes |
 | `/api/push/register` | POST | Public | No |
 | `/api/jugadores` | PUT | Public | No |
 | `/api/jugadores/{id}` | GET | Public | No |
 | `/api/jugadores/{id}/saldo` | GET | Public | No |
-| `/api/partidas/apuesta/{apuestaId}` | GET | Public | No |
-| `/api/partidas/chat/{chatId}` | GET | Public | No |
-| `/api/partidas/{id}/aceptar/{jugadorId}` | PUT | Public | No |
-| `/api/partidas/{id}/cancelar` | PUT | Public | No |
-| `/api/partidas/{id}/resultado` | PUT | Public | No |
-| `/api/partidas/jugador/{jugadorId}` | GET | Public | No |
-| `/api/matchmaking/ejecutar` | POST | Public | No |
-| `/api/matchmaking/cancelar` | POST | Public | No |
-| `/api/matchmaking/declinar` | POST | Public | No |
-| `/api/transacciones` | POST | Public | No |
-| `/api/transacciones/jugador/{id}` | GET | Public | No |
+| `/api/partidas/apuesta/{apuestaId}` | GET | User | Yes |
+| `/api/partidas/chat/{chatId}` | GET | User | Yes |
+| `/api/partidas/{id}/aceptar/{jugadorId}` | PUT | User | Yes |
+| `/api/partidas/{id}/cancelar` | PUT | User | Yes |
+| `/api/partidas/{id}/resultado` | PUT | User | Yes |
+| `/api/partidas/jugador/{jugadorId}` | GET | User | Yes |
+| `/api/matchmaking/ejecutar` | POST | User | Yes |
+| `/api/matchmaking/cancelar` | POST | User | Yes |
+| `/api/matchmaking/declinar` | POST | User | Yes |
+| `/api/transacciones` | POST | User | Yes |
+| `/api/transacciones/jugador/{id}` | GET | User | Yes |
 | `/api/transacciones/stream/{jugadorId}` | GET (SSE) | User/Admin | Yes |
 | `/sse/transacciones/{jugadorId}` | GET (SSE) | User/Admin | Yes |
 | `/sse/matchmaking/{jugadorId}` | GET (SSE) | User/Admin | Yes |
 | `/sse/match` | GET (SSE) | User/Admin | Yes |
-| `/api/chats/between` | GET | Public | No |
-| `/api/chats/partida/{partidaId}` | GET | Public | No |
-| `/api/chats/{chatId}/start-message` | POST | Public | No |
-| `/api/chats/{chatId}/share-link` | POST | Public | No |
-| `/api/chats/{chatId}/result-message` | POST | Public | No |
+| `/api/chats/between` | GET | User | Yes |
+| `/api/chats/partida/{partidaId}` | GET | User | Yes |
+| `/api/chats/{chatId}/start-message` | POST | User | Yes |
+| `/api/chats/{chatId}/share-link` | POST | User | Yes |
+| `/api/chats/{chatId}/result-message` | POST | User | Yes |
 | `/api/internal/notify-transaction-approved` | POST | ADMIN | Yes |
 | `/api/internal/notify-prize-distributed` | POST | ADMIN | Yes |
 | `/api/admin/images` | GET | ADMIN | Yes |

--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                     .requestMatchers("/api/admin/**").hasRole("ADMIN")
                     .requestMatchers("/api/transacciones/stream/**", "/sse/**").permitAll()
                     .requestMatchers("/api/push/register").permitAll()
-                    .requestMatchers("/api/**").authenticated()
+                    .requestMatchers("/api/**").hasRole("USER")
                     .anyRequest().denyAll())
             .oauth2ResourceServer(oauth2 -> oauth2
                     .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));


### PR DESCRIPTION
## Summary
- require `ROLE_USER` for all `/api/**` endpoints in Spring Security
- document user role requirement in the API table

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68886975ff1c83288cffa52e9bac0a4a