### PR TITLE
Refine SSE emitter lifecycle

### DIFF
--- a/back/src/main/java/co/com/arena/real/Application.java
+++ b/back/src/main/java/co/com/arena/real/Application.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
+@EnableScheduling // habilita tareas programadas (heartbeats y limpieza)
 public class Application {
 
     public static void main(String[] args) {

--- a/back/src/main/java/co/com/arena/real/application/service/AbstractSseEmitterService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/AbstractSseEmitterService.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,26 +26,24 @@ public abstract class AbstractSseEmitterService {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     protected SseEmitter subscribe(String jugadorId) {
-        String lock = ("lock_" + jugadorId).intern();
-        synchronized (lock) {
-            EmitterWrapper existing = emitters.remove(jugadorId);
-            if (existing != null) {
-                existing.emitter.complete();
+        SseEmitter emitter = new SseEmitter(0L);
+        EmitterWrapper wrapper = new EmitterWrapper(emitter);
+
+        EmitterWrapper prev = emitters.put(jugadorId, wrapper);
+        if (prev != null) {
+            try {
+                prev.emitter.complete();
+            } catch (Exception ignored) {
             }
-
-            SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
-            EmitterWrapper wrapper = new EmitterWrapper(emitter);
-
-            emitter.onCompletion(() -> removeEmitter(jugadorId));
-            emitter.onTimeout(() -> removeEmitter(jugadorId));
-            emitter.onError(ex -> removeEmitter(jugadorId));
-
-            emitters.put(jugadorId, wrapper);
-            log.info("Nueva conexión SSE para jugador: {}", jugadorId);
-
-            onSubscribe(jugadorId, wrapper);
-            return emitter;
         }
+
+        emitter.onCompletion(() -> removeEmitter(jugadorId, wrapper));
+        emitter.onTimeout(() -> removeEmitter(jugadorId, wrapper));
+        emitter.onError(ex -> removeEmitter(jugadorId, wrapper));
+
+        log.info("Nueva conexión SSE para jugador: {}", jugadorId);
+        onSubscribe(jugadorId, wrapper);
+        return emitter;
     }
 
     @Scheduled(fixedRate = 15000)
@@ -55,8 +52,8 @@ public abstract class AbstractSseEmitterService {
             try {
                 wrapper.emitter.send(SseEmitter.event().comment("heartbeat"));
                 wrapper.lastAccess = System.currentTimeMillis();
-            } catch (IOException e) {
-                removeEmitter(id);
+            } catch (Exception e) {
+                removeEmitter(id, wrapper);
             }
         });
     }
@@ -66,15 +63,19 @@ public abstract class AbstractSseEmitterService {
         long now = System.currentTimeMillis();
         emitters.forEach((id, wrapper) -> {
             if (now - wrapper.lastAccess > TTL_MS) {
-                removeEmitter(id);
-                wrapper.emitter.complete();
+                removeEmitter(id, wrapper);
             }
         });
     }
 
-    protected void removeEmitter(String jugadorId) {
-        emitters.remove(jugadorId);
-        log.info("Desconectado SSE jugador: {}", jugadorId);
+    protected void removeEmitter(String jugadorId, EmitterWrapper wrapper) {
+        if (emitters.remove(jugadorId, wrapper)) {
+            try {
+                wrapper.emitter.complete();
+            } catch (Exception ignored) {
+            }
+            log.info("Desconectado SSE jugador: {}", jugadorId);
+        }
     }
 
     protected void onSubscribe(String jugadorId, EmitterWrapper wrapper) {

--- a/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/MatchSseService.java
@@ -43,7 +43,7 @@ public class MatchSseService extends AbstractSseEmitterService {
                     wrapper.lastAccess = System.currentTimeMillis();
                     latestEvents.remove(jugadorId);
                 } catch (IOException e) {
-                    removeEmitter(jugadorId);
+                    removeEmitter(jugadorId, wrapper);
                     wrapper.emitter.completeWithError(e);
                 }
             });
@@ -112,7 +112,7 @@ public class MatchSseService extends AbstractSseEmitterService {
             wrapper.lastAccess = System.currentTimeMillis();
             latestEvents.remove(receptorId);
         } catch (IOException e) {
-            removeEmitter(receptorId);
+            removeEmitter(receptorId, wrapper);
             wrapper.emitter.completeWithError(e);
         }
     }
@@ -144,7 +144,7 @@ public class MatchSseService extends AbstractSseEmitterService {
             wrapper.lastAccess = System.currentTimeMillis();
             latestEvents.remove(receptorId);
         } catch (IOException e) {
-            removeEmitter(receptorId);
+            removeEmitter(receptorId, wrapper);
             wrapper.emitter.completeWithError(e);
         }
     }
@@ -173,7 +173,7 @@ public class MatchSseService extends AbstractSseEmitterService {
             wrapper.lastAccess = System.currentTimeMillis();
             latestEvents.remove(receptorId);
         } catch (IOException e) {
-            removeEmitter(receptorId);
+            removeEmitter(receptorId, wrapper);
             wrapper.emitter.completeWithError(e);
         }
     }
@@ -201,7 +201,7 @@ public class MatchSseService extends AbstractSseEmitterService {
             wrapper.lastAccess = System.currentTimeMillis();
             latestEvents.remove(receptorId);
         } catch (IOException e) {
-            removeEmitter(receptorId);
+            removeEmitter(receptorId, wrapper);
             wrapper.emitter.completeWithError(e);
         }
     }
@@ -228,7 +228,7 @@ public class MatchSseService extends AbstractSseEmitterService {
             wrapper.lastAccess = System.currentTimeMillis();
             latestEvents.remove(receptorId);
         } catch (IOException e) {
-            removeEmitter(receptorId);
+            removeEmitter(receptorId, wrapper);
             wrapper.emitter.completeWithError(e);
         }
     }
@@ -254,7 +254,7 @@ public class MatchSseService extends AbstractSseEmitterService {
             wrapper.lastAccess = System.currentTimeMillis();
             latestEvents.remove(receptorId);
         } catch (IOException e) {
-            removeEmitter(receptorId);
+            removeEmitter(receptorId, wrapper);
             wrapper.emitter.completeWithError(e);
         }
     }
@@ -274,7 +274,7 @@ public class MatchSseService extends AbstractSseEmitterService {
             wrapper.emitter.send(SseEmitter.event().data(payload));
             wrapper.lastAccess = System.currentTimeMillis();
         } catch (IOException e) {
-            removeEmitter(receptorId);
+            removeEmitter(receptorId, wrapper);
             wrapper.emitter.completeWithError(e);
         }
     }

--- a/back/src/main/java/co/com/arena/real/application/service/SseService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/SseService.java
@@ -139,7 +139,7 @@ public class SseService extends AbstractSseEmitterService {
             wrapper.lastAccess = System.currentTimeMillis();
         } catch (Exception e) { // IOException / IllegalStateException
             log.error("❌ Error SSE a jugador {} (evento '{}')", jugadorId, ev.name, e);
-            removeEmitter(jugadorId);
+            removeEmitter(jugadorId, wrapper);
             try { wrapper.emitter.completeWithError(e); } catch (Exception ignored) { }
             // No más acciones: el evento ya está en buffer/snapshot para próxima reconexión
         }


### PR DESCRIPTION
## Summary
- guard SSE emitter removal with a value check so stale callbacks can't drop a new connection
- update match and generic SSE services to pass the current emitter wrapper

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689df23e37648328ac114ace0271e2c6