### PR TITLE
Include Firebase auth header in API requests

### DIFF
--- a/front/src/hooks/usePushNotifications.ts
+++ b/front/src/hooks/usePushNotifications.ts
@@ -40,7 +40,8 @@ export default function usePushNotifications() {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization: `Bearer ${authToken}`
+                Authorization: `Bearer ${authToken}`,
+                'X-Auth-Provider': 'firebase'
               },
               body: JSON.stringify({ jugadorId: user.id, token })
             });

--- a/front/src/lib/actions.ts
+++ b/front/src/lib/actions.ts
@@ -28,7 +28,9 @@ async function authorizedFetch(input: RequestInfo | URL, init: RequestInit = {})
   }
   const headers = {
     ...(init.headers || {}),
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(token
+      ? { Authorization: `Bearer ${token}`, 'X-Auth-Provider': 'firebase' }
+      : {}),
   } as HeadersInit
   return fetch(input, { ...init, headers })
 }


### PR DESCRIPTION
## Summary
- include `X-Auth-Provider: firebase` header for push notification registration
- send the header with all authorized fetch requests

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6892ce67dac48328a7d9f6c40894b1dc