### PR TITLE
Fix Firebase popup COOP warning

### DIFF
--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  // Allow Firebase Auth popups to close by using
+  // `same-origin-allow-popups` for the Cross-Origin-Opener-Policy.
+  crossOriginOpenerPolicy: 'same-origin-allow-popups',
   typescript: {
     ignoreBuildErrors: true,
   },
@@ -17,12 +20,9 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-  // The previous configuration attempted to set a custom
-  // Cross-Origin-Opener-Policy header for authentication pages.
-  // This interfered with Firebase Auth popups, causing errors like:
-  // "Cross-Origin-Opener-Policy policy would block the window.close call.".
-  // Removing the header configuration allows Firebase to manage the popup
-  // lifecycle without being blocked by browser policies.
+  // Using the "same-origin-allow-popups" policy avoids the
+  // "Cross-Origin-Opener-Policy policy would block the window.close call" error
+  // logged by Firebase Auth when closing its login popup.
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- tweak Next.js config to allow Google Auth popup to close

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68896c142fa88328a74dedebfa1f1782