### PR TITLE
feat: add dark theme design tokens

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -1,104 +1,19 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --background: 210 20% 92%; /* Light stone gray, slightly cool */
-    --foreground: 225 40% 20%; /* Dark desaturated blue for text */
-
-    --card: 210 20% 98%; /* Lighter card background for contrast */
-    --card-foreground: 225 40% 20%;
-
-    --popover: 210 20% 98%;
-    --popover-foreground: 225 40% 20%;
-
-    --primary: 221 71% 55%; /* Royal Blue */
-    --primary-foreground: 0 0% 100%; /* White */
-    --primary-dark: 221 71% 45%; /* Darker Royal Blue for button 3D effect */
-
-    --secondary: 210 15% 85%; /* Slightly darker stone gray for secondary elements */
-    --secondary-foreground: 225 40% 25%;
-
-    --muted: 210 15% 80%;
-    --muted-foreground: 225 20% 45%;
-
-    --accent: 51 100% 50%; /* Gold */
-    --accent-foreground: 45 100% 15%; /* Dark Brown/Black for text on gold */
-
-    --destructive: 0 70% 45%; /* Darker, less saturated red */
-    --destructive-foreground: 0 0% 100%;
-
-    --border: 210 10% 75%; /* Grayer border */
-    --input: 210 15% 90%; /* Lighter input background */
-    --ring: 221 71% 55%; /* Primary color for rings */
-
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --radius: 0.8rem; /* Slightly larger radius for cartoonish feel */
-
-    /* Sidebar variables (can keep default or adjust if sidebar is used extensively) */
-    --sidebar-background: 210 20% 96%;
-    --sidebar-foreground: 225 40% 20%;
-    --sidebar-primary: 221 71% 55%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 51 100% 50%;
-    --sidebar-accent-foreground: 45 100% 15%;
-    --sidebar-border: 210 10% 80%;
-    --sidebar-ring: 221 71% 55%;
-  }
-
-  .dark {
-    /* Keeping dark mode similar for brevity, can be customized later */
-    --background: 225 20% 10%;
-    --foreground: 210 20% 95%;
-
-    --card: 225 20% 12%;
-    --card-foreground: 210 20% 95%;
-
-    --popover: 225 20% 12%;
-    --popover-foreground: 210 20% 95%;
-
-    --primary: 221 71% 60%;
-    --primary-foreground: 0 0% 100%;
-    --primary-dark: 221 71% 50%;
-
-    --secondary: 210 15% 20%;
-    --secondary-foreground: 210 20% 95%;
-
-    --muted: 210 15% 25%;
-    --muted-foreground: 210 20% 65%;
-
-    --accent: 51 100% 55%;
-    --accent-foreground: 45 100% 10%;
-
-    --destructive: 0 70% 50%;
-    --destructive-foreground: 0 0% 100%;
-
-    --border: 210 10% 30%;
-    --input: 210 15% 22%;
-    --ring: 221 71% 60%;
-
-    --sidebar-background: 225 20% 12%;
-    --sidebar-foreground: 210 20% 95%;
-    --sidebar-primary: 221 71% 60%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 51 100% 55%;
-    --sidebar-accent-foreground: 45 100% 10%;
-    --sidebar-border: 210 10% 30%;
-    --sidebar-ring: 221 71% 60%;
-  }
-}
-
-@layer base {
   * {
-    @apply border-border;
+    @apply border-stroke;
   }
+
   body {
-    @apply bg-background text-foreground antialiased;
-    background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23c7c7c7' fill-opacity='0.1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E"); /* Subtle stone-like texture */
+    @apply bg-bg text-text-primary font-ui antialiased;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-display;
   }
 }

--- a/front/tailwind.config.ts
+++ b/front/tailwind.config.ts
@@ -1,122 +1,35 @@
-import type {Config} from 'tailwindcss';
+import type { Config } from 'tailwindcss';
 
 export default {
   darkMode: ['class'],
-  content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
-  ],
+  content: ['src/**/*.{ts,tsx,js,jsx,html}'],
   theme: {
-    container: {
-      center: true,
-      padding: "2rem",
-      screens: {
-        "2xl": "1400px",
-      },
-    },
     extend: {
-      fontFamily: {
-        body: ['Fredoka', 'sans-serif'],
-        headline: ['Fredoka', 'sans-serif'],
-        code: ['monospace'],
-      },
       colors: {
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
-        card: {
-          DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))',
+        bg: '#0B0D0E',
+        panel: '#111315',
+        panel2: '#0E1113',
+        gold: {
+          DEFAULT: '#E8C26E',
+          strong: '#F2D27F',
         },
-        popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
+        text: {
+          primary: '#EDEDED',
+          secondary: '#A9AFB6',
         },
-        primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
-          dark: 'hsl(var(--primary-dark))',
-        },
-        secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
-        },
-        muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
-        },
-        accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
-        },
-        destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
-        },
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
-        chart: {
-          '1': 'hsl(var(--chart-1))',
-          '2': 'hsl(var(--chart-2))',
-          '3': 'hsl(var(--chart-3))',
-          '4': 'hsl(var(--chart-4))',
-          '5': 'hsl(var(--chart-5))',
-        },
-        sidebar: {
-          DEFAULT: 'hsl(var(--sidebar-background))',
-          foreground: 'hsl(var(--sidebar-foreground))',
-          primary: 'hsl(var(--sidebar-primary))',
-          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-          accent: 'hsl(var(--sidebar-accent))',
-          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-          border: 'hsl(var(--sidebar-border))',
-          ring: 'hsl(var(--sidebar-ring))',
-        },
+        stroke: '#2A2F33',
+        success: '#7ED57A',
+        error: '#F16A6A',
       },
       borderRadius: {
-        lg: 'var(--radius)',
-        md: 'calc(var(--radius) - 2px)',
-        sm: 'calc(var(--radius) - 4px)',
+        '2xl': '1.25rem',
       },
       boxShadow: {
-        'cartoon': '0 4px 0 hsl(var(--primary-dark)), 0 6px 10px rgba(0,0,0,0.2)',
-        'cartoon-sm': '0 2px 0 hsl(var(--primary-dark)), 0 3px 5px rgba(0,0,0,0.15)',
-        'cartoon-active': '0 2px 0 hsl(var(--primary-dark)), 0 3px 5px rgba(0,0,0,0.2)',
-        'card-medieval': '5px 5px 0px 0px hsl(var(--border))',
+        soft: '0 8px 24px rgba(0,0,0,0.25)',
       },
-      keyframes: {
-        'accordion-down': {
-          from: {
-            height: '0',
-          },
-          to: {
-            height: 'var(--radix-accordion-content-height)',
-          },
-        },
-        'accordion-up': {
-          from: {
-            height: 'var(--radix-accordion-content-height)',
-          },
-          to: {
-            height: '0',
-          },
-        },
-        'subtle-bounce': {
-          '0%, 100%': { transform: 'translateY(0)' },
-          '50%': { transform: 'translateY(-3px)' },
-        },
-        'fade-in-up': {
-          '0%': { opacity: '0', transform: 'translateY(10px)' },
-          '100%': { opacity: '1', transform: 'translateY(0)' },
-        }
-      },
-      animation: {
-        'accordion-down': 'accordion-down 0.2s ease-out',
-        'accordion-up': 'accordion-up 0.2s ease-out',
-        'subtle-bounce': 'subtle-bounce 1.5s ease-in-out infinite',
-        // speed up modal entrance to avoid perceived lag
-        'fade-in-up': 'fade-in-up 0.2s ease-out forwards',
+      fontFamily: {
+        display: ['Poppins', 'ui-sans-serif', 'system-ui'],
+        ui: ['Inter', 'ui-sans-serif', 'system-ui'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- define dark theme tokens in Tailwind config
- set global fonts and base color styling

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck` *(fails: Cannot find module '@radix-ui/react-separator'; type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bc27b3e48330b6f714f72439315d