### PR TITLE
Ensure duel prize always defined

### DIFF
--- a/front/src/app/history/page.tsx
+++ b/front/src/app/history/page.tsx
@@ -61,12 +61,12 @@ const HistoryPageContent = () => {
         if (duelResult.duels) {
           const mapped = duelResult.duels.map((d: BackendPartidaResponseDto) => {
             const matchDate = d.validadaEn || d.creada;
-            let prize: number | undefined;
+            let prize = 0;
             if (d.ganadorId === user.id) {
               const tx = prizeTxs.find(
                 t => Math.abs(new Date(t.creadoEn).getTime() - new Date(matchDate).getTime()) < 24 * 60 * 60 * 1000,
               );
-              prize = tx?.monto;
+              prize = tx?.monto ?? 0;
             }
             return {
               id: d.apuestaId,
@@ -117,7 +117,6 @@ const HistoryPageContent = () => {
             .map(s => s.charAt(0).toUpperCase() + s.slice(1))
             .join(' ')
         : 'Pendiente';
-    const prize = bet.prize ?? 0;
     return (
       <Card className="mb-4 shadow-md border-border hover:shadow-lg transition-shadow duration-200">
         <CardHeader className="pb-3">
@@ -159,7 +158,7 @@ const HistoryPageContent = () => {
               <p className="text-base">
                 Premio:{' '}
                 <span className="font-semibold text-accent">
-                  {bet.result ? (bet.prize !== undefined ? formatCOP(prize) : 'Pendiente') : 'Pendiente'}
+                  {bet.result ? formatCOP(bet.prize) : 'Pendiente'}
                 </span>
               </p>
               {name && (

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -163,7 +163,7 @@ export interface Bet {
   result?: MatchResult;
   status: BackendApuestaResponseDto['estado'];
   modoJuego: string;
-  prize?: number;
+  prize: number;
   screenshotUrl?: string;
 }
 


### PR DESCRIPTION
## Summary
- Initialize prize to 0 in history page and show prize when duel result exists
- Make bet prize mandatory in shared types

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689f29c7b6948328866e898884aafad2