### PR TITLE
Integrate separate JWT flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ The following table lists the available REST and SSE endpoints, the required HTT
 | `/api/matchmaking/declinar` | POST | User | Yes |
 | `/api/transacciones` | POST | User | Yes |
 | `/api/transacciones/jugador/{id}` | GET | User | Yes |
-| `/api/transacciones/stream/{jugadorId}` | GET (SSE) | User/Admin | Yes |
-| `/sse/transacciones/{jugadorId}` | GET (SSE) | User/Admin | Yes |
-| `/sse/matchmaking/{jugadorId}` | GET (SSE) | User/Admin | Yes |
-| `/sse/match` | GET (SSE) | User/Admin | Yes |
+| `/api/transacciones/stream/{jugadorId}` | GET (SSE) | User | Yes |
+| `/sse/transacciones/{jugadorId}` | GET (SSE) | User | Yes |
+| `/sse/matchmaking/{jugadorId}` | GET (SSE) | User | Yes |
+| `/sse/match` | GET (SSE) | User | Yes |
 | `/api/chats/between` | GET | User | Yes |
 | `/api/chats/partida/{partidaId}` | GET | User | Yes |
 | `/api/chats/{chatId}/start-message` | POST | User | Yes |

--- a/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
@@ -3,7 +3,6 @@ package co.com.arena.real.application.controller;
 import co.com.arena.real.application.service.SseService;
 import co.com.arena.real.application.service.JugadorService;
 import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -11,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,12 +21,19 @@ import org.springframework.security.access.prepost.PreAuthorize;
 @Slf4j
 @RestController
 @RequestMapping("/api/internal")
-@RequiredArgsConstructor
 public class AdminNotificationController {
 
     private final SseService sseService;
     private final JugadorService jugadorService;
     private final JwtDecoder jwtDecoder;
+
+    public AdminNotificationController(SseService sseService,
+            JugadorService jugadorService,
+            @Qualifier("hs256JwtDecoder") JwtDecoder jwtDecoder) {
+        this.sseService = sseService;
+        this.jugadorService = jugadorService;
+        this.jwtDecoder = jwtDecoder;
+    }
 
     @PostMapping("/notify-transaction-approved")
     @PreAuthorize("hasRole('ADMIN')")

--- a/back/src/main/java/co/com/arena/real/application/service/FirebaseJwtDecoder.java
+++ b/back/src/main/java/co/com/arena/real/application/service/FirebaseJwtDecoder.java
@@ -1,0 +1,56 @@
+package co.com.arena.real.application.service;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+
+public class FirebaseJwtDecoder implements JwtDecoder {
+
+    private final ObjectProvider<FirebaseApp> firebaseAppProvider;
+
+    public FirebaseJwtDecoder(ObjectProvider<FirebaseApp> firebaseAppProvider) {
+        this.firebaseAppProvider = firebaseAppProvider;
+    }
+
+    @Override
+    public Jwt decode(String token) throws JwtException {
+        FirebaseApp app = firebaseAppProvider.getIfAvailable();
+        if (app == null) {
+            throw new JwtException("Firebase not configured");
+        }
+        try {
+            FirebaseToken fbToken = FirebaseAuth.getInstance(app).verifyIdToken(token);
+            Map<String, Object> claims = new HashMap<>(fbToken.getClaims());
+            claims.put("firebase", true);
+            Long issued = getLongClaim(claims.get("iat"));
+            Long expires = getLongClaim(claims.get("exp"));
+            Jwt.Builder builder = Jwt.withTokenValue(token)
+                    .subject(fbToken.getUid())
+                    .claims(map -> map.putAll(claims));
+            if (issued != null) {
+                builder.issuedAt(Instant.ofEpochSecond(issued));
+            }
+            if (expires != null) {
+                builder.expiresAt(Instant.ofEpochSecond(expires));
+            }
+            return builder.build();
+        } catch (FirebaseAuthException ex) {
+            throw new JwtException("Invalid Firebase token", ex);
+        }
+    }
+
+    private Long getLongClaim(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        return null;
+    }
+}

--- a/back/src/main/java/co/com/arena/real/application/service/TokenValidationService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TokenValidationService.java
@@ -11,16 +11,21 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class TokenValidationService {
 
     private final JwtDecoder jwtDecoder;
     private final ObjectProvider<FirebaseApp> firebaseAppProvider;
+
+    public TokenValidationService(
+            @Qualifier("hs256JwtDecoder") JwtDecoder jwtDecoder,
+            ObjectProvider<FirebaseApp> firebaseAppProvider) {
+        this.jwtDecoder = jwtDecoder;
+        this.firebaseAppProvider = firebaseAppProvider;
+    }
 
     public java.util.Optional<Jwt> validate(String token) {
         if (token == null || token.isBlank()) {

--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package co.com.arena.real.config;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -10,11 +12,19 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -24,6 +34,7 @@ import java.util.List;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import co.com.arena.real.application.service.FirebaseJwtDecoder;
 
 @Configuration
 @EnableMethodSecurity
@@ -31,17 +42,18 @@ import java.nio.charset.StandardCharsets;
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+            AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver) throws Exception {
         http.csrf(csrf -> csrf.disable())
             .cors(Customizer.withDefaults())
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/public/**", "/auth/**", "/api/admin/auth/login", "/api/register", "/api/jugadores/**").permitAll()
                     .requestMatchers("/api/admin/**", "/api/internal/**").hasRole("ADMIN")
-                    .requestMatchers("/api/transacciones/stream/**", "/sse/**").authenticated()
+                    .requestMatchers("/sse/**", "/api/transacciones/**").hasRole("USER")
                     .requestMatchers("/api/push/register").permitAll()
                     .anyRequest().permitAll())
             .oauth2ResourceServer(oauth2 -> oauth2
-                    .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
+                    .authenticationManagerResolver(authenticationManagerResolver));
         return http.build();
     }
 
@@ -66,11 +78,56 @@ public class SecurityConfig {
         return converter;
     }
 
-    @Bean
-    public JwtDecoder jwtDecoder(@Value("${security.jwt-secret}") String secret) {
+    private JwtAuthenticationConverter firebaseAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(jwt -> java.util.List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_USER")));
+        return converter;
+    }
+
+    @Bean("hs256JwtDecoder")
+    public JwtDecoder hs256JwtDecoder(@Value("${security.jwt-secret}") String secret) {
         SecretKey key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
         return NimbusJwtDecoder.withSecretKey(key).build();
     }
+
+    @Bean
+    public JwtDecoder firebaseJwtDecoder(ObjectProvider<com.google.firebase.FirebaseApp> firebaseAppProvider) {
+        return new FirebaseJwtDecoder(firebaseAppProvider);
+    }
+
+    @Bean
+    public AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver(
+            @Qualifier("hs256JwtDecoder") JwtDecoder hs256JwtDecoder,
+            JwtDecoder firebaseJwtDecoder) {
+        JwtAuthenticationProvider adminProvider = new JwtAuthenticationProvider(hs256JwtDecoder);
+        adminProvider.setJwtAuthenticationConverter(jwtAuthenticationConverter());
+
+        JwtAuthenticationProvider firebaseProvider = new JwtAuthenticationProvider(firebaseJwtDecoder);
+        firebaseProvider.setJwtAuthenticationConverter(firebaseAuthenticationConverter());
+
+        AuthenticationManager adminManager = new ProviderManager(adminProvider);
+        AuthenticationManager firebaseManager = new ProviderManager(firebaseProvider);
+
+        return request -> {
+            String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+            if (header != null && header.startsWith("Bearer ")) {
+                String token = header.substring(7);
+                try {
+                    hs256JwtDecoder.decode(token);
+                    return adminManager;
+                } catch (JwtException ex) {
+                    try {
+                        firebaseJwtDecoder.decode(token);
+                        return firebaseManager;
+                    } catch (JwtException ex2) {
+                        return auth -> { throw new BadCredentialsException("Invalid token", ex2); };
+                    }
+                }
+            }
+            return auth -> { throw new BadCredentialsException("Missing bearer token"); };
+        };
+    }
+
 
     @Bean
     @Primary


### PR DESCRIPTION
## Summary
- add Firebase JWT decoder and custom AuthenticationManagerResolver
- restrict `/sse/**` and transaction routes to `ROLE_USER`
- inject HS256 decoder via `@Qualifier`
- update README table for SSE route roles
- fix constructor injection for AdminNotificationController
- use qualifier in TokenValidationService

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_688af2cf2e88832892472252ad836e9c