### PR TITLE
Style navbars with fantasy typography

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -135,3 +135,11 @@
     border-top: 1px solid rgba(255, 255, 255, 0.06);
   }
 }
+
+@layer utilities {
+  .fantasy-text {
+    font-family: 'Cinzel', serif;
+    letter-spacing: 0.05em;
+    text-shadow: 0 0 6px rgba(233, 196, 106, 0.6);
+  }
+}

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -20,7 +20,14 @@ export default function RootLayout({
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;500;600;700&display=swap" rel="stylesheet" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
       </head>
       <body className="font-body antialiased">
         <ReduxProvider>

--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -50,7 +50,7 @@ const BottomNav = () => {
                     <span className="absolute -top-1 -right-1 block w-3 h-3 bg-red-500 rounded-full" />
                   )}
                 </span>
-                <span>{label}</span>
+                <span className="fantasy-text">{label}</span>
               </Link>
             </li>
           );

--- a/front/src/components/Navbar.tsx
+++ b/front/src/components/Navbar.tsx
@@ -50,7 +50,7 @@ const Navbar = () => {
         {/* Logo */}
         <Link
           href="/home"
-          className="flex items-center gap-2 font-bold text-lg text-[color:var(--gold)]"
+          className="flex items-center gap-2 font-bold text-lg text-[color:var(--gold)] fantasy-text"
         >
           <Crown className="h-6 w-6" />
           Arena Real
@@ -74,6 +74,7 @@ const Navbar = () => {
               label={label}
               icon={icon}
               badge={href === '/chat' && hasActiveChat}
+              className="fantasy-text"
             />
           ))}
         </nav>
@@ -122,7 +123,7 @@ const Navbar = () => {
                 label={label}
                 icon={icon}
                 badge={href === '/chat' && hasActiveChat}
-                className="gap-2 px-3 py-2"
+                className="gap-2 px-3 py-2 fantasy-text"
               />
             ))}
             {isAuthenticated && user && (

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -20,7 +20,7 @@ const TopNavbar = () => {
 
   return (
     <header className="md:hidden navbar h-16 px-4 py-3 flex justify-between items-center">
-      <div className="flex items-center gap-1 font-bold text-lg text-[color:var(--gold)]">
+      <div className="flex items-center gap-1 font-bold text-lg text-[color:var(--gold)] fantasy-text">
         <Crown className="h-5 w-5" />
         Arena Real
       </div>

--- a/front/src/components/landing/Navbar.tsx
+++ b/front/src/components/landing/Navbar.tsx
@@ -1,47 +1,44 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import SwordsIcon from './SwordsIcon';
 
 export default function Navbar() {
   return (
     <header className="navbar bg-[#0d0d0d]">
-    <div className="container mx-auto px-5 flex items-center justify-between py-3">
-      
+      <div className="container mx-auto px-5 flex items-center justify-between py-3">
         {/* Logo */}
         <Link href="/" className="flex items-center gap-2">
-  <Image
-    src="/logo.png"
-    alt="Logo GladiArena"
-    width={58}
-    height={58}
-    className="object-contain"
-    priority
-  />
-  <span className="hidden sm:inline text-lg font-semibold text-[var(--gold)]">
-    Arena Real
-  </span>
-</Link>
-
-
-      {/* Nav Links */}
-      <nav aria-label="Navegación primaria" className="flex gap-2">
-        <Link 
-          href="/login" 
-          className="btn btn-ghost btn-pill px-4 py-3 text-[color:var(--gold)] hover:bg-[rgba(233,196,106,.12)]"
-        >
-          Entrar
+          <Image
+            src="/logo.png"
+            alt="Logo GladiArena"
+            width={58}
+            height={58}
+            className="object-contain"
+            priority
+          />
+          <span className="hidden sm:inline text-lg font-semibold text-[var(--gold)] fantasy-text">
+            Arena Real
+          </span>
         </Link>
 
-        <Link 
-          href="/register" 
-          aria-label="Registrarse y comenzar duelo"
-          className="btn btn-pill px-4 py-3 text-[#141414]"
-          style={{ backgroundImage: 'linear-gradient(135deg, var(--gold), var(--gold-2))' }}
-        >
-          Registrarse
-        </Link>
-      </nav>
-    </div>
-  </header>
+        {/* Nav Links */}
+        <nav aria-label="Navegación primaria" className="flex gap-2">
+          <Link
+            href="/login"
+            className="btn btn-ghost btn-pill px-4 py-3 text-[color:var(--gold)] hover:bg-[rgba(233,196,106,.12)] fantasy-text"
+          >
+            Entrar
+          </Link>
+
+          <Link
+            href="/register"
+            aria-label="Registrarse y comenzar duelo"
+            className="btn btn-pill px-4 py-3 text-[#141414] fantasy-text"
+            style={{ backgroundImage: 'linear-gradient(135deg, var(--gold), var(--gold-2))' }}
+          >
+            Registrarse
+          </Link>
+        </nav>
+      </div>
+    </header>
   );
 }


### PR DESCRIPTION
## Summary
- load Cinzel font and add `.fantasy-text` utility for elegant lettering
- apply fantasy styling across desktop, mobile and landing navbars
- remove unused import from landing navbar

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals")*

------
https://chatgpt.com/codex/tasks/task_e_68b0a829d8d88330befa522261b1c87a