### PR TITLE
Remove background seam on landing page

### DIFF
--- a/front/src/app/landing.css
+++ b/front/src/app/landing.css
@@ -29,8 +29,9 @@ body { @apply font-sans antialiased; }
   pointer-events: none;
   min-height: 100%;
   background:
-    radial-gradient(38rem 22rem at 50% 18%, rgba(233,196,106,.20) 0%, rgba(233,196,106,0) 60%),
+    radial-gradient(38rem 22rem at 50% 18%, rgba(233,196,106,.20) 0%, rgba(16,21,33,0) 60%),
     linear-gradient(180deg, #101521 0%, #0b0f14 100%);
+  background-blend-mode: overlay;
 }
 .bg-app::after {
   content:""; position:absolute; inset:0; pointer-events:none;


### PR DESCRIPTION
## Summary
- blend landing background gradients to eliminate visible seam

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68b0861a5d888330a8f28978376aef3b