### PR TITLE
Add token logging for SSE debug

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -121,6 +121,7 @@ public class SecurityConfig {
             String header = request.getHeader(HttpHeaders.AUTHORIZATION);
             if (header != null && header.startsWith("Bearer ")) {
                 String token = header.substring(7);
+                log.info("Token recibido: {}", token);
                 log.debug("Resolving token for request {} {}", request.getMethod(), request.getRequestURI());
                 try {
                     hs256JwtDecoder.decode(token);


### PR DESCRIPTION
## Summary
- log received token in `AuthenticationManagerResolver` to help debug 401 errors

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_688be0cc480c83289c8a93100926b861