### PR TITLE
Inject admin credentials from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ Admin endpoints are available under `/api/admin` on the main server (port
 `8080` by default). Start the backend as explained above and then run the admin
 frontend:
 
+The login uses credentials configured via `admin.credentials` in the backend
+configuration. For local development the default username and password are both
+`admin`. When deploying, override these with the `ADMIN_CREDENTIALS_USER` and
+`ADMIN_CREDENTIALS_PASSWORD` environment variables.
+
 ```bash
 cd admin
 npm install

--- a/back/src/main/java/co/com/arena/real/admin/application/controller/AdminAuthController.java
+++ b/back/src/main/java/co/com/arena/real/admin/application/controller/AdminAuthController.java
@@ -5,6 +5,7 @@ import co.com.arena.real.admin.infrastructure.exception.InvalidCredentialsExcept
 import co.com.arena.real.admin.infrastructure.security.JwtUtil;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,13 +22,18 @@ public class AdminAuthController {
 
     private final JwtUtil jwtUtil;
 
+    @Value("${admin.credentials.user}")
+    private String adminUser;
+
+    @Value("${admin.credentials.password}")
+    private String adminPassword;
+
     /**
-     * Authenticates the admin user using hardcoded credentials and returns a JWT.
+     * Authenticates the admin user using configured credentials and returns a JWT.
      */
     @PostMapping("/login")
     public ResponseEntity<Map<String, String>> login(@RequestBody LoginRequest request) {
-        // Demo credentials check
-        if ("admin".equals(request.getUsername()) && "1234".equals(request.getPassword())) {
+        if (adminUser.equals(request.getUsername()) && adminPassword.equals(request.getPassword())) {
             String token = jwtUtil.generateToken(request.getUsername());
             return ResponseEntity.ok(Map.of("token", token));
         }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -30,8 +30,8 @@ admin:
   secret:
     token: ${ADMIN_SECRET_TOKEN}
   credentials:
-    user: ${ADMIN_CREDENTIALS_USER}
-    password: ${ADMIN_CREDENTIALS_PASSWORD}
+    user: ${ADMIN_CREDENTIALS_USER:admin}
+    password: ${ADMIN_CREDENTIALS_PASSWORD:admin}
 jwt:
   secret: ${JWT_SECRET:changeme}
 cors:


### PR DESCRIPTION
## Summary
- inject admin login credentials via `@Value` and configuration properties
- add default admin credentials to `application.yml`
- document `ADMIN_CREDENTIALS_USER` and `ADMIN_CREDENTIALS_PASSWORD` variables for deployments

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689bde3956908328ab73fd801028e083