### PR TITLE
Integrate Firebase JWT validation

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/TokenValidationService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TokenValidationService.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -19,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TokenValidationService {
 
-    private final JwtDecoder jwtDecoder;
+    private final @Qualifier("hs256JwtDecoder") JwtDecoder jwtDecoder;
     private final ObjectProvider<FirebaseApp> firebaseAppProvider;
 
     public java.util.Optional<Jwt> validate(String token) {


### PR DESCRIPTION
## Summary
- support Firebase JWT in security filter chain
- use HS256 decoder within TokenValidationService

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_688af2cf2e88832892472252ad836e9c