### PR TITLE
Refine SSE emitter lifecycle

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/AbstractSseEmitterService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/AbstractSseEmitterService.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,26 +26,24 @@ public abstract class AbstractSseEmitterService {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     protected SseEmitter subscribe(String jugadorId) {
-        String lock = ("lock_" + jugadorId).intern();
-        synchronized (lock) {
-            EmitterWrapper existing = emitters.remove(jugadorId);
-            if (existing != null) {
-                existing.emitter.complete();
+        SseEmitter emitter = new SseEmitter(0L);
+        EmitterWrapper wrapper = new EmitterWrapper(emitter);
+
+        EmitterWrapper prev = emitters.put(jugadorId, wrapper);
+        if (prev != null) {
+            try {
+                prev.emitter.complete();
+            } catch (Exception ignored) {
             }
-
-            SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
-            EmitterWrapper wrapper = new EmitterWrapper(emitter);
-
-            emitter.onCompletion(() -> removeEmitter(jugadorId));
-            emitter.onTimeout(() -> removeEmitter(jugadorId));
-            emitter.onError(ex -> removeEmitter(jugadorId));
-
-            emitters.put(jugadorId, wrapper);
-            log.info("Nueva conexión SSE para jugador: {}", jugadorId);
-
-            onSubscribe(jugadorId, wrapper);
-            return emitter;
         }
+
+        emitter.onCompletion(() -> removeEmitter(jugadorId));
+        emitter.onTimeout(() -> removeEmitter(jugadorId));
+        emitter.onError(ex -> removeEmitter(jugadorId));
+
+        log.info("Nueva conexión SSE para jugador: {}", jugadorId);
+        onSubscribe(jugadorId, wrapper);
+        return emitter;
     }
 
     @Scheduled(fixedRate = 15000)
@@ -55,7 +52,7 @@ public abstract class AbstractSseEmitterService {
             try {
                 wrapper.emitter.send(SseEmitter.event().comment("heartbeat"));
                 wrapper.lastAccess = System.currentTimeMillis();
-            } catch (IOException e) {
+            } catch (Exception e) {
                 removeEmitter(id);
             }
         });
@@ -67,14 +64,19 @@ public abstract class AbstractSseEmitterService {
         emitters.forEach((id, wrapper) -> {
             if (now - wrapper.lastAccess > TTL_MS) {
                 removeEmitter(id);
-                wrapper.emitter.complete();
             }
         });
     }
 
     protected void removeEmitter(String jugadorId) {
-        emitters.remove(jugadorId);
-        log.info("Desconectado SSE jugador: {}", jugadorId);
+        EmitterWrapper removed = emitters.remove(jugadorId);
+        if (removed != null) {
+            try {
+                removed.emitter.complete();
+            } catch (Exception ignored) {
+            }
+            log.info("Desconectado SSE jugador: {}", jugadorId);
+        }
     }
 
     protected void onSubscribe(String jugadorId, EmitterWrapper wrapper) {


### PR DESCRIPTION
## Summary
- replace String.intern locking with atomic map swap to allow one emitter per player
- use explicit 0L timeout and idempotent emitter removal
- simplify cleanup and harden heartbeat sending

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.6 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689df23e37648328ac114ace0271e2c6