### PR TITLE
Remove voucher name from deposit notification

### DIFF
--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -357,7 +357,7 @@ const HomePageContent = () => {
     if (result.transaction) {
       toast({
         title: '¡Solicitud de Depósito Recibida!',
-        description: `Has solicitado un depósito de ${new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(amount)}. Tu comprobante (${depositScreenshotFile.name}) está siendo revisado. Tu saldo se actualizará una vez verificado (ID Transacción: ${result.transaction.id}).`,
+        description: `Has solicitado un depósito de ${new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(amount)}. Tu comprobante está siendo revisado. Tu saldo se actualizará una vez verificado (ID Transacción: ${result.transaction.id}).`,
         variant: 'success',
       });
       await refreshUser();


### PR DESCRIPTION
## Summary
- simplify deposit request toast by removing voucher filename

## Testing
- `npm run lint` *(fails: numerous prettier errors across project)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b63dc4010483308d8a0ba41bee6b8d