### PR TITLE
Avoid duplicate SSE notifications

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/SseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/SseService.java
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.ArrayDeque;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -20,6 +21,8 @@ public class SseService extends AbstractSseEmitterService {
 
     private record LatestEvent(String name, Object data) {}
     private static final int BUFFER_CAPACITY = 50;
+    private static final Set<String> SNAPSHOT_BLOCKLIST =
+            Set.of("transaccion-aprobada");
 
     // Evento completo para buffer con ID
     private static final class Ev {
@@ -91,6 +94,7 @@ public class SseService extends AbstractSseEmitterService {
         Map<String, LatestEvent> map = latestByType.get(jugadorId);
         if (map != null) {
             for (LatestEvent le : map.values()) {
+                if (SNAPSHOT_BLOCKLIST.contains(le.name())) continue;
                 long id = nextId(jugadorId);
                 trySend(wrapper, jugadorId, new Ev(id, le.name(), le.data()));
             }

--- a/front/src/hooks/useApprovedTransactionsSse.ts
+++ b/front/src/hooks/useApprovedTransactionsSse.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { EventSourcePolyfill } from 'event-source-polyfill';
 import { useAuth } from '@/hooks/useAuth';
 import useNotifications from '@/hooks/useNotifications';
@@ -13,22 +13,28 @@ export interface ApprovedTransaction {
   creadoEn: string;
 }
 
+let source: EventSource | null = null;
+let lastHandled = 0;
+
 export default function useApprovedTransactionsSse() {
   const [transactions, setTransactions] = useState<ApprovedTransaction[]>([]);
   const { user } = useAuth();
   const { addNotification } = useNotifications();
-  const eventSourceRef = useRef<EventSource | null>(null);
-  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!user?.id) return;
 
     const connect = () => {
+      if (source) return source;
       const url = `${BACKEND_URL}/api/transacciones/stream/${encodeURIComponent(user.id)}`;
       const es = new EventSourcePolyfill(url);
-      eventSourceRef.current = es;
+      source = es;
 
-      const handler = (event: MessageEvent) => {
+      es.addEventListener('transaccion-aprobada', (event: MessageEvent) => {
+        const id = Number((event as any).lastEventId || 0);
+        if (id <= lastHandled) return;
+        lastHandled = id;
+
         try {
           const data = JSON.parse(event.data) as ApprovedTransaction;
           setTransactions(prev => [data, ...prev]);
@@ -42,28 +48,21 @@ export default function useApprovedTransactionsSse() {
         } catch (err) {
           console.error('Error parsing SSE event', err);
         }
+      });
+
+      es.onerror = () => {
+        /* optional: log */
       };
 
-      es.addEventListener('transaccion-aprobada', handler as EventListener);
-
-      es.onerror = (err: Event) => {
-        console.error('SSE error:', err);
-        es.close();
-        reconnectTimeoutRef.current = setTimeout(connect, 3000);
-      };
+      return es;
     };
 
-    connect();
-
+    const es = connect();
     return () => {
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
-      }
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
-      }
+      es?.close();
+      source = null;
     };
-  }, [user]);
+  }, [user?.id, addNotification]);
 
   return transactions;
 }


### PR DESCRIPTION
## Summary
- Skip `transaccion-aprobada` in backend snapshot replay
- Deduplicate SSE events on the client and ensure single connection

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: network is unreachable)*
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689d5c1d6f0c83288d03b4e853ea68cd