### PR TITLE
Improve push registration token handling

### DIFF
--- a/front/src/hooks/usePushNotifications.ts
+++ b/front/src/hooks/usePushNotifications.ts
@@ -23,12 +23,21 @@ export default function usePushNotifications() {
           const token = await getToken(messaging!, {
             serviceWorkerRegistration: reg
           });
-          const authToken = await auth.currentUser?.getIdToken();
+          let authToken: string | null = null;
+          try {
+            authToken = await auth.currentUser?.getIdToken(true) || null;
+          } catch {
+            authToken = null;
+          }
+          if (!authToken) {
+            console.warn('Push registration skipped: no auth token');
+            return;
+          }
           await fetch(`${BACKEND_URL}/api/push/register`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              ...(authToken ? { Authorization: `Bearer ${authToken}` } : {})
+              Authorization: `Bearer ${authToken}`
             },
             body: JSON.stringify({ jugadorId: user.id, token })
           });


### PR DESCRIPTION
## Summary
- refresh Firebase ID token and skip push registration when missing

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: ESLint must be installed)*
- `mvn test` *(fails: could not resolve parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_688932d99efc8328a44fda3fad92cd9f