### PR TITLE
Extend fantasy styling across frontend UI

### DIFF
--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -81,11 +81,11 @@ export default function LoginPage() {
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4 font-body animate-fade-in-up">
-      <Card className="w-full max-w-md shadow-card-medieval border-2 border-accent">
-        <CardHeader className="text-center">
-          <CrownIcon className="mx-auto h-16 w-16 text-accent mb-4" />
-          <CardTitle className="text-4xl font-headline text-accent">Iniciar Sesión</CardTitle>
-          <CardDescription className="text-muted-foreground text-base">
+        <Card className="w-full max-w-md shadow-card-medieval border-2 border-accent">
+          <CardHeader className="text-center">
+            <CrownIcon className="mx-auto h-16 w-16 text-accent mb-4" />
+            <CardTitle className="text-4xl">Iniciar Sesión</CardTitle>
+            <CardDescription className="text-muted-foreground text-base">
             Accede a tu cuenta de Arena Real para continuar.
           </CardDescription>
         </CardHeader>

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -69,7 +69,7 @@
             </span>
             <Icon src="/icons/espadas.png" alt="Espadas" size={94} className="mt-0" />
 
-            <h1 className="font-cinzel font-extrabold tracking-wide mt-2 text-[clamp(28px,8vw,46px)]">
+            <h1 className="font-cinzel fantasy-text font-extrabold mt-2 text-[clamp(28px,8vw,46px)]">
               DESAFÍA LA <span className="neon">ARENA REAL</span>
             </h1>
             <p className="max-w-2xl mx-auto text-muted text-[17px] mt-1">
@@ -81,14 +81,14 @@
             >
               <Link
                 href="/login"
-                className="btn btn-solid btn-lg btn-pill px-6 text-[#141414]"
+                className="btn btn-solid btn-lg btn-pill px-6 text-[#141414] fantasy-text"
                 style={{ backgroundImage: 'linear-gradient(135deg, var(--gold), var(--gold-2))' }}
               >
                 Desafiar ahora
               </Link>
               <Link
                 href="/login"
-                className="btn btn-ghost btn-lg btn-pill px-6 text-[color:var(--gold)] hover:bg-[rgba(233,196,106,.12)]"
+                className="btn btn-ghost btn-lg btn-pill px-6 text-[color:var(--gold)] hover:bg-[rgba(233,196,106,.12)] fantasy-text"
               >
                 Ver batallas
               </Link>
@@ -169,14 +169,14 @@
                 <div className="w-full max-w-[340px] grid grid-cols-1 gap-2">
                   <Link
                     href="/login"
-                    className="btn btn-solid btn-lg btn-pill px-6 text-[#141414] text-center"
+                    className="btn btn-solid btn-lg btn-pill px-6 text-[#141414] text-center fantasy-text"
                     style={{ backgroundImage: 'linear-gradient(135deg, var(--gold), var(--gold-2))' }}
                   >
                     Entrar a la Arena
                   </Link>
                   <Link
                     href="/login"
-                    className="btn btn-ghost btn-lg btn-pill px-6 text-[color:var(--gold)] hover:bg-[rgba(233,196,106,.12)] text-center"
+                    className="btn btn-ghost btn-lg btn-pill px-6 text-[color:var(--gold)] hover:bg-[rgba(233,196,106,.12)] text-center fantasy-text"
                   >
                     Ver batallas
                   </Link>

--- a/front/src/app/register/page.tsx
+++ b/front/src/app/register/page.tsx
@@ -185,9 +185,9 @@ export default function RegisterPage() {
       <Card className="w-full max-w-lg shadow-card-medieval border-2 border-accent">
         <CardHeader className="text-center">
           <CrownIcon className="mx-auto h-16 w-16 text-accent mb-4" />
-          <CardTitle className="text-4xl font-headline text-accent">
-            {step === 1 ? "Crea Tu Cuenta" : `Completa tu Perfil, ${googleAuthData?.username || ''}`}
-          </CardTitle>
+            <CardTitle className="text-4xl">
+              {step === 1 ? "Crea Tu Cuenta" : `Completa tu Perfil, ${googleAuthData?.username || ''}`}
+            </CardTitle>
           <CardDescription className="text-muted-foreground text-base">
             {step === 1 ? "¡Únete a Arena Real y empieza a apostar!" : "Necesitamos unos detalles más para empezar."}
           </CardDescription>

--- a/front/src/components/ui/CartoonButton.tsx
+++ b/front/src/components/ui/CartoonButton.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from "class-variance-authority";
 
 const cartoonButtonVariants = cva(
-  "inline-flex items-center justify-center rounded-lg font-headline text-lg font-semibold tracking-wide transition-transform duration-150 ease-in-out hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-0.5 disabled:pointer-events-none disabled:opacity-70",
+  "inline-flex items-center justify-center rounded-lg fantasy-text text-lg font-semibold tracking-wide transition-transform duration-150 ease-in-out hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-0.5 disabled:pointer-events-none disabled:opacity-70",
   {
     variants: {
       variant: {

--- a/front/src/components/ui/button.tsx
+++ b/front/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium fantasy-text ring-offset-background transition-colors transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/front/src/components/ui/card.tsx
+++ b/front/src/components/ui/card.tsx
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      "fantasy-text text-[color:var(--gold)] text-2xl font-semibold leading-none tracking-tight",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- add `fantasy-text` class to shared button components for consistent gladiator typography
- style `CardTitle` with gold fantasy font and update login/register headers

## Testing
- `npm run lint` *(fails: numerous prettier errors across repo)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0b6d116f48330bc69882b26d1507b