### PR TITLE
Fix referral registration before inviter plays

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/JugadorService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/JugadorService.java
@@ -32,7 +32,6 @@ public class JugadorService {
         jugador.setReferralCode(java.util.UUID.randomUUID().toString());
         if (dto.getReferralCode() != null && !dto.getReferralCode().isBlank()) {
             jugadorRepository.findByReferralCode(dto.getReferralCode())
-                    .filter(Jugador::isHasPlayed)
                     .ifPresent(inviter -> jugador.setReferredBy(inviter.getId()));
         }
         Jugador saved = jugadorRepository.save(jugador);

--- a/back/src/main/java/co/com/arena/real/application/service/ReferralRewardService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/ReferralRewardService.java
@@ -33,7 +33,7 @@ public class ReferralRewardService {
         if (jugador == null || jugador.getReferredBy() == null) {
             return;
         }
-        jugadorRepository.findById(jugador.getReferredBy()).ifPresent(inviter -> {
+        jugadorRepository.findById(jugador.getReferredBy()).filter(Jugador::isHasPlayed).ifPresent(inviter -> {
             ReferralReward reward = ReferralReward.builder()
                     .inviter(inviter)
                     .referred(jugador)


### PR DESCRIPTION
## Summary
- Allow referrals to be recorded even if the inviter hasn't played yet
- Credit referral rewards only when the inviter has already played a match

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b61a2ac4648330abb6accea2fc2878