### PR TITLE
Send single start message per chat

### DIFF
--- a/front/src/app/chat/[matchId]/page.tsx
+++ b/front/src/app/chat/[matchId]/page.tsx
@@ -263,12 +263,12 @@ const ChatPageContent = () => {
 
   useEffect(() => {
     if (incompleteData || isLoading || !user || !opponentProfile || startMessageSentRef.current) return;
-    if (messages.length === 0) {
+    if (messages.length === 0 && user.id < validOpponentGoogleId) {
       startMessageSentRef.current = true;
       fetch(`${BACKEND_URL}/api/chats/${encodeURIComponent(validChatId)}/start-message`, { method: 'POST' })
         .catch(err => console.error('Error solicitando mensaje inicial', err));
     }
-  }, [user, opponentProfile, validChatId, validOpponentTag, opponentDisplayName, messages.length, incompleteData, isLoading, BACKEND_URL]);
+  }, [user?.id, opponentProfile, validChatId, validOpponentTag, opponentDisplayName, validOpponentGoogleId, messages.length, incompleteData, isLoading, BACKEND_URL]);
 
   const handleSendMessage = (e: FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- ensure only one player triggers chat start message by comparing user IDs

## Testing
- `npm run lint` *(fails: Prettier errors across project)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689e9ac83c0083289ce758c0dea44365