### PR TITLE
Show prize from prize transaction

### DIFF
--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -163,6 +163,7 @@ export interface Bet {
   result?: MatchResult;
   status: BackendApuestaResponseDto['estado'];
   modoJuego: string;
+  prize?: number;
   screenshotUrl?: string;
 }
 


### PR DESCRIPTION
## Summary
- track prize per bet with new `prize` field
- fetch prize transactions and display their amounts in duel history

## Testing
- `npm ci`
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689f136fa0c88328a0b547d947426a47