### PR TITLE
feat: add reliable sse replay

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
+++ b/back/src/main/java/co/com/arena/real/application/controller/TransaccionController.java
@@ -9,17 +9,17 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/transacciones")
@@ -44,8 +44,14 @@ public class TransaccionController {
         return ResponseEntity.ok(lista);
     }
 
-    @GetMapping("/stream/{jugadorId}")
-    public SseEmitter stream(@PathVariable String jugadorId) {
-        return sseService.subscribe(jugadorId);
+    // Alias de SSE bajo /api/transacciones
+    @GetMapping(path = "/stream/{jugadorId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter stream(
+            @PathVariable String jugadorId,
+            @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId
+    ) {
+        SseEmitter emitter = sseService.subscribe(jugadorId);
+        sseService.replayOnSubscribe(jugadorId, lastEventId);
+        return emitter;
     }
 }

--- a/back/src/main/java/co/com/arena/real/application/service/SseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/SseService.java
@@ -7,10 +7,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Service
 @RequiredArgsConstructor
@@ -19,75 +19,136 @@ public class SseService extends AbstractSseEmitterService {
     private static final Logger log = LoggerFactory.getLogger(SseService.class);
 
     private record LatestEvent(String name, Object data) {}
+    private static final int BUFFER_CAPACITY = 50;
 
-    private final Map<String, LatestEvent> latestEvents = new ConcurrentHashMap<>();
+    private static final class Ev {
+        final long id;
+        final String name;
+        final Object data;
+        final long ts;
+
+        Ev(long id, String name, Object data) {
+            this.id = id;
+            this.name = name;
+            this.data = data;
+            this.ts = System.currentTimeMillis();
+        }
+    }
+
+    // Un emisor por jugador (heredado de AbstractSseEmitterService)
+    // protected final Map<String, EmitterWrapper> emitters = ...
+
+    // Secuencia por jugador (para IDs)
+    private final Map<String, AtomicLong> seqByUser = new ConcurrentHashMap<>();
+    // Buffer acotado por jugador para replay con Last-Event-ID
+    private final Map<String, ArrayDeque<Ev>> buffers = new ConcurrentHashMap<>();
+    // Últimos por tipo (snapshot consistente)
+    private final Map<String, Map<String, LatestEvent>> latestByType = new ConcurrentHashMap<>();
 
     @Override
     protected void onSubscribe(String jugadorId, EmitterWrapper wrapper) {
-        LatestEvent last = latestEvents.remove(jugadorId); // directamente lo eliminamos al intentar enviar
-        if (last != null) {
-            CompletableFuture.runAsync(() -> {
-                try {
-                    wrapper.emitter.send(SseEmitter.event()
-                            .name(last.name())
-                            .data(last.data()));
-                    wrapper.lastAccess = System.currentTimeMillis();
-                } catch (IOException e) {
-                    log.error("❌ Error al enviar evento pendiente en onSubscribe", e);
-                    removeEmitter(jugadorId);
-                    wrapper.emitter.completeWithError(e);
-                    latestEvents.put(jugadorId, last); // lo volvemos a guardar si falló
-                }
-            });
+        try {
+            wrapper.emitter.send(SseEmitter.event().name("connected").data("ok").reconnectTime(3000));
+            wrapper.lastAccess = System.currentTimeMillis();
+        } catch (Exception ignored) {
         }
+        // El replay real lo dispara el controlador llamando a replayOnSubscribe(...)
     }
 
     public SseEmitter subscribe(String jugadorId) {
+        // Asegúrate de que AbstractSseEmitterService registre onTimeout/onError/onCompletion -> removeEmitter(jugadorId)
         return super.subscribe(jugadorId);
     }
 
-    public void notificarTransaccionAprobada(TransaccionResponse dto) {
-        String jugadorId = dto.getJugadorId();
-        LatestEvent latest = new LatestEvent("transaccion-aprobada", dto);
-
+    /** Reproduce eventos pendientes al suscribirse/reconectarse */
+    public void replayOnSubscribe(String jugadorId, String lastEventIdStr) {
         EmitterWrapper wrapper = emitters.get(jugadorId);
         if (wrapper == null) {
-            latestEvents.put(jugadorId, latest);
             return;
         }
 
+        Long lastId = null;
         try {
-            wrapper.emitter.send(SseEmitter.event()
-                    .name("transaccion-aprobada")
-                    .data(dto));
-            wrapper.lastAccess = System.currentTimeMillis();
-        } catch (IOException e) {
-            log.error("❌ Error al enviar evento SSE al jugador {}", jugadorId, e);
-            removeEmitter(jugadorId);
-            wrapper.emitter.completeWithError(e);
-            latestEvents.put(jugadorId, latest);
+            if (lastEventIdStr != null) {
+                lastId = Long.parseLong(lastEventIdStr.trim());
+            }
+        } catch (NumberFormatException ignored) {
+        }
+
+        if (lastId != null) {
+            ArrayDeque<Ev> dq = buffers.get(jugadorId);
+            if (dq != null && !dq.isEmpty()) {
+                synchronized (dq) {
+                    for (Ev ev : dq) {
+                        if (ev.id > lastId) {
+                            trySend(wrapper, jugadorId, ev);
+                        }
+                    }
+                }
+                return;
+            }
+        }
+
+        Map<String, LatestEvent> map = latestByType.get(jugadorId);
+        if (map != null) {
+            for (LatestEvent le : map.values()) {
+                long id = nextId(jugadorId);
+                trySend(wrapper, jugadorId, new Ev(id, le.name(), le.data()));
+            }
         }
     }
 
+    /** Atajo específico de dominio */
+    public void notificarTransaccionAprobada(TransaccionResponse dto) {
+        sendEvent(dto.getJugadorId(), "transaccion-aprobada", dto);
+    }
+
+    /** Enviar evento (o encolar si el usuario aún no está suscrito) */
     public void sendEvent(String jugadorId, String eventName, Object data) {
-        LatestEvent latest = new LatestEvent(eventName, data);
+        long id = nextId(jugadorId);
+        Ev ev = new Ev(id, eventName, data);
+
+        // Actualizar snapshot por tipo
+        latestByType.computeIfAbsent(jugadorId, k -> new ConcurrentHashMap<>())
+                .put(eventName, new LatestEvent(eventName, data));
+
+        // Encolar en buffer acotado
+        ArrayDeque<Ev> dq = buffers.computeIfAbsent(jugadorId, k -> new ArrayDeque<>(BUFFER_CAPACITY));
+        synchronized (dq) {
+            if (dq.size() == BUFFER_CAPACITY) {
+                dq.removeFirst();
+            }
+            dq.addLast(ev);
+        }
 
         EmitterWrapper wrapper = emitters.get(jugadorId);
         if (wrapper == null) {
-            latestEvents.put(jugadorId, latest);
             return;
         }
 
+        trySend(wrapper, jugadorId, ev);
+    }
+
+    private void trySend(EmitterWrapper wrapper, String jugadorId, Ev ev) {
         try {
             wrapper.emitter.send(SseEmitter.event()
-                    .name(eventName)
-                    .data(data));
+                    .id(Long.toString(ev.id))
+                    .name(ev.name)
+                    .data(ev.data)
+                    .reconnectTime(3000));
             wrapper.lastAccess = System.currentTimeMillis();
-        } catch (IOException e) {
-            log.error("❌ Error al enviar evento SSE '{}'", eventName, e);
+        } catch (Exception e) {
+            log.error("❌ Error SSE a jugador {} (evento '{}')", jugadorId, ev.name, e);
             removeEmitter(jugadorId);
-            wrapper.emitter.completeWithError(e);
-            latestEvents.put(jugadorId, latest);
+            try {
+                wrapper.emitter.completeWithError(e);
+            } catch (Exception ignored) {
+            }
         }
+    }
+
+    private long nextId(String jugadorId) {
+        return seqByUser.computeIfAbsent(jugadorId, k -> new AtomicLong(0)).incrementAndGet();
     }
 }
+


### PR DESCRIPTION
## Summary
- add per-player buffering and incremental event IDs for SSE
- replay missed events on reconnect and send snapshot of latest event types
- expose Last-Event-ID aware SSE endpoints

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689d26c2fe5083288891cd2afb05d379