### PR TITLE
Unify metrics and features under a single gradient section

### DIFF
--- a/front/public/arena-mobile.html
+++ b/front/public/arena-mobile.html
@@ -88,27 +88,17 @@
   @keyframes draw { to { stroke-dashoffset: 0 } }
 
   /* Metrics */
-  .metrics { display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; max-width: 900px; margin: 28px auto 0 }
+  .metrics { display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; max-width: 900px; margin: 0 auto; padding: 32px 0 }
   .shield { position:relative; border-radius: var(--radius); padding: 18px;
     background: linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));
     border: 1px solid rgba(233,196,106,.28); box-shadow: var(--shadow-1); }
   .metric-value { font: 800 28px/1 Cinzel, serif; color: var(--gold-2) }
   .metric-label { margin-top: 6px; font-size: 11px; letter-spacing: .18em; opacity:.75 }
-
-  /* Ornamental separator */
-  .sep-curved { position: relative; height: 24px; margin: 8px 0 0; /* limpio, sin cortes */
-    background: radial-gradient(120% 140% at 50% -20%, rgba(233,196,106,.34) 0%, rgba(233,196,106,.18) 30%, rgba(233,196,106,0) 60%);
-    pointer-events: none; }
-  .sep-curved::after { content:""; position:absolute; left:0; right:0; bottom:-1px; height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(0,0,0,.45), transparent); }
-
   /* Features */
-  .features-section { position: relative; border-radius: 22px; padding: 24px; margin-top: 0; /* conecta con sep */
-    background: linear-gradient(180deg, rgba(26,19,36,.88) 0%, rgba(13,14,20,1) 100%);
+  .features-section { border-radius: 22px; padding: 24px; margin-top: 32px;
+    background: radial-gradient(120% 80% at 50% 0%, rgba(233,196,106,.15), rgba(233,196,106,0) 70%),
+      linear-gradient(180deg, rgba(18,23,33,1) 0%, rgba(11,15,20,0.95) 100%);
     border: 1px solid rgba(233,196,106,.16); box-shadow: 0 10px 26px rgba(0,0,0,.35); overflow: hidden; }
-  .features-section::before { content:""; position: absolute; left: -1px; right: -1px; top: -1px; height: 140px;
-    border-radius: 22px 22px 0 0; background: radial-gradient(120% 80% at 50% 0%, rgba(233,196,106,.18), rgba(233,196,106,0) 70%);
-    pointer-events: none; }
   .section-title { text-align:center; margin: 8px 0 14px; font: 800 26px/1.15 Cinzel, serif; color: #f0e0a6 }
   .features { display:grid; grid-template-columns: repeat(3, 1fr); gap: 16px; background: none }
   .card { position: relative; border-radius: var(--radius); padding: 18px;
@@ -211,6 +201,9 @@
         <a class="btn btn-ghost btn-lg btn-pill" href="/login">Ver batallas</a>
       </div>
 
+    </section>
+
+    <section class="container features-section">
       <div class="metrics" role="list">
         <article class="shield" role="listitem">
           <div class="metric-value"><span id="m1">+0</span></div>
@@ -225,11 +218,9 @@
           <div class="metric-label">GLADIADORES</div>
         </article>
       </div>
-    </section>
 
-    <div class="sep-curved" aria-hidden="true"></div>
+      <div class="sep"></div>
 
-    <section class="container features-section">
       <h2 class="section-title">Forja tu leyenda</h2>
       <div class="features">
         <article class="card">

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -96,8 +96,15 @@
                 Ver batallas
               </Link>
             </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-3xl mx-auto mt-7" role="list">
+          </section>
+          <section
+            className="container mx-auto px-5 mt-8 rounded-3xl border border-[rgba(233,196,106,.16)] shadow-[0_10px_26px_rgba(0,0,0,.35)] overflow-hidden"
+            style={{
+              background:
+                'radial-gradient(120% 80% at 50% 0%, rgba(233,196,106,.15), rgba(233,196,106,0) 70%), linear-gradient(180deg, rgba(18,23,33,1) 0%, rgba(11,15,20,0.95) 100%)',
+            }}
+          >
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-4xl mx-auto py-8" role="list">
               <article className="card text-center" role="listitem">
                 <Icon src="/icons/espadas.png" alt="Duelos activos" size={56} className="mb-2" />
                 <div className="font-cinzel font-extrabold text-[28px] leading-none text-[color:var(--gold-2)]">
@@ -122,20 +129,13 @@
                 <div className="mt-1 text-[11px] tracking-[.18em] opacity-75">GLADIADORES</div>
               </article>
             </div>
-          </section>
 
-          <section
-            className="container mx-auto px-5 relative -mt-6 rounded-3xl p-6 border border-[rgba(233,196,106,.16)] shadow-[0_10px_26px_rgba(0,0,0,.35)] overflow-hidden"
-            style={{ background: 'linear-gradient(180deg, rgba(18,23,33,.88) 0%, rgba(11,15,20,1) 100%)' }}
-          >
-            <div
-              className="pointer-events-none absolute -inset-x-px -top-px h-36 rounded-t-3xl"
-              style={{ background: 'radial-gradient(120% 80% at 50% 0%, rgba(233,196,106,.28), rgba(233,196,106,0) 70%)' }}
-            />
-            <h2 className="text-center my-2 font-cinzel font-extrabold text-[26px] leading-tight text-[#f0e0a6]">
+            <div className="h-px w-full my-6 bg-gradient-to-r from-transparent via-amber-300/20 to-transparent" />
+
+            <h2 className="text-center font-cinzel font-extrabold text-[26px] text-[#f0e0a6]">
               Forja tu leyenda
             </h2>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-4">
               <article className="card card-lg relative">
                 <svg className="absolute right-3 top-3 opacity-90" width="28" height="28" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                   <path d="M12 2l3 6 6 .9-4.5 4.4 1 6.3L12 16l-5.5 3.6 1-6.3L3 8.9 9 8l3-6z" stroke="currentColor" strokeWidth="1.3" color="#CDA434" />


### PR DESCRIPTION
## Summary
- Wrap metrics and "Forja tu leyenda" into one section with a shared radial+linear gradient background.
- Remove deprecated separator structure in static HTML and consolidate metrics and feature cards.

## Testing
- `npm run lint` *(fails: numerous prettier/prettier rule violations in unrelated files)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68af945019908330ad9faa49b8cfa03f