### PR TITLE
Expose SSE endpoints publicly

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/SseController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/SseController.java
@@ -7,10 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
@@ -22,29 +19,17 @@ public class SseController {
     private final MatchSseService matchSseService;
 
     @GetMapping("/transacciones/{jugadorId}")
-    public SseEmitter streamTransacciones(@PathVariable String jugadorId,
-                                          Authentication authentication) {
-        checkJugador(jugadorId, authentication);
+    public SseEmitter streamTransacciones(@PathVariable String jugadorId) {
         return sseService.subscribe(jugadorId);
     }
 
     @GetMapping("/matchmaking/{jugadorId}")
-    public SseEmitter streamMatch(@PathVariable("jugadorId") String jugadorId,
-                                  Authentication authentication) {
-        checkJugador(jugadorId, authentication);
+    public SseEmitter streamMatch(@PathVariable("jugadorId") String jugadorId) {
         return matchSseService.subscribe(jugadorId);
     }
 
     @GetMapping("/match")
-    public SseEmitter streamMatchLegacy(@RequestParam("jugadorId") String jugadorId,
-                                        Authentication authentication) {
-        checkJugador(jugadorId, authentication);
+    public SseEmitter streamMatchLegacy(@RequestParam("jugadorId") String jugadorId) {
         return matchSseService.subscribe(jugadorId);
-    }
-
-    private void checkJugador(String jugadorId, Authentication authentication) {
-        if (authentication == null || !jugadorId.equals(authentication.getName())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
-        }
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
@@ -2,13 +2,12 @@ package co.com.arena.real.application.controller;
 
 import co.com.arena.real.application.service.SseService;
 import co.com.arena.real.application.service.TransaccionService;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 import co.com.arena.real.infrastructure.dto.rq.TransaccionRequest;
 import co.com.arena.real.infrastructure.dto.rs.TransaccionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -47,15 +45,7 @@ public class TransaccionController {
     }
 
     @GetMapping("/stream/{jugadorId}")
-    public SseEmitter stream(@PathVariable String jugadorId,
-                             Authentication authentication) {
-        checkJugador(jugadorId, authentication);
+    public SseEmitter stream(@PathVariable String jugadorId) {
         return sseService.subscribe(jugadorId);
-    }
-
-    private void checkJugador(String jugadorId, Authentication authentication) {
-        if (authentication == null || !jugadorId.equals(authentication.getName())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
-        }
     }
 }

--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -47,9 +47,9 @@ public class SecurityConfig {
         http.csrf(csrf -> csrf.disable())
             .cors(Customizer.withDefaults())
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/public/**", "/auth/**", "/api/admin/auth/login", "/api/register", "/api/jugadores/**").permitAll()
+                .requestMatchers("/public/**", "/auth/**", "/api/admin/auth/login", "/api/register", "/api/jugadores/**", "/sse/**", "/api/transacciones/stream/**").permitAll()
                 .requestMatchers("/api/admin/**", "/api/internal/**").hasRole("ADMIN")
-                .requestMatchers("/sse/**", "/api/transacciones/**").hasRole("USER")
+                .requestMatchers("/api/transacciones/**").hasRole("USER")
                 .requestMatchers("/api/push/register").hasRole("USER")
                 .anyRequest().authenticated())
             .oauth2ResourceServer(oauth2 -> oauth2

--- a/front/src/hooks/useApprovedTransactionsSse.ts
+++ b/front/src/hooks/useApprovedTransactionsSse.ts
@@ -3,7 +3,6 @@ import { EventSourcePolyfill } from 'event-source-polyfill';
 import { useAuth } from '@/hooks/useAuth';
 import useNotifications from '@/hooks/useNotifications';
 import { BACKEND_URL } from '@/lib/config';
-import { auth } from '@/lib/firebase';
 
 export interface ApprovedTransaction {
   id: string;
@@ -24,20 +23,9 @@ export default function useApprovedTransactionsSse() {
   useEffect(() => {
     if (!user?.id) return;
 
-    const connect = async () => {
-      let token: string | null = null;
-      if (typeof window !== 'undefined') {
-        try {
-          token = await auth.currentUser?.getIdToken(true) || null;
-        } catch {
-          token = null;
-        }
-      }
+    const connect = () => {
       const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}`;
-      const es = new EventSourcePolyfill(url, {
-        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        withCredentials: false,
-      });
+      const es = new EventSourcePolyfill(url);
       eventSourceRef.current = es;
 
       const handler = (event: MessageEvent) => {


### PR DESCRIPTION
## Summary
- Permit `/sse/**` and `/api/transacciones/stream/**` without authentication.
- Remove authentication checks from SSE controllers.
- Connect frontend SSE hooks without JWT headers.

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6892c7b0e7748328bf9d97d6a6a6b69e