### PR TITLE
Add viewport meta tag to layouts

### DIFF
--- a/front/src/app/(app)/layout.tsx
+++ b/front/src/app/(app)/layout.tsx
@@ -18,6 +18,7 @@ export default function RootLayout({
   return (
     <html lang="es">
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"

--- a/front/src/app/(marketing)/layout.tsx
+++ b/front/src/app/(marketing)/layout.tsx
@@ -14,6 +14,7 @@ export default function MarketingLayout({
   return (
     <html lang="es">
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link


### PR DESCRIPTION
## Summary
- add responsive viewport meta tag to marketing layout
- add responsive viewport meta tag to app layout

## Testing
- `npm run lint` *(fails: numerous Prettier formatting issues)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b519fe501c8330baa811d9f6bd91e1