### PR TITLE
Fix SSE heartbeat timeout option

### DIFF
--- a/front/src/hooks/useTransactionUpdates.ts
+++ b/front/src/hooks/useTransactionUpdates.ts
@@ -34,7 +34,7 @@ export default function useTransactionUpdates() {
 
     const connect = () => {
       const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}`;
-      const es = new EventSourcePolyfill(url,{heartbeaTimeout:120000});
+      const es = new EventSourcePolyfill(url, { heartbeatTimeout: 120000 });
       eventSourceRef.current = es;
 
       es.onopen = () => {


### PR DESCRIPTION
## Summary
- fix typo in EventSource heartbeat option so SSE reconnect waits 120s

## Testing
- `npm run lint` *(fails: many Prettier errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689bdfa6c1388328830a561601af1d7b