### PR TITLE
fix: allow configurable CORS origins

### DIFF
--- a/back/src/main/java/co/com/arena/real/admin/application/controller/AuthController.java
+++ b/back/src/main/java/co/com/arena/real/admin/application/controller/AuthController.java
@@ -7,7 +7,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin/auth")
 @RequiredArgsConstructor
-@CrossOrigin
 public class AuthController {
 
     private final AuthService authService;

--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -70,7 +70,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource(
             @Value("${cors.allowed-origins}") List<String> allowedOrigins) {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(allowedOrigins);
+        config.setAllowedOriginPatterns(allowedOrigins);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/back/src/main/java/co/com/arena/real/config/WebConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/WebConfig.java
@@ -1,5 +1,7 @@
 package co.com.arena.real.config;
 
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -8,13 +10,16 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig {
 
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
+
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:3000", "http://localhost:3001")
+                        .allowedOriginPatterns(allowedOrigins.toArray(new String[0]))
                         .allowedMethods("*")
                         .allowedHeaders("*")
                         .allowCredentials(true);

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -36,10 +36,8 @@ admin:
 security:
   jwt-secret: ${SECURITY_JWT_SECRET:${ADMIN_SECURITY_JWT_SECRET}}
 cors:
-  # Allowed origins for CORS; empty list allows none by default
-  allowed-origins:
-  - http://localhost:3000
-  - http://localhost:3001
+  # Allowed origins for CORS; override with CORS_ALLOWED_ORIGINS env var
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001}
      
 firebase:
   enabled: true


### PR DESCRIPTION
## Summary
- make CORS origins configurable via env var and allow patterns
- centralize CORS handling and remove per-controller annotation

## Testing
- `mvn -q package -DskipTests` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.6 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6892691d67a88328b7b814b4e502048f