### PR TITLE
Handle Firebase token validation

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/TokenValidationService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TokenValidationService.java
@@ -3,6 +3,10 @@ package co.com.arena.real.application.service;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -32,12 +36,32 @@ public class TokenValidationService {
             FirebaseApp app = firebaseAppProvider.getIfAvailable();
             if (app != null) {
                 try {
-                    FirebaseAuth.getInstance(app).verifyIdToken(token);
-                    return java.util.Optional.empty();
+                    FirebaseToken fbToken = FirebaseAuth.getInstance(app).verifyIdToken(token);
+                    Map<String, Object> claims = new HashMap<>(fbToken.getClaims());
+                    claims.put("firebase", true);
+                    Long issued = getLongClaim(claims.get("iat"));
+                    Long expires = getLongClaim(claims.get("exp"));
+                    Jwt.Builder builder = Jwt.withTokenValue(token)
+                            .subject(fbToken.getUid())
+                            .claims(map -> map.putAll(claims));
+                    if (issued != null) {
+                        builder.issuedAt(Instant.ofEpochSecond(issued));
+                    }
+                    if (expires != null) {
+                        builder.expiresAt(Instant.ofEpochSecond(expires));
+                    }
+                    return java.util.Optional.of(builder.build());
                 } catch (FirebaseAuthException ignore) {
                 }
             }
         }
         return java.util.Optional.empty();
+    }
+
+    private Long getLongClaim(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        return null;
     }
 }

--- a/back/src/test/java/co/com/arena/real/application/service/TokenValidationServiceTest.java
+++ b/back/src/test/java/co/com/arena/real/application/service/TokenValidationServiceTest.java
@@ -1,0 +1,43 @@
+package co.com.arena.real.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseToken;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.ObjectProvider;
+
+public class TokenValidationServiceTest {
+
+    @Test
+    void returnsJwtForFirebaseToken() throws Exception {
+        FirebaseToken fbToken = mock(FirebaseToken.class);
+        when(fbToken.getUid()).thenReturn("123");
+        when(fbToken.getClaims()).thenReturn(Map.of("foo", "bar", "iat", 1000L, "exp", 2000L));
+
+        FirebaseApp app = mock(FirebaseApp.class);
+        ObjectProvider<FirebaseApp> provider = () -> app;
+        JwtDecoder decoder = mock(JwtDecoder.class);
+        when(decoder.decode("token")).thenThrow(new JwtException("bad"));
+
+        try (MockedStatic<FirebaseAuth> firebaseAuthMock = mockStatic(FirebaseAuth.class)) {
+            FirebaseAuth auth = mock(FirebaseAuth.class);
+            when(auth.verifyIdToken("token")).thenReturn(fbToken);
+            firebaseAuthMock.when(() -> FirebaseAuth.getInstance(app)).thenReturn(auth);
+
+            TokenValidationService svc = new TokenValidationService(decoder, provider);
+            var result = svc.validate("token");
+            assertThat(result).isPresent();
+            assertThat(result.get().getSubject()).isEqualTo("123");
+            assertThat(result.get().getClaimAsBoolean("firebase")).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `Jwt` from Firebase token in `TokenValidationService`
- add unit test covering Firebase token handling
- fix token validation test to mock `JwtDecoder`

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6889e78ef1a883289dbd432fd095601b