### PR TITLE
Fix referral reward tracking

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/ReferralRewardService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/ReferralRewardService.java
@@ -31,20 +31,26 @@ public class ReferralRewardService {
     }
 
     private void creditForPlayer(Jugador jugador, Partida partida) {
-        if (jugador == null || jugador.getReferredBy() == null) {
+        if (jugador == null) {
             return;
         }
-        jugadorRepository.findById(jugador.getReferredBy()).filter(Jugador::isHasPlayed).ifPresent(inviter -> {
-            ReferralReward reward = ReferralReward.builder()
-                    .inviter(inviter)
-                    .referred(jugador)
-                    .partida(partida)
-                    .amount(REWARD_AMOUNT)
-                    .creditedAt(LocalDateTime.now())
-                    .build();
-            rewardRepository.save(reward);
-            saldoService.acreditarSaldo(inviter.getId(), REWARD_AMOUNT);
-        });
+
+        if (jugador.getReferredBy() != null) {
+            jugadorRepository.findById(jugador.getReferredBy())
+                    .filter(Jugador::isHasPlayed)
+                    .ifPresent(inviter -> {
+                        ReferralReward reward = ReferralReward.builder()
+                                .inviter(inviter)
+                                .referred(jugador)
+                                .partida(partida)
+                                .amount(REWARD_AMOUNT)
+                                .creditedAt(LocalDateTime.now())
+                                .build();
+                        rewardRepository.save(reward);
+                        saldoService.acreditarSaldo(inviter.getId(), REWARD_AMOUNT);
+                    });
+        }
+
         if (!jugador.isHasPlayed()) {
             jugador.setHasPlayed(true);
             jugadorRepository.save(jugador);


### PR DESCRIPTION
## Summary
- Ensure `hasPlayed` is marked for all participants
- Only award referral rewards when a player was referred

## Testing
- ⚠️ `cd back && mvn -q test` *(failed: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b649bed92c83309ea833da20a71cc8