### PR TITLE
Guard Firebase messaging for unsupported browsers

### DIFF
--- a/front/src/lib/firebase.ts
+++ b/front/src/lib/firebase.ts
@@ -3,7 +3,7 @@ import { initializeApp, getApps, getApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
-import { getMessaging, type Messaging } from 'firebase/messaging';
+import { getMessaging, isSupported, type Messaging } from 'firebase/messaging';
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
@@ -21,9 +21,15 @@ const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const auth = getAuth(app);
 const db = getFirestore(app);
 const storage = getStorage(app);
-let messaging: Messaging | undefined;
-if (typeof window !== 'undefined') {
-  messaging = getMessaging(app);
+
+let messagingInstance: Messaging | null = null;
+
+export async function getFirebaseMessaging(): Promise<Messaging | null> {
+  if (messagingInstance) return messagingInstance;
+  if (typeof window === 'undefined') return null;
+  if (!(await isSupported())) return null;
+  messagingInstance = getMessaging(app);
+  return messagingInstance;
 }
 
-export { auth, db, storage, messaging };
+export { auth, db, storage };


### PR DESCRIPTION
## Summary
- Avoid initializing Firebase Cloud Messaging when the environment lacks browser support
- Load push notifications only after verifying messaging support

## Testing
- `npm run lint` *(fails: Failed to load plugin 'prettier' or multiple Prettier/ESLint errors across repository)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0a0f004a0833090dfbf7413ddce8f