### PR TITLE
Improve security exception handling

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -128,15 +128,21 @@ public class SecurityConfig {
                     return adminManager;
                 } catch (JwtException ex) {
                     log.debug("Not an admin token: {}", ex.getMessage());
-                    try {
-                        firebaseJwtDecoder.decode(token);
-                        log.debug("Token validated as Firebase token");
-                        return firebaseManager;
-                    } catch (JwtException ex2) {
-                        log.debug("Invalid token for both decoders: {}", ex2.getMessage());
-                        return auth -> { throw new BadCredentialsException("Invalid token", ex2); };
-                    }
+                } catch (Exception ex) {
+                    log.error("Error decoding admin token", ex);
                 }
+
+                try {
+                    firebaseJwtDecoder.decode(token);
+                    log.debug("Token validated as Firebase token");
+                    return firebaseManager;
+                } catch (JwtException ex2) {
+                    log.debug("Invalid Firebase token: {}", ex2.getMessage());
+                } catch (Exception ex2) {
+                    log.error("Error decoding Firebase token", ex2);
+                }
+
+                return auth -> { throw new BadCredentialsException("Invalid token"); };
             }
             return auth -> { throw new BadCredentialsException("Missing bearer token"); };
         };

--- a/back/src/main/java/co/com/arena/real/infrastructure/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/co/com/arena/real/infrastructure/exception/GlobalExceptionHandler.java
@@ -6,12 +6,18 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(DuplicateUserException.class)
     public ResponseEntity<String> handleDuplicateUser(DuplicateUserException ex) {
@@ -44,5 +50,23 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<String> handleNotFound(ResourceNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<String> handleJwt(JwtException ex) {
+        log.error("Invalid JWT", ex);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token");
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<String> handleAuth(AuthenticationException ex) {
+        log.error("Authentication error", ex);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<String> handleAccess(AccessDeniedException ex) {
+        log.error("Access denied", ex);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Forbidden");
     }
 }


### PR DESCRIPTION
## Summary
- add logging and handling for authentication errors
- return 401/403 instead of 500 by catching JwtException and friends

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688bd3d795688328acb563fa47178e35