### PR TITLE
Reutiliza chats existentes entre jugadores

### DIFF
--- a/back/src/main/java/co/com/arena/real/application/service/ChatService.java
+++ b/back/src/main/java/co/com/arena/real/application/service/ChatService.java
@@ -59,7 +59,12 @@ public class ChatService {
     }
 
     public UUID crearChat(String jugador1Id, String jugador2Id) {
-        return crearChatParaPartida(jugador1Id, jugador2Id);
+        return chatRepository.findBetween(jugador1Id, jugador2Id)
+                .map(chat -> {
+                    log.info("Reutilizando chat existente {} entre {} y {}", chat.getId(), jugador1Id, jugador2Id);
+                    return chat.getId();
+                })
+                .orElseGet(() -> crearChatParaPartida(jugador1Id, jugador2Id));
     }
 
     public void cerrarChat(UUID chatId) {


### PR DESCRIPTION
## Summary
- Reuse an active chat between two players if one already exists, preventing duplicate chat creation.

## Testing
- ⚠️ `mvn -q test` *(failed: Non-resolvable parent POM; Network is unreachable)*
- ❌ `npm run lint`
- ✅ `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b72a8113b08330bf0f7c8c7b6ae453