### PR TITLE
Handle auth before SSE and push registration

### DIFF
--- a/front/src/hooks/useMatchmakingSse.ts
+++ b/front/src/hooks/useMatchmakingSse.ts
@@ -218,9 +218,23 @@ export default function useMatchmakingSse(
       };
     };
     connectRef.current = connect;
-    connect();
+    let authUnsub: (() => void) | undefined;
+    if (!auth.currentUser) {
+      console.info('Matchmaking SSE skipped: no Firebase user. Waiting for login...');
+      authUnsub = auth.onAuthStateChanged(u => {
+        if (u) {
+          console.info('Firebase user logged in, starting matchmaking SSE');
+          connect();
+          authUnsub && authUnsub();
+          authUnsub = undefined;
+        }
+      });
+    } else {
+      connect();
+    }
 
     return () => {
+      authUnsub && authUnsub();
       console.log('Cerrando conexión SSE de matchmaking');
       disconnect();
 

--- a/front/src/hooks/usePushNotifications.ts
+++ b/front/src/hooks/usePushNotifications.ts
@@ -13,44 +13,66 @@ export default function usePushNotifications() {
     if (!user?.id) return;
     if (!messaging) return;
     if (!('Notification' in window)) return;
+    let authUnsub: (() => void) | undefined;
+    let onMessageUnsub: (() => void) | undefined;
 
-    navigator.serviceWorker
-      .register('/firebase-messaging-sw.js', { scope: '/' })
-      .then(async reg => {
-        const perm = await Notification.requestPermission();
-        if (perm !== 'granted') return;
-        try {
-          const token = await getToken(messaging!, {
-            serviceWorkerRegistration: reg
-          });
-          let authToken: string | null = null;
+    const register = () => {
+      navigator.serviceWorker
+        .register('/firebase-messaging-sw.js', { scope: '/' })
+        .then(async reg => {
+          const perm = await Notification.requestPermission();
+          if (perm !== 'granted') return;
           try {
-            authToken = await auth.currentUser?.getIdToken(true) || null;
-          } catch {
-            authToken = null;
+            const token = await getToken(messaging!, {
+              serviceWorkerRegistration: reg
+            });
+            let authToken: string | null = null;
+            try {
+              authToken = (await auth.currentUser?.getIdToken(true)) || null;
+            } catch {
+              authToken = null;
+            }
+            if (!authToken) {
+              console.warn('Push registration skipped: no auth token');
+              return;
+            }
+            await fetch(`${BACKEND_URL}/api/push/register`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${authToken}`
+              },
+              body: JSON.stringify({ jugadorId: user.id, token })
+            });
+          } catch (err) {
+            console.error('FCM registration failed', err);
           }
-          if (!authToken) {
-            console.warn('Push registration skipped: no auth token');
-            return;
-          }
-          await fetch(`${BACKEND_URL}/api/push/register`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${authToken}`
-            },
-            body: JSON.stringify({ jugadorId: user.id, token })
-          });
-        } catch (err) {
-          console.error('FCM registration failed', err);
-        }
-      })
-      .catch(err => console.error('SW registration failed', err));
+        })
+        .catch(err => console.error('SW registration failed', err));
 
-    const unsub = onMessage(messaging!, payload => {
-      const { title, body } = payload.notification || {};
-      if (title) new Notification(title, { body });
-    });
-    return () => unsub();
+      onMessageUnsub = onMessage(messaging!, payload => {
+        const { title, body } = payload.notification || {};
+        if (title) new Notification(title, { body });
+      });
+    };
+
+    if (!auth.currentUser) {
+      console.info('Push registration skipped: no Firebase user. Waiting for login...');
+      authUnsub = auth.onAuthStateChanged(u => {
+        if (u) {
+          console.info('Firebase user logged in, registering push notifications');
+          register();
+          authUnsub && authUnsub();
+          authUnsub = undefined;
+        }
+      });
+    } else {
+      register();
+    }
+
+    return () => {
+      onMessageUnsub && onMessageUnsub();
+      authUnsub && authUnsub();
+    };
   }, [user]);
 }


### PR DESCRIPTION
## Summary
- ensure matchmaking SSE waits for Firebase login before opening
- register push notifications only after a Firebase user exists

## Testing
- `npm run lint` *(fails: many prettier errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68894716353c83288c477299f9e2bdde