### PR TITLE
Add fallback CORS filter configuration

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/CustomCorsConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/CustomCorsConfig.java
@@ -1,0 +1,31 @@
+package co.com.arena.real.config;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CustomCorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter(@Value("${cors.allowed-origins:}") String corsAllowedOrigins) {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        List<String> origins = Arrays.stream(corsAllowedOrigins.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isBlank())
+                .toList();
+        config.setAllowedOrigins(origins);
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `CustomCorsConfig` with a global `CorsFilter` using `cors.allowed-origins` from application properties

## Testing
- `cd back && mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6891cb1449948328a064575f542ab4e8