### PR TITLE
feat: add theme-arena design tokens

### DIFF
--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -522,11 +522,12 @@ const HomePageContent = () => {
           />
           <div className="flex gap-2">
             <Button
-              variant="ghost"
+              variant="primary"
               size="sm"
               onClick={handleOpenDepositModal}
               aria-busy={isDepositLoading}
               disabled={isDepositLoading}
+              className="shadow-glow"
             >
               Depositar
             </Button>
@@ -548,12 +549,12 @@ const HomePageContent = () => {
       <Card className="max-w-[920px] mx-auto">
         <CardHeader className="items-center text-center space-y-3">
           <Badge className="gap-2">
-            <Swords className="h-5 w-5" /> En vivo · Duelos
+            <Swords className="h-5 w-5 text-gold-1" aria-label="duelos" /> En vivo · Duelos
           </Badge>
-          <CardTitle className="text-[22px] font-headline text-gold">
+          <CardTitle className="text-4xl font-headline text-gold-1">
             Buscar Duelo
           </CardTitle>
-          <CardDescription className="text-center">
+          <CardDescription className="text-center text-text-2">
             Inscripción $6.000 COP. Ganador recibe $10.800 COP. Requiere saldo ≥
             $6.000.
           </CardDescription>
@@ -562,10 +563,10 @@ const HomePageContent = () => {
           <Button
             variant="primary"
             onClick={handleOpenModeModal}
-            className="w-full sm:w-auto px-8 py-4 text-xl font-headline"
+            className="w-full sm:w-auto px-8 py-4 text-xl font-headline shadow-glow"
             disabled={user.balance < 6000}
           >
-            <Swords className="h-5 w-5" /> Buscar Oponente
+            <Swords className="h-5 w-5" aria-hidden="true" /> Buscar Oponente
           </Button>
         </CardContent>
       </Card>

--- a/front/src/app/(app)/layout.tsx
+++ b/front/src/app/(app)/layout.tsx
@@ -29,7 +29,10 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body data-theme="arena-app" className="font-body antialiased">
+      <body
+        data-theme="theme-arena"
+        className="font-body antialiased bg-bg-0 text-text-1"
+      >
         <ReduxProvider>
           <PushNotificationsInitializer />
           <TransactionUpdatesListener />

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -4,47 +4,64 @@
 
 /* ✅ Tema SOLO para el app (NO landing) */
 @layer base {
-  [data-theme='arena-app'] {
-    --bg: #0b0f14;
-    --bg-end: #111418;
-    --panel: #111315;
-    --panel-2: #0e1113;
-    --text: #ededed;
-    --muted: #a9afb6;
-    --stroke: #23272b;
-    --gold: #ffd369;
-    --gold-strong: #d4af37;
-    --gold-dark: #b98c2a;
+  [data-theme='theme-arena'] {
+    /* Design tokens */
+    --bg-0: #0b0f14;
+    --bg-1: #111418;
+    --bg-2: #0f141a;
+    --gold-1: #ffd369;
+    --gold-2: #d4af37;
+    --gold-3: #b98c2a;
+    --text-1: #ece8d9;
+    --text-2: #c9c6b8;
+    --text-3: #8f8b79;
+    --line: rgba(255, 255, 255, 0.08);
+    --glow: rgba(212, 175, 55, 0.45);
+    --radius-xl: 0.75rem;
+    --radius-2xl: 1rem;
+    --shadow-glow: 0 10px 30px -20px var(--glow);
+    --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    /* Legacy variables for existing styles */
+    --bg: var(--bg-0);
+    --bg-end: var(--bg-1);
+    --panel: var(--bg-1);
+    --panel-2: var(--bg-2);
+    --text: var(--text-1);
+    --muted: var(--text-2);
+    --stroke: var(--line);
+    --gold: var(--gold-1);
+    --gold-strong: var(--gold-2);
+    --gold-dark: var(--gold-3);
     --success: #7ed57a;
     --error: #f16a6a;
-    --radius: 16px;
-    --shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+    --radius: var(--radius-xl);
+    --shadow: var(--shadow-glow);
     /* shadcn/ui variables mapped to design tokens */
-    --background: 213 29% 6%;
-    --foreground: 228 24% 96%;
+    --background: var(--bg-0);
+    --foreground: var(--text-1);
     --card: var(--panel);
     --card-foreground: var(--text);
     --popover: var(--panel);
     --popover-foreground: var(--text);
     --primary: 42 100% 71%;
-    --primary-foreground: 0 0% 8%;
+    --primary-foreground: 0 0% 0%;
     --primary-dark: 41 63% 45%;
     --secondary: var(--panel);
     --secondary-foreground: var(--text);
     --muted-bg: var(--panel-2);
     --muted-foreground: var(--muted);
     --accent: 42 100% 71%;
-    --accent-foreground: 0 0% 8%;
+    --accent-foreground: 0 0% 0%;
     --destructive: 0 70% 45%;
     --destructive-foreground: 0 0% 100%;
     --border: var(--stroke);
     --input: var(--stroke);
-    --ring: var(--gold);
-    background: linear-gradient(180deg, var(--bg) 0%, var(--bg-end) 100%);
-    color: var(--text);
+    --ring: var(--gold-2);
+    background: linear-gradient(180deg, var(--bg-0) 0%, var(--bg-1) 100%);
+    color: var(--text-1);
   }
 
-  [data-theme='arena-app'] * {
+  [data-theme='theme-arena'] * {
     @apply border-border;
   }
 
@@ -89,36 +106,36 @@
 }
 
 @layer components {
-  [data-theme='arena-app'] .navbar {
+  [data-theme='theme-arena'] .navbar {
     @apply sticky top-0 z-50;
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
-    background: color-mix(in srgb, var(--bg) 90%, transparent);
-    border-bottom: 1px solid var(--stroke);
+    background: color-mix(in srgb, var(--bg-0) 90%, transparent);
+    border-bottom: 1px solid var(--line);
   }
 
-  [data-theme='arena-app'] .card {
-    background: var(--panel);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+  [data-theme='theme-arena'] .card {
+    background: var(--bg-1);
+    border: 1px solid var(--line);
     border-radius: var(--radius);
-    box-shadow: 0 4px 12px rgba(212, 175, 55, 0.15);
+    box-shadow: var(--shadow-glow);
     padding: 16px;
   }
-  [data-theme='arena-app'] .card--alt {
-    background: var(--panel-2);
+  [data-theme='theme-arena'] .card--alt {
+    background: var(--bg-2);
   }
 
-  [data-theme='arena-app'] .title {
-    color: var(--gold);
+  [data-theme='theme-arena'] .title {
+    color: var(--gold-1);
     font-weight: 800;
     letter-spacing: 0.3px;
-    text-shadow: 0 0 12px rgba(232, 194, 110, 0.15);
+    text-shadow: 0 0 12px var(--glow);
   }
-  [data-theme='arena-app'] .subtitle {
-    color: var(--muted);
+  [data-theme='theme-arena'] .subtitle {
+    color: var(--text-2);
   }
 
-  [data-theme='arena-app'] .btn {
+  [data-theme='theme-arena'] .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -133,42 +150,42 @@
       box-shadow 0.2s,
       background-color 0.2s;
   }
-  [data-theme='arena-app'] .btn:hover {
+  [data-theme='theme-arena'] .btn:hover {
     transform: scale(1.02);
-    box-shadow: 0 0 12px rgba(255, 211, 105, 0.4);
+    box-shadow: 0 0 12px var(--glow);
   }
-  [data-theme='arena-app'] .btn:active {
+  [data-theme='theme-arena'] .btn:active {
     transform: scale(0.98) translateY(1px);
   }
-  [data-theme='arena-app'] .btn:focus-visible {
-    outline: 2px solid var(--gold);
+  [data-theme='theme-arena'] .btn:focus-visible {
+    outline: 2px solid var(--gold-1);
     outline-offset: 2px;
   }
-  [data-theme='arena-app'] .btn--primary {
-    background: linear-gradient(180deg, #ffd369 0%, #d4af37 100%);
-    color: #000;
-    border: 1px solid var(--gold-dark);
+  [data-theme='theme-arena'] .btn--primary {
+    background: linear-gradient(180deg, var(--gold-1) 0%, var(--gold-2) 100%);
+    color: black;
+    border: 1px solid var(--gold-3);
   }
-  [data-theme='arena-app'] .btn--primary:hover {
-    box-shadow: 0 0 15px rgba(212, 175, 55, 0.6);
+  [data-theme='theme-arena'] .btn--primary:hover {
+    box-shadow: 0 0 15px var(--glow);
   }
-  [data-theme='arena-app'] .btn--outline {
+  [data-theme='theme-arena'] .btn--outline {
     background: transparent;
-    color: var(--gold);
-    border: 1px solid var(--gold);
+    color: var(--gold-1);
+    border: 1px solid var(--gold-1);
   }
-  [data-theme='arena-app'] .btn--ghost {
+  [data-theme='theme-arena'] .btn--ghost {
     background: transparent;
-    border: 1px solid var(--stroke);
-    color: var(--text);
+    border: 1px solid var(--line);
+    color: var(--text-1);
   }
-  [data-theme='arena-app'] .btn--sm {
+  [data-theme='theme-arena'] .btn--sm {
     height: 40px;
     padding: 0 14px;
     border-radius: 12px;
   }
 
-  [data-theme='arena-app'] .badge {
+  [data-theme='theme-arena'] .badge {
     display: inline-flex;
     align-items: center;
     gap: 8px;
@@ -176,50 +193,52 @@
     font-size: 12px;
     padding: 8px 16px;
     border-radius: 999px;
-    background: color-mix(in srgb, var(--gold) 15%, transparent);
-    color: var(--gold);
+    background: color-mix(in srgb, var(--gold-1) 15%, transparent);
+    color: var(--gold-1);
   }
 
-  [data-theme='arena-app'] .bottom-nav {
+  [data-theme='theme-arena'] .bottom-nav {
     position: fixed;
     left: 0;
     right: 0;
     bottom: 0;
-    background: color-mix(in srgb, var(--bg) 92%, transparent);
+    background: color-mix(in srgb, var(--bg-0) 92%, transparent);
     backdrop-filter: blur(6px);
-    border-top: 1px solid var(--stroke);
+    border-top: 1px solid var(--line);
     display: grid;
     grid-template-columns: repeat(5, 1fr);
     padding: 8px;
     z-index: 50;
   }
   @media (min-width: 768px) {
-    [data-theme='arena-app'] .bottom-nav {
+    [data-theme='theme-arena'] .bottom-nav {
       display: none;
     }
   }
-  [data-theme='arena-app'] .tab {
+  [data-theme='theme-arena'] .tab {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 8px;
-    color: var(--muted);
+    color: var(--text-3);
     font-size: 11px;
     min-width: 44px;
     min-height: 44px;
     padding: 8px 0;
+    transition: transform 0.2s, color 0.2s;
   }
-  [data-theme='arena-app'] .tab svg {
+  [data-theme='theme-arena'] .tab svg {
     width: 20px;
     height: 20px;
     opacity: 0.9;
   }
-  [data-theme='arena-app'] .tab--active {
-    color: var(--gold);
-    text-shadow: 0 0 8px rgba(255, 211, 105, 0.4);
+  [data-theme='theme-arena'] .tab--active {
+    color: var(--gold-1);
+    text-shadow: 0 0 8px var(--glow);
+    transform: scale(1.05);
   }
-  [data-theme='arena-app'] .tab:active {
-    transform: translateY(1px);
+  [data-theme='theme-arena'] .tab:active {
+    transform: scale(0.95);
   }
 }
 
@@ -227,6 +246,6 @@
   .fantasy-text {
     font-family: 'Cinzel', serif;
     letter-spacing: 0.05em;
-    text-shadow: 0 0 6px rgba(233, 196, 106, 0.6);
+    text-shadow: 0 0 6px var(--glow);
   }
 }

--- a/front/src/components/ActiveLink.tsx
+++ b/front/src/components/ActiveLink.tsx
@@ -19,11 +19,12 @@ const ActiveLink = ({ href, label, icon: Icon, badge, className }: ActiveLinkPro
   return (
     <Link
       href={href}
+      aria-label={label}
       className={cn(
-        "flex items-center gap-1 rounded-full px-3 py-1 border-b-2 transition-colors duration-200",
+        "flex items-center gap-1 rounded-full px-3 py-1 transition-colors",
         isActive
-          ? "text-[color:var(--gold)] border-[color:var(--gold)]"
-          : "text-[color:var(--muted)] border-transparent hover:text-[color:var(--gold)] hover:border-[color:var(--gold)]",
+          ? "bg-gold-1/20 text-gold-1"
+          : "text-text-3 hover:text-gold-1 hover:bg-gold-1/10",
         className
       )}
     >

--- a/front/src/components/AppLayout.tsx
+++ b/front/src/components/AppLayout.tsx
@@ -10,7 +10,7 @@ import AuthGuard from './AuthGuard';
 const AppLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <AuthGuard>
-      <div className="flex flex-col min-h-screen bg-background text-foreground font-body">
+      <div className="flex flex-col min-h-screen bg-bg-0 text-text-1 font-body">
         <div className="md:hidden">
           <TopNavbar />
         </div>
@@ -20,7 +20,7 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
         <main className="flex-grow container mx-auto px-4 pt-16 pb-24 md:pt-8 md:pb-8 md:px-6 lg:px-8 lg:py-10 animate-fade-in-up">
           {children}
         </main>
-        <footer className="bg-primary/10 text-center py-4 text-sm text-foreground/70 font-headline">
+        <footer className="bg-bg-1 text-center py-4 text-sm text-text-2 font-headline">
           Arena Real &copy; {new Date().getFullYear()}
         </footer>
         <BottomNav />

--- a/front/src/components/ui/StatTile.tsx
+++ b/front/src/components/ui/StatTile.tsx
@@ -16,17 +16,17 @@ export const StatTile = React.forwardRef<HTMLDivElement, StatTileProps>(
       className={cn('flex items-center gap-2', className)}
       {...props}
     >
-      {icon && <div className="text-gold flex-none w-5 h-5">{icon}</div>}
+      {icon && <div className="text-gold-1 flex-none w-5 h-5">{icon}</div>}
       <div
         className={cn(
           'flex flex-col',
           align === 'end' ? 'items-end text-right' : 'items-start'
         )}
       >
-        <span className="text-3xl font-headline text-gold leading-none">
+        <span className="text-[36px] font-bold text-gold-1 leading-none drop-shadow-[0_0_6px_var(--glow)]">
           {value}
         </span>
-        <span className="text-sm text-muted-foreground">{label}</span>
+        <span className="text-xs text-text-3 uppercase">{label}</span>
       </div>
     </div>
   )

--- a/front/tailwind.config.ts
+++ b/front/tailwind.config.ts
@@ -22,6 +22,19 @@ export default {
         code: ['monospace'],
       },
       colors: {
+        /* Design tokens */
+        'bg-0': 'var(--bg-0)',
+        'bg-1': 'var(--bg-1)',
+        'bg-2': 'var(--bg-2)',
+        'gold-1': 'var(--gold-1)',
+        'gold-2': 'var(--gold-2)',
+        'gold-3': 'var(--gold-3)',
+        'text-1': 'var(--text-1)',
+        'text-2': 'var(--text-2)',
+        'text-3': 'var(--text-3)',
+        line: 'var(--line)',
+        glow: 'var(--glow)',
+        /* Legacy aliases */
         bg: 'var(--bg)',
         panel: 'var(--panel)',
         'panel-2': 'var(--panel-2)',
@@ -70,7 +83,7 @@ export default {
         },
         border: 'var(--stroke)',
         input: 'var(--stroke)',
-        ring: 'var(--gold)',
+        ring: 'var(--gold-1)',
         chart: {
           '1': 'hsl(var(--chart-1))',
           '2': 'hsl(var(--chart-2))',
@@ -90,12 +103,15 @@ export default {
         },
       },
       borderRadius: {
-        lg: 'var(--radius)',
-        md: 'calc(var(--radius) - 2px)',
-        sm: 'calc(var(--radius) - 4px)',
-        '2xl': 'calc(var(--radius) + 4px)',
+        xl: 'var(--radius-xl)',
+        '2xl': 'var(--radius-2xl)',
+        lg: 'var(--radius-xl)',
+        md: 'calc(var(--radius-xl) - 2px)',
+        sm: 'calc(var(--radius-xl) - 4px)',
       },
       boxShadow: {
+        glow: 'var(--shadow-glow)',
+        inset: 'var(--shadow-inset)',
         soft: 'var(--shadow)',
         cartoon: '0 4px 0 hsl(var(--primary-dark)), 0 6px 10px rgba(0,0,0,0.2)',
         'cartoon-sm':


### PR DESCRIPTION
## Summary
- add theme-arena tokens for backgrounds, golds, text, line, glow and shadows
- wire new tokens into Tailwind config with fonts, radii and shadow utilities
- apply theme to internal layout, navigation and saldo/duel views

## Testing
- `npm run lint` *(fails: numerous Prettier formatting errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b510df9624833081b2f08e8670ad17