### PR TITLE
Hide prize for lost duels

### DIFF
--- a/front/src/app/history/page.tsx
+++ b/front/src/app/history/page.tsx
@@ -142,12 +142,14 @@ const HistoryPageContent = () => {
                 Inscripción:{' '}
                 <span className="font-semibold text-accent">{formatCOP(bet.amount)}</span>
               </p>
-              <p className="text-base">
-                Premio:{' '}
-                <span className="font-semibold text-accent">
-                  {formatCOP(bet.prize ?? 0)}
-                </span>
-              </p>
+              {bet.result !== 'loss' && (
+                <p className="text-base">
+                  Premio:{' '}
+                  <span className="font-semibold text-accent">
+                    {formatCOP(bet.prize ?? 0)}
+                  </span>
+                </p>
+              )}
               {name && (
                 <p className="text-base">
                   Oponente: <span className="font-semibold">{name}</span>


### PR DESCRIPTION
## Summary
- hide prize display on history page when the duel was lost

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a357afdf9c83329128f9c854fabad8