### PR TITLE
Require auth for unspecified endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ notifications.
 
 ## API overview
 
-The following table lists the available REST and SSE endpoints, the required HTTP method, expected role and whether a JWT token is required. Public endpoints can be called without authentication. ADMIN routes expect an `Authorization` header with a valid token and all other `/api` routes now require a token granting the `USER` role.
+The following table lists the available REST and SSE endpoints, the required HTTP method, expected role and whether a JWT token is required. Public endpoints can be called without authentication. ADMIN routes expect an `Authorization` header with a valid token and all other `/api` routes now require a token granting the `USER` role. Any route not explicitly listed as public is authenticated by default; only `/public/**`, `/auth/**`, `/api/admin/auth/login`, `/api/register` and `/api/jugadores/**` are open.
 
 | Route | Method | Role | JWT required |
 |-------|--------|------|--------------|
 | `/api/register` | POST | Public | No |
 | `/api/referrals/earnings/{userId}` | GET | User | Yes |
-| `/api/push/register` | POST | Public | Yes |
+| `/api/push/register` | POST | User | Yes |
 | `/api/jugadores` | PUT | Public | No |
 | `/api/jugadores/{id}` | GET | Public | No |
 | `/api/jugadores/{id}/saldo` | GET | Public | No |

--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/admin/**", "/api/internal/**").hasRole("ADMIN")
                 .requestMatchers("/sse/**", "/api/transacciones/**").hasRole("USER")
                 .requestMatchers("/api/push/register").hasRole("USER")
-                .anyRequest().permitAll())
+                .anyRequest().authenticated())
             .oauth2ResourceServer(oauth2 -> oauth2
                     .authenticationManagerResolver(authenticationManagerResolver))
             .exceptionHandling(ex -> ex


### PR DESCRIPTION
## Summary
- Require authentication for any request not explicitly permitted
- Document default authentication rules and public paths
- Clarify `/api/push/register` needs a user token

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689175c3fff88328920797077c63da7d