### PR TITLE
Mark bet delivered when validating game

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/PartidaService.java
@@ -1,6 +1,7 @@
 package co.com.arena.real.application.service;
 
 import co.com.arena.real.domain.entity.Apuesta;
+import co.com.arena.real.domain.entity.EstadoApuesta;
 import co.com.arena.real.domain.entity.EstadoTransaccion;
 import co.com.arena.real.domain.entity.TipoTransaccion;
 import co.com.arena.real.domain.entity.Transaccion;
@@ -164,6 +165,8 @@ public class PartidaService {
 
             Apuesta apuesta = apuestaRepository.findById(partida.getApuesta().getId())
                     .orElseThrow(() -> new IllegalArgumentException("Apuesta no encontrada"));
+            apuesta.setEstado(EstadoApuesta.ENTREGADA);
+            apuestaRepository.save(apuesta);
 
             Transaccion premio = new Transaccion();
             premio.setJugador(partida.getGanador());


### PR DESCRIPTION
## Summary
- mark bet as ENTREGADA when a validated match has a winner
- persist updated bet status during match validation

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true package` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a34b170f7c83329d92f1bcdd176279