### PR TITLE
Fix duplicated constructor

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/AdminNotificationController.java
@@ -35,13 +35,6 @@ public class AdminNotificationController {
         this.jwtDecoder = jwtDecoder;
     }
 
-    public AdminNotificationController(SseService sseService,
-            JugadorService jugadorService,
-            @Qualifier("hs256JwtDecoder") JwtDecoder jwtDecoder) {
-        this.sseService = sseService;
-        this.jugadorService = jugadorService;
-        this.jwtDecoder = jwtDecoder;
-    }
 
     @PostMapping("/notify-transaction-approved")
     @PreAuthorize("hasRole('ADMIN')")


### PR DESCRIPTION
## Summary
- remove duplicate constructor in `AdminNotificationController`

## Testing
- `mvn -q -DskipTests install` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_688b13161e488328a086634d7d786a23