### PR TITLE
Refactor token validation

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -127,7 +127,7 @@ public class SecurityConfig {
                 log.debug("Resolving token for request {} {}", request.getMethod(), request.getRequestURI());
                 try {
                     hs256JwtDecoder.decode(token);
-                    log.debug("Token validated as admin token");
+                    log.debug("Token validated as admin token -> ROLE_ADMIN");
                     return adminManager;
                 } catch (JwtException ex) {
                     log.debug("Not an admin token: {}", ex.getMessage());
@@ -137,7 +137,7 @@ public class SecurityConfig {
 
                 try {
                     firebaseJwtDecoder.decode(token);
-                    log.debug("Token validated as Firebase token");
+                    log.debug("Token validated as Firebase token -> ROLE_USER");
                     return firebaseManager;
                 } catch (JwtException ex2) {
                     log.debug("Invalid Firebase token: {}", ex2.getMessage());


### PR DESCRIPTION
## Summary
- centralize Firebase Jwt building inside `FirebaseJwtDecoder`
- use this decoder from `TokenValidationService`
- log role when resolving tokens in `SecurityConfig` and in the validation service

## Testing
- `mvn -pl back -am package -DskipTests` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom)*

------
https://chatgpt.com/codex/tasks/task_b_688d0a140eb08328bd0ab0241f9ba269