### PR TITLE
Enlarge navbar logo and hide username

### DIFF
--- a/front/src/components/Navbar.tsx
+++ b/front/src/components/Navbar.tsx
@@ -52,7 +52,7 @@ const Navbar = () => {
           href="/home"
           className="flex items-center gap-2 font-bold text-lg text-[color:var(--gold)] fantasy-text"
         >
-          <Image src="/logo.png" alt="Arena Real logo" width={24} height={24} className="h-6 w-6" />
+          <Image src="/logo.png" alt="Arena Real logo" width={32} height={32} className="h-8 w-8" />
           Arena Real
         </Link>
 

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -22,7 +22,7 @@ const TopNavbar = () => {
   return (
     <header className="md:hidden navbar h-16 px-4 py-3 flex justify-between items-center">
       <div className="flex items-center gap-1 font-bold text-lg text-[color:var(--gold)] fantasy-text">
-        <Image src="/logo.png" alt="Arena Real logo" width={20} height={20} className="h-5 w-5" />
+        <Image src="/logo.png" alt="Arena Real logo" width={32} height={32} className="h-8 w-8" />
         Arena Real
       </div>
 
@@ -62,10 +62,7 @@ const TopNavbar = () => {
         </DropdownMenu>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <button className="flex items-center gap-2 focus-visible:outline-none transition-transform hover:scale-105">
-              <span className="text-sm font-medium">
-                {user?.username || 'Invitado'}
-              </span>
+            <button className="flex items-center focus-visible:outline-none transition-transform hover:scale-105">
               {avatarSrc ? (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img src={avatarSrc} alt={user?.username} className="w-8 h-8 rounded-full" />


### PR DESCRIPTION
## Summary
- enlarge Arena Real logo in navbars
- hide username from mobile navbar

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck` *(fails: Cannot find module '@radix-ui/react-separator')*

------
https://chatgpt.com/codex/tasks/task_e_68b0d05facb08330871f9b6eb5f4f4e2