### PR TITLE
Implement JWT authentication for admin routes

### DIFF
--- a/back/pom.xml
+++ b/back/pom.xml
@@ -103,6 +103,24 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <!-- JWT -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- Retry utilities -->
         <dependency>
             <groupId>org.springframework.retry</groupId>

--- a/back/src/main/java/co/com/arena/real/admin/application/controller/AdminAuthController.java
+++ b/back/src/main/java/co/com/arena/real/admin/application/controller/AdminAuthController.java
@@ -1,0 +1,36 @@
+package co.com.arena.real.admin.application.controller;
+
+import co.com.arena.real.admin.infrastructure.dto.LoginRequest;
+import co.com.arena.real.admin.infrastructure.exception.InvalidCredentialsException;
+import co.com.arena.real.admin.infrastructure.security.JwtUtil;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller that handles admin authentication and issues JWT tokens.
+ */
+@RestController
+@RequestMapping("/api/admin/auth")
+@RequiredArgsConstructor
+public class AdminAuthController {
+
+    private final JwtUtil jwtUtil;
+
+    /**
+     * Authenticates the admin user using hardcoded credentials and returns a JWT.
+     */
+    @PostMapping("/login")
+    public ResponseEntity<Map<String, String>> login(@RequestBody LoginRequest request) {
+        // Demo credentials check
+        if ("admin".equals(request.getUsername()) && "1234".equals(request.getPassword())) {
+            String token = jwtUtil.generateToken(request.getUsername());
+            return ResponseEntity.ok(Map.of("token", token));
+        }
+        throw new InvalidCredentialsException("Credenciales inválidas");
+    }
+}

--- a/back/src/main/java/co/com/arena/real/admin/infrastructure/dto/LoginRequest.java
+++ b/back/src/main/java/co/com/arena/real/admin/infrastructure/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package co.com.arena.real.admin.infrastructure.dto;
+
+import lombok.Data;
+
+/**
+ * Request body for admin login.
+ */
+@Data
+public class LoginRequest {
+
+    private String username;
+    private String password;
+}

--- a/back/src/main/java/co/com/arena/real/admin/infrastructure/security/JwtAdminFilter.java
+++ b/back/src/main/java/co/com/arena/real/admin/infrastructure/security/JwtAdminFilter.java
@@ -1,0 +1,64 @@
+package co.com.arena.real.admin.infrastructure.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Filter that validates JWT tokens only for /api/admin/** endpoints.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAdminFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+        // Skip non-admin paths and login endpoint
+        if (!path.startsWith("/api/admin") || path.equals("/api/admin/auth/login")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        String token = header.substring(7);
+        try {
+            Jws<Claims> claims = jwtUtil.parseToken(token);
+            String role = claims.getBody().get("role", String.class);
+            if ("ADMIN".equals(role)) {
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                        claims.getBody().getSubject(), null,
+                        List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } else {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+        } catch (JwtException e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/back/src/main/java/co/com/arena/real/admin/infrastructure/security/JwtUtil.java
+++ b/back/src/main/java/co/com/arena/real/admin/infrastructure/security/JwtUtil.java
@@ -1,0 +1,47 @@
+package co.com.arena.real.admin.infrastructure.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Utility class for generating and validating JWT tokens for admin endpoints.
+ */
+@Component
+public class JwtUtil {
+
+    private final Key key;
+
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    /**
+     * Generates a JWT token for the given username including the ADMIN role claim.
+     */
+    public String generateToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("role", "ADMIN")
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 86_400_000)) // 24h
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Parses the token and returns the claims if valid.
+     */
+    public Jws<Claims> parseToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+}

--- a/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
+++ b/back/src/main/java/co/com/arena/real/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package co.com.arena.real.config;
 
+import co.com.arena.real.admin.infrastructure.security.JwtAdminFilter;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,19 +11,27 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAdminFilter jwtAdminFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())
                 .cors(Customizer.withDefaults())
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/register", "/api/push/register", "/api/jugadores/**", "/api/admin/auth/login").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .anyRequest().permitAll())
+                .addFilterBefore(jwtAdminFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/back/src/main/resources/application-dev.yml
+++ b/back/src/main/resources/application-dev.yml
@@ -11,3 +11,5 @@ service:
     credentials:
       user: ${ADMIN_CREDENTIALS_USER:admin}
       password: ${ADMIN_CREDENTIALS_PASSWORD:admin}
+jwt:
+  secret: ${JWT_SECRET:changeme}

--- a/back/src/main/resources/application-prod.yml
+++ b/back/src/main/resources/application-prod.yml
@@ -13,3 +13,5 @@ service:
     credentials:
       user: ${ADMIN_CREDENTIALS_USER:admin}
       password: ${ADMIN_CREDENTIALS_PASSWORD:admin}
+jwt:
+  secret: ${JWT_SECRET:changeme}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -32,6 +32,8 @@ admin:
   credentials:
     user: ${ADMIN_CREDENTIALS_USER}
     password: ${ADMIN_CREDENTIALS_PASSWORD}
+jwt:
+  secret: ${JWT_SECRET:changeme}
 cors:
   # Allowed origins for CORS; override with CORS_ALLOWED_ORIGINS env var
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001}


### PR DESCRIPTION
## Summary
- add jjwt dependencies and configurable JWT secret
- implement JwtUtil and JwtAdminFilter to secure /api/admin/** endpoints
- expose /api/admin/auth/login endpoint to issue admin tokens
- configure security to require ADMIN role for admin endpoints

## Testing
- `mvn -q -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689bc5e5fd3c83288616d0db083ce7b4