### PR TITLE
Secure push token registration via Spring Security

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/JwtDecoderResolver.java
+++ b/back/src/main/java/co/com/arena/real/application/service/JwtDecoderResolver.java
@@ -1,0 +1,52 @@
+package co.com.arena.real.application.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtDecoderResolver {
+
+    private final @Qualifier("hs256JwtDecoder") JwtDecoder jwtDecoder;
+    private final @Qualifier("firebaseJwtDecoder") JwtDecoder firebaseJwtDecoder;
+
+    public Optional<DecodedToken> decode(String token) {
+        if (token == null || token.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            Jwt jwt = jwtDecoder.decode(token);
+            String scope = jwt.getClaimAsString("scope");
+            if ("ADMIN".equals(scope) || "USER".equals(scope)) {
+                return Optional.of(new DecodedToken(jwt, Provider.ADMIN));
+            } else if (jwt.hasClaim("firebase")) {
+                return Optional.of(new DecodedToken(jwt, Provider.FIREBASE));
+            }
+        } catch (JwtException ex) {
+            // Not an HS256 token, try Firebase
+        }
+
+        try {
+            Jwt firebaseJwt = firebaseJwtDecoder.decode(token);
+            return Optional.of(new DecodedToken(firebaseJwt, Provider.FIREBASE));
+        } catch (JwtException ex) {
+            log.debug("Invalid Firebase token: {}", ex.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    public enum Provider {
+        ADMIN,
+        FIREBASE
+    }
+
+    public record DecodedToken(Jwt jwt, Provider provider) {
+    }
+}

--- a/back/src/main/java/co/com/arena/real/application/service/TokenValidationService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/TokenValidationService.java
@@ -1,52 +1,20 @@
 package co.com.arena.real.application.service;
 
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtException;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Service;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 @Slf4j
 public class TokenValidationService {
 
-    private final @Qualifier("hs256JwtDecoder") JwtDecoder jwtDecoder;
-    private final JwtDecoder firebaseJwtDecoder;
+    private final JwtDecoderResolver decoderResolver;
 
-    public TokenValidationService(
-            @Qualifier("hs256JwtDecoder") JwtDecoder jwtDecoder,
-            @Qualifier("firebaseJwtDecoder") JwtDecoder firebaseJwtDecoder) {
-        this.jwtDecoder = jwtDecoder;
-        this.firebaseJwtDecoder = firebaseJwtDecoder;
-    }
-
-    public java.util.Optional<Jwt> validate(String token) {
-        if (token == null || token.isBlank()) {
-            return java.util.Optional.empty();
-        }
-        try {
-            Jwt jwt = jwtDecoder.decode(token);
-            String scope = jwt.getClaimAsString("scope");
-            if ("ADMIN".equals(scope) || "USER".equals(scope)) {
-                log.debug("Token validated as {} token", scope);
-                return java.util.Optional.of(jwt);
-            } else if (jwt.hasClaim("firebase")) {
-                log.debug("Token already contains firebase claim. Granting ROLE_USER");
-                return java.util.Optional.of(jwt);
-            }
-        } catch (JwtException ignore) {
-            // Not a HS256 token, try Firebase
-        }
-
-        try {
-            Jwt firebaseJwt = firebaseJwtDecoder.decode(token);
-            log.debug("Token validated via Firebase. Granting ROLE_USER");
-            return java.util.Optional.of(firebaseJwt);
-        } catch (JwtException ex) {
-            log.debug("Invalid Firebase token: {}", ex.getMessage());
-        }
-
-        return java.util.Optional.empty();
+    public Optional<Jwt> validate(String token) {
+        return decoderResolver.decode(token)
+                .map(JwtDecoderResolver.DecodedToken::jwt);
     }
 }


### PR DESCRIPTION
## Summary
- enforce user authentication for push token registration
- share JWT decoding through reusable resolver

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM for co.com.arena.real:arena-real:1.0.3)*

------
https://chatgpt.com/codex/tasks/task_b_68915de986448328a180ca1d29226368