### PR TITLE
Fix referral reward tracking

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/ReferralRewardService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/ReferralRewardService.java
@@ -31,20 +31,26 @@ public class ReferralRewardService {
     }
 
     private void creditForPlayer(Jugador jugador, Partida partida) {
-        if (jugador == null || jugador.getReferredBy() == null) {
+        if (jugador == null) {
             return;
         }
-        jugadorRepository.findById(jugador.getReferredBy()).filter(Jugador::isHasPlayed).ifPresent(inviter -> {
-            ReferralReward reward = ReferralReward.builder()
-                    .inviter(inviter)
-                    .referred(jugador)
-                    .partida(partida)
-                    .amount(REWARD_AMOUNT)
-                    .creditedAt(LocalDateTime.now())
-                    .build();
-            rewardRepository.save(reward);
-            saldoService.acreditarSaldo(inviter.getId(), REWARD_AMOUNT);
-        });
+
+        if (jugador.getReferredBy() != null) {
+            jugadorRepository.findById(jugador.getReferredBy())
+                    .filter(Jugador::isHasPlayed)
+                    .ifPresent(inviter -> {
+                        ReferralReward reward = ReferralReward.builder()
+                                .inviter(inviter)
+                                .referred(jugador)
+                                .partida(partida)
+                                .amount(REWARD_AMOUNT)
+                                .creditedAt(LocalDateTime.now())
+                                .build();
+                        rewardRepository.save(reward);
+                        saldoService.acreditarSaldo(inviter.getId(), REWARD_AMOUNT);
+                    });
+        }
+
         if (!jugador.isHasPlayed()) {
             jugador.setHasPlayed(true);
             jugadorRepository.save(jugador);

--- a/front/src/hooks/useTransactionUpdates.ts
+++ b/front/src/hooks/useTransactionUpdates.ts
@@ -74,6 +74,17 @@ export default function useTransactionUpdates() {
         await refreshUser();
       });
 
+      es.addEventListener('referral-registered', (event: MessageEvent) => {
+        try {
+          const data = JSON.parse(event.data) as { id: string; nombre: string };
+          const msg = `El usuario ${data.nombre} ha usado tu código de referido.`;
+          toast({ title: 'Nuevo referido', description: msg, variant: 'success' });
+          addNotification(msg);
+        } catch (err) {
+          console.error('Error procesando evento de referido', err);
+        }
+      });
+
       es.onerror = (err: Event) => {
         console.error('SSE error:', err);
         if (connectedRef.current) {


### PR DESCRIPTION
## Summary
- Ensure `hasPlayed` is marked for all participants
- Only award referral rewards when a player was referred
- Notify inviter immediately when their referral code is used

## Testing
- `cd back && mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*
- `cd front && npm run lint` *(fails: numerous prettier/eslint errors)*
- `cd front && npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b649bed92c83309ea833da20a71cc8