### PR TITLE
Read CORS origins from application properties

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -31,6 +31,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import lombok.extern.slf4j.Slf4j;
 import java.util.List;
+import java.util.Arrays;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -68,9 +69,13 @@ public class SecurityConfig {
     }
 
     @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
+    public CorsConfigurationSource corsConfigurationSource(@Value("${cors.allowed-origins:}") String corsAllowedOrigins) {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:3001"));
+        List<String> origins = Arrays.stream(corsAllowedOrigins.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isBlank())
+                .toList();
+        config.setAllowedOrigins(origins);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -35,5 +35,8 @@ admin:
 
 security:
   jwt-secret: ${SECURITY_JWT_SECRET:${ADMIN_SECURITY_JWT_SECRET}}
+cors:
+  # Allowed origins for CORS; empty list allows none by default
+  allowed-origins: []
 firebase:
   enabled: true


### PR DESCRIPTION
## Summary
- read CORS origins from `cors.allowed-origins` property
- document `cors.allowed-origins` default in application.yml

## Testing
- `mvn -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689150aa80b083288e70d0dffd3ed4dd