### PR TITLE
Restrict JWT auth to admin endpoints

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -36,11 +36,10 @@ public class SecurityConfig {
             .cors(Customizer.withDefaults())
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/public/**", "/auth/**", "/api/admin/auth/login", "/api/register", "/api/jugadores/**").permitAll()
-                    .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                    .requestMatchers("/api/admin/**", "/api/internal/**").hasRole("ADMIN")
                     .requestMatchers("/api/transacciones/stream/**", "/sse/**").permitAll()
                     .requestMatchers("/api/push/register").permitAll()
-                    .requestMatchers("/api/**").hasRole("USER")
-                    .anyRequest().denyAll())
+                    .anyRequest().permitAll())
             .oauth2ResourceServer(oauth2 -> oauth2
                     .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
         return http.build();


### PR DESCRIPTION
## Summary
- secure only admin and internal endpoints with JWT

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688aadd778a08328836b477a01be6269