### PR TITLE
feat: add dark theme tokens

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -35,12 +35,18 @@
 
     --radius: 18px;
 
-    --bg: #0b0f14;
-    --bg-elev: #121721;
-    --text: #f2f3f7;
-    --gold: #e9c46a;
-    --gold-2: #cda434;
-    --gold-3: #fff2b2;
+    --bg: #0B0D0E;
+    --panel: #111315;
+    --panel-2: #0E1113;
+    --text-primary: #EDEDED;
+    --text-secondary: #A9AFB6;
+    --gold: #E8C26E;
+    --gold-strong: #F2D27F;
+    --stroke: #2A2F33;
+    --success: #7ED57A;
+    --error: #F16A6A;
+    --radius-2xl: 1.25rem;
+    --shadow-soft: 0 8px 24px rgba(0,0,0,0.25);
     --safe: max(env(safe-area-inset-bottom), 16px);
   }
 
@@ -76,12 +82,18 @@
 
     --radius: 18px;
 
-    --bg: #0b0f14;
-    --bg-elev: #121721;
-    --text: #f2f3f7;
-    --gold: #e9c46a;
-    --gold-2: #cda434;
-    --gold-3: #fff2b2;
+    --bg: #0B0D0E;
+    --panel: #111315;
+    --panel-2: #0E1113;
+    --text-primary: #EDEDED;
+    --text-secondary: #A9AFB6;
+    --gold: #E8C26E;
+    --gold-strong: #F2D27F;
+    --stroke: #2A2F33;
+    --success: #7ED57A;
+    --error: #F16A6A;
+    --radius-2xl: 1.25rem;
+    --shadow-soft: 0 8px 24px rgba(0,0,0,0.25);
     --safe: max(env(safe-area-inset-bottom), 16px);
   }
 }
@@ -95,9 +107,9 @@
     height: 100%;
   }
   body {
-    @apply font-sans antialiased;
+    @apply font-body antialiased;
     background: var(--bg);
-    color: var(--text);
+    color: var(--text-primary);
   }
 
   @keyframes gradient-x {

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -21,11 +21,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;500;600;700&display=swap"
-          rel="stylesheet"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@700&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/front/tailwind.config.ts
+++ b/front/tailwind.config.ts
@@ -17,11 +17,25 @@ export default {
     },
     extend: {
       fontFamily: {
-        body: ['Fredoka', 'sans-serif'],
-        headline: ['Fredoka', 'sans-serif'],
+        body: ['Inter', 'ui-sans-serif', 'system-ui'],
+        headline: ['Poppins', 'ui-sans-serif', 'system-ui'],
         code: ['monospace'],
       },
       colors: {
+        bg: '#0B0D0E',
+        panel: '#111315',
+        panel2: '#0E1113',
+        gold: {
+          DEFAULT: '#E8C26E',
+          strong: '#F2D27F',
+        },
+        text: {
+          primary: '#EDEDED',
+          secondary: '#A9AFB6',
+        },
+        stroke: '#2A2F33',
+        success: '#7ED57A',
+        error: '#F16A6A',
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
         card: {
@@ -78,8 +92,10 @@ export default {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
+        '2xl': '1.25rem',
       },
       boxShadow: {
+        soft: '0 8px 24px rgba(0,0,0,0.25)',
         'cartoon': '0 4px 0 hsl(var(--primary-dark)), 0 6px 10px rgba(0,0,0,0.2)',
         'cartoon-sm': '0 2px 0 hsl(var(--primary-dark)), 0 3px 5px rgba(0,0,0,0.15)',
         'cartoon-active': '0 2px 0 hsl(var(--primary-dark)), 0 3px 5px rgba(0,0,0,0.2)',


### PR DESCRIPTION
## Summary
- add premium dark palette and font families to Tailwind config
- define CSS variables for gold-accented dark theme
- load Inter and Poppins fonts globally

## Testing
- `npm run lint` *(fails: Failed to load plugin 'prettier' declared in '.eslintrc.json')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0c1f3766c8330b29f5e7f85fa258f