### PR TITLE
Improve auth checks for matchmaking and push notifications

### DIFF
--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -218,9 +218,23 @@ export default function useMatchmakingSse(
       };
     };
     connectRef.current = connect;
-    connect();
+    let authUnsub: (() => void) | undefined;
+    if (!auth.currentUser) {
+      console.info('Matchmaking SSE skipped: no Firebase user. Waiting for login...');
+      authUnsub = auth.onAuthStateChanged(u => {
+        if (u) {
+          console.info('Firebase user logged in, starting matchmaking SSE');
+          connect();
+          authUnsub && authUnsub();
+          authUnsub = undefined;
+        }
+      });
+    } else {
+      connect();
+    }
 
     return () => {
+      authUnsub && authUnsub();
       console.log('Cerrando conexión SSE de matchmaking');
       disconnect();
 

--- a/front/src/hooks/usePushNotifications.ts
+++ b/front/src/hooks/usePushNotifications.ts
@@ -13,6 +13,10 @@ export default function usePushNotifications() {
     if (!user?.id) return;
     if (!messaging) return;
     if (!('Notification' in window)) return;
+    if (!auth.currentUser) {
+      console.info('Push registration skipped: no Firebase user. Will retry after login.');
+      return;
+    }
 
     navigator.serviceWorker
       .register('/firebase-messaging-sw.js', { scope: '/' })


### PR DESCRIPTION
## Summary
- ensure matchmaking SSE waits for Firebase login before connecting
- guard push notification registration until Firebase auth is available

## Testing
- `npm run lint` *(fails: many existing prettier errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_68894716353c83288c477299f9e2bdde