### PR TITLE
Inject CORS allowed origins list

### DIFF
--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -68,13 +67,10 @@ public class SecurityConfig {
     }
 
     @Bean
-    public CorsConfigurationSource corsConfigurationSource(@Value("${cors.allowed-origins:}") String corsAllowedOrigins) {
+    public CorsConfigurationSource corsConfigurationSource(
+            @Value("${cors.allowed-origins}") List<String> allowedOrigins) {
         CorsConfiguration config = new CorsConfiguration();
-        List<String> origins = Arrays.stream(corsAllowedOrigins.split(","))
-                .map(String::trim)
-                .filter(origin -> !origin.isBlank())
-                .toList();
-        config.setAllowedOrigins(origins);
+        config.setAllowedOrigins(allowedOrigins);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
## Summary
- inject `cors.allowed-origins` directly as a `List<String>`
- remove comma-splitting logic and use list assignment for CORS configuration

## Testing
- `mvn spring-boot:run -DskipTests` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6891d88ac8848328828f527a2579aaad