### PR TITLE
Apply gladiator dark-gold theme

### DIFF
--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -29,6 +29,7 @@ import {
   Banknote,
   Loader2,
 } from '@/components/icons/lazy';
+import HelmetIcon from '@/components/icons/Helmet';
 import {
   requestTransactionAction,
   matchmakingAction,
@@ -470,7 +471,7 @@ const HomePageContent = () => {
         toast({
           title: 'Error al cancelar',
           description: result.error,
-        variant: 'error',
+          variant: 'error',
         });
       } else {
         toast({
@@ -499,12 +500,11 @@ const HomePageContent = () => {
             </AvatarFallback>
           </Avatar>
           <div>
-        <CardTitle className="text-[22px]">
+            <CardTitle className="text-[22px] font-headline flex items-center gap-2">
+              <HelmetIcon className="h-6 w-6 text-gold" />
               {user.username}
             </CardTitle>
-            <CardDescription>
-              ¡Bienvenido de nuevo, Gladiador!
-            </CardDescription>
+            <CardDescription>¡Bienvenido de nuevo, Gladiador!</CardDescription>
           </div>
         </div>
         <Card
@@ -554,14 +554,15 @@ const HomePageContent = () => {
             Buscar Duelo
           </CardTitle>
           <CardDescription className="text-center">
-            Inscripción $6.000 COP. Ganador recibe $10.800 COP. Requiere saldo ≥ $6.000.
+            Inscripción $6.000 COP. Ganador recibe $10.800 COP. Requiere saldo ≥
+            $6.000.
           </CardDescription>
         </CardHeader>
         <CardContent className="flex justify-center">
           <Button
             variant="primary"
             onClick={handleOpenModeModal}
-            className="w-full sm:w-auto"
+            className="w-full sm:w-auto px-8 py-4 text-xl font-headline"
             disabled={user.balance < 6000}
           >
             <Swords className="h-5 w-5" /> Buscar Oponente

--- a/front/src/app/(app)/layout.tsx
+++ b/front/src/app/(app)/layout.tsx
@@ -19,9 +19,13 @@ export default function RootLayout({
     <html lang="es">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@700&display=swap"
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -4,84 +4,224 @@
 
 /* ✅ Tema SOLO para el app (NO landing) */
 @layer base {
-  [data-theme="arena-app"] {
-    --bg:#0B0D0E;
-    --panel:#111315;
-    --panel-2:#0E1113;
-    --text:#EDEDED;
-    --muted:#A9AFB6;
-    --stroke:#23272B;
-    --gold:#E8C26E;
-    --gold-strong:#F2D27F;
-    --success:#7ED57A;
-    --error:#F16A6A;
-    --radius:16px;
-    --shadow:0 8px 24px rgba(0,0,0,.25);
+  [data-theme='arena-app'] {
+    --bg: #0b0f14;
+    --bg-end: #111418;
+    --panel: #111315;
+    --panel-2: #0e1113;
+    --text: #ededed;
+    --muted: #a9afb6;
+    --stroke: #23272b;
+    --gold: #ffd369;
+    --gold-strong: #d4af37;
+    --gold-dark: #b98c2a;
+    --success: #7ed57a;
+    --error: #f16a6a;
+    --radius: 16px;
+    --shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
     /* shadcn/ui variables mapped to design tokens */
-    --background:213 29% 6%;
-    --foreground:228 24% 96%;
-    --card:var(--panel);
-    --card-foreground:var(--text);
-    --popover:var(--panel);
-    --popover-foreground:var(--text);
-    --primary:43 74% 66%;
-    --primary-foreground:0 0% 8%;
-    --primary-dark:44 60% 50%;
-    --secondary:var(--panel);
-    --secondary-foreground:var(--text);
-    --muted-bg:var(--panel-2);
-    --muted-foreground:var(--muted);
-    --accent:43 74% 66%;
-    --accent-foreground:0 0% 8%;
-    --destructive:0 70% 45%;
-    --destructive-foreground:0 0% 100%;
-    --border:var(--stroke);
-    --input:var(--stroke);
-    --ring:var(--gold);
-    background:var(--bg);
-    color:var(--text);
+    --background: 213 29% 6%;
+    --foreground: 228 24% 96%;
+    --card: var(--panel);
+    --card-foreground: var(--text);
+    --popover: var(--panel);
+    --popover-foreground: var(--text);
+    --primary: 42 100% 71%;
+    --primary-foreground: 0 0% 8%;
+    --primary-dark: 41 63% 45%;
+    --secondary: var(--panel);
+    --secondary-foreground: var(--text);
+    --muted-bg: var(--panel-2);
+    --muted-foreground: var(--muted);
+    --accent: 42 100% 71%;
+    --accent-foreground: 0 0% 8%;
+    --destructive: 0 70% 45%;
+    --destructive-foreground: 0 0% 100%;
+    --border: var(--stroke);
+    --input: var(--stroke);
+    --ring: var(--gold);
+    background: linear-gradient(180deg, var(--bg) 0%, var(--bg-end) 100%);
+    color: var(--text);
   }
 
-  [data-theme="arena-app"] * {@apply border-border;}
+  [data-theme='arena-app'] * {
+    @apply border-border;
+  }
 
-  html,body{height:100%;}
+  html,
+  body {
+    height: 100%;
+  }
 
-  body{@apply font-body antialiased;}
+  body {
+    @apply font-body antialiased;
+  }
 
-  a:focus-visible{outline:2px solid var(--gold);outline-offset:2px;}
+  a:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: 2px;
+  }
 
-  @media (prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important;}}
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation: none !important;
+      transition: none !important;
+    }
+  }
 
-  @keyframes gradient-x{0%{background-position:0% 50%;}50%{background-position:100% 50%;}100%{background-position:0% 50%;}}
-  .animate-gradient-x{background-size:200% 200%;animation:gradient-x 8s ease infinite;}
+  @keyframes gradient-x {
+    0% {
+      background-position: 0% 50%;
+    }
+    50% {
+      background-position: 100% 50%;
+    }
+    100% {
+      background-position: 0% 50%;
+    }
+  }
+  .animate-gradient-x {
+    background-size: 200% 200%;
+    animation: gradient-x 8s ease infinite;
+  }
 }
 
 @layer components {
-  [data-theme="arena-app"] .navbar{@apply sticky top-0 z-50;backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);background:color-mix(in srgb,var(--bg) 90%,transparent);border-bottom:1px solid var(--stroke);}
+  [data-theme='arena-app'] .navbar {
+    @apply sticky top-0 z-50;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    background: color-mix(in srgb, var(--bg) 90%, transparent);
+    border-bottom: 1px solid var(--stroke);
+  }
 
-  [data-theme="arena-app"] .card{background:var(--panel);border:1px solid var(--stroke);border-radius:var(--radius);box-shadow:var(--shadow);padding:16px;}
-  [data-theme="arena-app"] .card--alt{background:var(--panel-2);}
+  [data-theme='arena-app'] .card {
+    background: var(--panel);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius);
+    box-shadow: 0 4px 12px rgba(212, 175, 55, 0.15);
+    padding: 16px;
+  }
+  [data-theme='arena-app'] .card--alt {
+    background: var(--panel-2);
+  }
 
-  [data-theme="arena-app"] .title{color:var(--gold);font-weight:800;letter-spacing:.3px;text-shadow:0 0 12px rgba(232,194,110,.15);}
-  [data-theme="arena-app"] .subtitle{color:var(--muted);}
+  [data-theme='arena-app'] .title {
+    color: var(--gold);
+    font-weight: 800;
+    letter-spacing: 0.3px;
+    text-shadow: 0 0 12px rgba(232, 194, 110, 0.15);
+  }
+  [data-theme='arena-app'] .subtitle {
+    color: var(--muted);
+  }
 
-  [data-theme="arena-app"] .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;height:44px;padding:0 16px;border-radius:14px;font-weight:700;transition:transform .08s,box-shadow .15s,background-color .15s;}
-  [data-theme="arena-app"] .btn:active{transform:translateY(1px);}
-  [data-theme="arena-app"] .btn--primary{background:var(--gold);color:var(--bg);box-shadow:0 6px 0 rgba(232,194,110,.25);}
-  [data-theme="arena-app"] .btn--primary:hover{background:var(--gold-strong);}
-  [data-theme="arena-app"] .btn--outline{background:transparent;color:var(--text);border:1px solid var(--gold);}
-  [data-theme="arena-app"] .btn--ghost{background:transparent;border:1px solid var(--stroke);color:var(--text);}
-  [data-theme="arena-app"] .btn--sm{height:40px;padding:0 14px;border-radius:12px;}
+  [data-theme='arena-app'] .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    height: 44px;
+    padding: 0 16px;
+    border-radius: 14px;
+    font-weight: 700;
+    transform: scale(0.98);
+    transition:
+      transform 0.2s,
+      box-shadow 0.2s,
+      background-color 0.2s;
+  }
+  [data-theme='arena-app'] .btn:hover {
+    transform: scale(1.02);
+    box-shadow: 0 0 12px rgba(255, 211, 105, 0.4);
+  }
+  [data-theme='arena-app'] .btn:active {
+    transform: scale(0.98) translateY(1px);
+  }
+  [data-theme='arena-app'] .btn:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: 2px;
+  }
+  [data-theme='arena-app'] .btn--primary {
+    background: linear-gradient(180deg, #ffd369 0%, #d4af37 100%);
+    color: #000;
+    border: 1px solid var(--gold-dark);
+  }
+  [data-theme='arena-app'] .btn--primary:hover {
+    box-shadow: 0 0 15px rgba(212, 175, 55, 0.6);
+  }
+  [data-theme='arena-app'] .btn--outline {
+    background: transparent;
+    color: var(--gold);
+    border: 1px solid var(--gold);
+  }
+  [data-theme='arena-app'] .btn--ghost {
+    background: transparent;
+    border: 1px solid var(--stroke);
+    color: var(--text);
+  }
+  [data-theme='arena-app'] .btn--sm {
+    height: 40px;
+    padding: 0 14px;
+    border-radius: 12px;
+  }
 
-  [data-theme="arena-app"] .badge{display:inline-flex;align-items:center;gap:8px;font-weight:700;font-size:12px;padding:8px 16px;border-radius:999px;background:color-mix(in srgb,var(--gold) 15%,transparent);color:var(--gold);}
+  [data-theme='arena-app'] .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 700;
+    font-size: 12px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--gold) 15%, transparent);
+    color: var(--gold);
+  }
 
-  [data-theme="arena-app"] .bottom-nav{position:fixed;left:0;right:0;bottom:0;background:color-mix(in srgb,var(--bg) 92%,transparent);backdrop-filter:blur(6px);border-top:1px solid var(--stroke);display:grid;grid-template-columns:repeat(5,1fr);padding:8px;z-index:50;}
-  [data-theme="arena-app"] .tab{display:flex;flex-direction:column;align-items:center;gap:8px;color:var(--muted);font-size:11px;min-width:44px;min-height:44px;padding:8px 0;}
-  [data-theme="arena-app"] .tab svg{width:20px;height:20px;opacity:.9;}
-  [data-theme="arena-app"] .tab--active{color:var(--gold);}
-  [data-theme="arena-app"] .tab:active{transform:translateY(1px);}
+  [data-theme='arena-app'] .bottom-nav {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: color-mix(in srgb, var(--bg) 92%, transparent);
+    backdrop-filter: blur(6px);
+    border-top: 1px solid var(--stroke);
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    padding: 8px;
+    z-index: 50;
+  }
+  [data-theme='arena-app'] .tab {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    color: var(--muted);
+    font-size: 11px;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 8px 0;
+  }
+  [data-theme='arena-app'] .tab svg {
+    width: 20px;
+    height: 20px;
+    opacity: 0.9;
+  }
+  [data-theme='arena-app'] .tab--active {
+    color: var(--gold);
+    text-shadow: 0 0 8px rgba(255, 211, 105, 0.4);
+  }
+  [data-theme='arena-app'] .tab:active {
+    transform: translateY(1px);
+  }
 }
 
 @layer utilities {
-  .fantasy-text{font-family:'Cinzel',serif;letter-spacing:.05em;text-shadow:0 0 6px rgba(233,196,106,.6);}
+  .fantasy-text {
+    font-family: 'Cinzel', serif;
+    letter-spacing: 0.05em;
+    text-shadow: 0 0 6px rgba(233, 196, 106, 0.6);
+  }
 }

--- a/front/src/components/BottomNav.tsx
+++ b/front/src/components/BottomNav.tsx
@@ -1,17 +1,17 @@
-"use client";
+'use client';
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useAuth } from "@/hooks/useAuth";
-import useActiveChat from "@/hooks/useActiveChat";
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth';
+import useActiveChat from '@/hooks/useActiveChat';
 import {
-  Home,
+  Shield,
   MessageCircle,
   ScrollText,
   Trophy,
-  Users,
-} from "@/components/icons/lazy";
-import { cn } from "@/lib/utils";
+  Award,
+} from '@/components/icons/lazy';
+import { cn } from '@/lib/utils';
 
 const BottomNav = () => {
   const pathname = usePathname();
@@ -19,11 +19,11 @@ const BottomNav = () => {
   const { activeChatId } = useActiveChat(user?.id);
   const hasActiveChat = Boolean(activeChatId);
   const navItems = [
-    { id: "inicio", label: "Inicio", href: "/home", icon: Home },
-    { id: "chat", label: "Chat", href: "/chat", icon: MessageCircle },
-    { id: "historial", label: "Historial", href: "/history", icon: ScrollText },
-    { id: "torneo", label: "Torneo", href: "/torneos", icon: Trophy },
-    { id: "referidos", label: "Referidos", href: "/referrals", icon: Users },
+    { id: 'inicio', label: 'Inicio', href: '/home', icon: Shield },
+    { id: 'chat', label: 'Chat', href: '/chat', icon: MessageCircle },
+    { id: 'historial', label: 'Historial', href: '/history', icon: ScrollText },
+    { id: 'torneo', label: 'Torneo', href: '/torneos', icon: Trophy },
+    { id: 'referidos', label: 'Referidos', href: '/referrals', icon: Award },
   ];
 
   return (
@@ -35,11 +35,11 @@ const BottomNav = () => {
             <li key={id}>
               <Link
                 href={href}
-                className={cn("tab", isActive && "tab--active")}
+                className={cn('tab', isActive && 'tab--active')}
               >
                 <span className="relative">
                   <Icon />
-                  {id === "chat" && hasActiveChat && (
+                  {id === 'chat' && hasActiveChat && (
                     <span className="absolute -top-1 -right-1 block w-3 h-3 bg-error rounded-full" />
                   )}
                 </span>

--- a/front/src/components/icons/Helmet.tsx
+++ b/front/src/components/icons/Helmet.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+const HelmetIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M4 14v-2a8 8 0 0 1 16 0v2" />
+    <path d="M12 3v5l3 2-3 2-3-2 3-2" />
+    <path d="M9 14h6v8H9z" />
+    <path d="M4 22h16" />
+  </svg>
+);
+
+export default HelmetIcon;

--- a/front/src/components/icons/lazy.tsx
+++ b/front/src/components/icons/lazy.tsx
@@ -1,19 +1,78 @@
 import dynamic from 'next/dynamic';
 
-export const Bell = dynamic(() => import('lucide-react').then(m => ({ default: m.Bell })), { ssr: false });
-export const Home = dynamic(() => import('lucide-react').then(m => ({ default: m.Home })), { ssr: false });
-export const Trophy = dynamic(() => import('lucide-react').then(m => ({ default: m.Trophy })), { ssr: false });
-export const Menu = dynamic(() => import('lucide-react').then(m => ({ default: m.Menu })), { ssr: false });
-export const ScrollText = dynamic(() => import('lucide-react').then(m => ({ default: m.ScrollText })), { ssr: false });
-export const MessageCircle = dynamic(() => import('lucide-react').then(m => ({ default: m.MessageCircle })), { ssr: false });
-export const Users = dynamic(() => import('lucide-react').then(m => ({ default: m.Users })), { ssr: false });
-export const Swords = dynamic(() => import('lucide-react').then(m => ({ default: m.Swords })), { ssr: false });
-export const Layers = dynamic(() => import('lucide-react').then(m => ({ default: m.Layers })), { ssr: false });
-export const UploadCloud = dynamic(() => import('lucide-react').then(m => ({ default: m.UploadCloud })), { ssr: false });
-export const Coins = dynamic(() => import('lucide-react').then(m => ({ default: m.Coins })), { ssr: false });
-export const Loader2 = dynamic(() => import('lucide-react').then(m => ({ default: m.Loader2 })), { ssr: false });
-export const Send = dynamic(() => import('lucide-react').then(m => ({ default: m.Send })), { ssr: false });
-export const LinkIcon = dynamic(() => import('lucide-react').then(m => ({ default: m.Link })), { ssr: false });
-export const CheckCircle = dynamic(() => import('lucide-react').then(m => ({ default: m.CheckCircle })), { ssr: false });
-export const XCircle = dynamic(() => import('lucide-react').then(m => ({ default: m.XCircle })), { ssr: false });
-export const Banknote = dynamic(() => import('lucide-react').then(m => ({ default: m.Banknote })), { ssr: false });
+export const Bell = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Bell })),
+  { ssr: false }
+);
+export const Home = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Home })),
+  { ssr: false }
+);
+export const Trophy = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Trophy })),
+  { ssr: false }
+);
+export const Menu = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Menu })),
+  { ssr: false }
+);
+export const ScrollText = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.ScrollText })),
+  { ssr: false }
+);
+export const MessageCircle = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.MessageCircle })),
+  { ssr: false }
+);
+export const Users = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Users })),
+  { ssr: false }
+);
+export const Shield = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Shield })),
+  { ssr: false }
+);
+export const Award = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Award })),
+  { ssr: false }
+);
+export const Swords = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Swords })),
+  { ssr: false }
+);
+export const Layers = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Layers })),
+  { ssr: false }
+);
+export const UploadCloud = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.UploadCloud })),
+  { ssr: false }
+);
+export const Coins = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Coins })),
+  { ssr: false }
+);
+export const Loader2 = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Loader2 })),
+  { ssr: false }
+);
+export const Send = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Send })),
+  { ssr: false }
+);
+export const LinkIcon = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Link })),
+  { ssr: false }
+);
+export const CheckCircle = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.CheckCircle })),
+  { ssr: false }
+);
+export const XCircle = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.XCircle })),
+  { ssr: false }
+);
+export const Banknote = dynamic(
+  () => import('lucide-react').then((m) => ({ default: m.Banknote })),
+  { ssr: false }
+);

--- a/front/src/components/ui/CartoonButton.tsx
+++ b/front/src/components/ui/CartoonButton.tsx
@@ -1,29 +1,33 @@
-"use client";
+'use client';
 
 import React from 'react';
-import { Slot } from "@radix-ui/react-slot";
+import { Slot } from '@radix-ui/react-slot';
 import { cn } from '@/lib/utils';
-import { cva, type VariantProps } from "class-variance-authority";
+import { cva, type VariantProps } from 'class-variance-authority';
 
 const cartoonButtonVariants = cva(
-  "inline-flex items-center justify-center rounded-lg fantasy-text text-lg font-semibold tracking-wide transition-transform duration-150 ease-in-out hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-0.5 disabled:pointer-events-none disabled:opacity-70",
+  'inline-flex items-center justify-center rounded-lg fantasy-text text-lg font-semibold tracking-wide transition-transform duration-150 ease-in-out hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-0.5 disabled:pointer-events-none disabled:opacity-70',
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground border-b-4 border-primary-dark shadow-cartoon hover:brightness-110 hover:-translate-y-0.5 active:shadow-cartoon-active active:border-b-2",
-        secondary: "bg-secondary text-secondary-foreground border-b-4 border-[hsl(var(--secondary))] shadow-cartoon hover:brightness-110 hover:-translate-y-0.5 active:shadow-cartoon-active active:border-b-2", // Example, define secondary-dark if needed
-        accent: "bg-accent text-accent-foreground border-b-4 border-[hsl(var(--accent))] shadow-cartoon hover:brightness-110 hover:-translate-y-0.5 active:shadow-cartoon-active active:border-b-2", // Example, define accent-dark if needed
-        destructive: "bg-destructive text-destructive-foreground border-b-4 border-[hsl(var(--destructive))] shadow-cartoon hover:brightness-110 hover:-translate-y-0.5 active:shadow-cartoon-active active:border-b-2", // Example, define destructive-dark if needed
+        default:
+          'bg-gradient-to-b from-[#FFD369] to-[#D4AF37] text-black border-b-4 border-[#B98C2A] shadow-cartoon hover:shadow-[0_0_10px_rgba(255,211,105,0.5)] hover:-translate-y-0.5 active:shadow-cartoon-active active:border-b-2',
+        secondary:
+          'bg-transparent text-[#FFD369] border-2 border-[#D4AF37] shadow-cartoon hover:shadow-[0_0_10px_rgba(255,211,105,0.4)] hover:-translate-y-0.5 active:shadow-cartoon-active',
+        accent:
+          'bg-accent text-accent-foreground border-b-4 border-[hsl(var(--accent))] shadow-cartoon hover:brightness-110 hover:-translate-y-0.5 active:shadow-cartoon-active active:border-b-2', // Example, define accent-dark if needed
+        destructive:
+          'bg-destructive text-destructive-foreground border-b-4 border-[hsl(var(--destructive))] shadow-cartoon hover:brightness-110 hover:-translate-y-0.5 active:shadow-cartoon-active active:border-b-2', // Example, define destructive-dark if needed
       },
       size: {
-        default: "px-8 py-4 text-xl", // Large buttons
-        medium: "px-6 py-3 text-lg",
-        small: "px-4 py-2 text-base",
+        default: 'px-8 py-4 text-xl', // Large buttons
+        medium: 'px-6 py-3 text-lg',
+        small: 'px-4 py-2 text-base',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
   }
 );
@@ -37,8 +41,20 @@ export interface CartoonButtonProps
 }
 
 const CartoonButton = React.forwardRef<HTMLButtonElement, CartoonButtonProps>(
-  ({ className, variant, size, asChild = false, iconLeft, iconRight, children, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
+  (
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      iconLeft,
+      iconRight,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const Comp = asChild ? Slot : 'button';
     return (
       <Comp
         className={cn(cartoonButtonVariants({ variant, size, className }))}
@@ -52,6 +68,6 @@ const CartoonButton = React.forwardRef<HTMLButtonElement, CartoonButtonProps>(
     );
   }
 );
-CartoonButton.displayName = "CartoonButton";
+CartoonButton.displayName = 'CartoonButton';
 
 export { CartoonButton, cartoonButtonVariants };

--- a/front/src/components/ui/StatTile.tsx
+++ b/front/src/components/ui/StatTile.tsx
@@ -1,24 +1,34 @@
-import * as React from "react";
+import * as React from 'react';
 
-import { cn } from "@/lib/utils";
+import { cn } from '@/lib/utils';
 
 interface StatTileProps extends React.HTMLAttributes<HTMLDivElement> {
   icon?: React.ReactNode;
   value: React.ReactNode;
   label: React.ReactNode;
-  align?: "start" | "end";
+  align?: 'start' | 'end';
 }
 
 export const StatTile = React.forwardRef<HTMLDivElement, StatTileProps>(
-  ({ icon, value, label, align = "start", className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-center gap-2", className)} {...props}>
+  ({ icon, value, label, align = 'start', className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('flex items-center gap-2', className)}
+      {...props}
+    >
       {icon && <div className="text-gold flex-none w-5 h-5">{icon}</div>}
-      <div className={cn("flex flex-col", align === "end" ? "items-end text-right" : "items-start") }>
-        <span className="text-2xl font-bold leading-none">{value}</span>
+      <div
+        className={cn(
+          'flex flex-col',
+          align === 'end' ? 'items-end text-right' : 'items-start'
+        )}
+      >
+        <span className="text-3xl font-headline text-gold leading-none">
+          {value}
+        </span>
         <span className="text-sm text-muted-foreground">{label}</span>
       </div>
     </div>
   )
 );
-StatTile.displayName = "StatTile";
-
+StatTile.displayName = 'StatTile';

--- a/front/tailwind.config.ts
+++ b/front/tailwind.config.ts
@@ -1,4 +1,4 @@
-import type {Config} from 'tailwindcss';
+import type { Config } from 'tailwindcss';
 
 export default {
   darkMode: ['class'],
@@ -10,15 +10,15 @@ export default {
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: '2rem',
       screens: {
-        "2xl": "1400px",
+        '2xl': '1400px',
       },
     },
     extend: {
       fontFamily: {
         body: ['Inter', 'ui-sans-serif', 'system-ui'],
-        headline: ['Poppins', 'ui-sans-serif', 'system-ui'],
+        headline: ['Cinzel', 'serif'],
         code: ['monospace'],
       },
       colors: {
@@ -97,9 +97,11 @@ export default {
       },
       boxShadow: {
         soft: 'var(--shadow)',
-        'cartoon': '0 4px 0 hsl(var(--primary-dark)), 0 6px 10px rgba(0,0,0,0.2)',
-        'cartoon-sm': '0 2px 0 hsl(var(--primary-dark)), 0 3px 5px rgba(0,0,0,0.15)',
-        'cartoon-active': '0 2px 0 hsl(var(--primary-dark)), 0 3px 5px rgba(0,0,0,0.2)',
+        cartoon: '0 4px 0 hsl(var(--primary-dark)), 0 6px 10px rgba(0,0,0,0.2)',
+        'cartoon-sm':
+          '0 2px 0 hsl(var(--primary-dark)), 0 3px 5px rgba(0,0,0,0.15)',
+        'cartoon-active':
+          '0 2px 0 hsl(var(--primary-dark)), 0 3px 5px rgba(0,0,0,0.2)',
         'card-medieval': '5px 5px 0px 0px hsl(var(--border))',
       },
       keyframes: {
@@ -126,7 +128,7 @@ export default {
         'fade-in-up': {
           '0%': { opacity: '0', transform: 'translateY(10px)' },
           '100%': { opacity: '1', transform: 'translateY(0)' },
-        }
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',


### PR DESCRIPTION
## Summary
- switch headline font to Cinzel and load it via Google Fonts
- restyle app with dark-to-darker gradient background and golden accents
- add gladiator icons and larger balance/CTA styling

## Testing
- `npm run lint` *(fails: prettier errors across repository)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b4ffb0a4e0833095d9918689428db2