### PR TITLE
fix: hide mobile nav bar on desktop

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -193,6 +193,11 @@
     padding: 8px;
     z-index: 50;
   }
+  @media (min-width: 768px) {
+    [data-theme='arena-app'] .bottom-nav {
+      display: none;
+    }
+  }
   [data-theme='arena-app'] .tab {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- hide mobile bottom navigation on desktop screens

## Testing
- `npm run lint` (fails: numerous prettier errors)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b50e0a1b848330821eaf75be7fa108