### PR TITLE
Add gold themed UI elements

### DIFF
--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/components/ui/Card';
 import { StatTile } from '@/components/ui/StatTile';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
 import { CartoonButton } from '@/components/ui/CartoonButton';
 import { Input } from '@/components/ui/input';
@@ -40,6 +39,10 @@ import {
 import useMatchmakingSse, { MatchEventData } from '@/hooks/useMatchmakingSse';
 import { setLocalStorageItem } from '@/lib/storage';
 import { ACTIVE_CHAT_KEY } from '@/hooks/useActiveChat';
+import { GoldButton } from '@/components/ui/GoldButton';
+import { DuelCTAButton } from '@/components/ui/DuelCTAButton';
+import { AnimatedBalance } from '@/components/ui/AnimatedBalance';
+import { motion } from 'framer-motion';
 
 const HomePageContent = () => {
   const { user, refreshUser } = useAuth();
@@ -509,38 +512,30 @@ const HomePageContent = () => {
         </div>
         <Card
           variant="alt"
-          className="flex flex-col items-center text-center p-6 gap-4"
+          className="flex flex-col items-center text-center p-6 gap-4 card-saldo-animate"
         >
           <SaldoIcon className="h-6 w-6 text-gold-1" />
-          <span className="text-5xl font-bold text-gold-1 leading-none drop-shadow-[0_0_6px_var(--glow)]">
-            {new Intl.NumberFormat('es-CO', {
-              style: 'currency',
-              currency: 'COP',
-              minimumFractionDigits: 0,
-            }).format(user.balance)}
-          </span>
+          <AnimatedBalance value={user.balance} />
           <span className="text-xs text-text-3 uppercase">Saldo actual</span>
           <div className="mt-4 flex w-full flex-col gap-3">
-            <Button
-              variant="primary"
+            <GoldButton
               onClick={handleOpenDepositModal}
               aria-busy={isDepositLoading}
               disabled={isDepositLoading}
-              className="w-full rounded-full h-12 text-lg shadow-glow"
+              className="h-12 text-lg"
             >
               Depositar
-            </Button>
-            <Button
-              variant="primary"
+            </GoldButton>
+            <GoldButton
               onClick={handleOpenWithdrawModal}
               aria-busy={isWithdrawLoading}
               disabled={
                 user.balance === 0 || !user.nequiAccount || isWithdrawLoading
               }
-              className="w-full rounded-full h-12 text-lg shadow-glow"
+              className="h-12 text-lg"
             >
               Retirar
-            </Button>
+            </GoldButton>
           </div>
         </Card>
       </Card>
@@ -548,7 +543,17 @@ const HomePageContent = () => {
       <Card className="max-w-[920px] mx-auto">
         <CardHeader className="items-center text-center space-y-3">
           <Badge className="gap-2">
-            <Swords className="h-5 w-5 text-gold-1" aria-label="duelos" /> En vivo · Duelos
+            <Swords className="h-5 w-5 text-gold-1" aria-label="duelos" />
+            <motion.span
+              animate={{ scale: [1, 1.3, 1] }}
+              transition={{
+                repeat: Infinity,
+                duration: 1.2,
+                ease: 'easeInOut',
+              }}
+              className="inline-flex h-2 w-2 rounded-full bg-[#E24D4D]"
+            />
+            En vivo · Duelos
           </Badge>
           <CardTitle className="text-4xl font-headline text-gold-1">
             Buscar Duelo
@@ -559,14 +564,13 @@ const HomePageContent = () => {
           </CardDescription>
         </CardHeader>
         <CardContent className="flex justify-center">
-          <Button
-            variant="primary"
+          <DuelCTAButton
             onClick={handleOpenModeModal}
-            className="w-full sm:w-auto px-8 py-4 text-xl font-headline shadow-glow"
+            className="sm:w-auto px-8 py-4 text-xl font-headline"
             disabled={user.balance < 6000}
           >
             <Swords className="h-5 w-5" aria-hidden="true" /> Buscar Oponente
-          </Button>
+          </DuelCTAButton>
         </CardContent>
       </Card>
 

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -103,6 +103,22 @@
     background-size: 200% 200%;
     animation: gradient-x 8s ease infinite;
   }
+
+  @keyframes goldSpark {
+    0% {
+      box-shadow: inset 0 0 0 rgba(245, 211, 108, 0);
+    }
+    50% {
+      box-shadow: inset 0 0 24px rgba(245, 211, 108, 0.08);
+    }
+    100% {
+      box-shadow: inset 0 0 0 rgba(245, 211, 108, 0);
+    }
+  }
+
+  .card-saldo-animate {
+    animation: goldSpark 1.5s ease-out 1;
+  }
 }
 
 @layer components {
@@ -225,7 +241,9 @@
     min-width: 44px;
     min-height: 44px;
     padding: 8px 0;
-    transition: transform 0.2s, color 0.2s;
+    transition:
+      transform 0.2s,
+      color 0.2s;
   }
   [data-theme='theme-arena'] .tab svg {
     width: 20px;

--- a/front/src/components/ui/AnimatedBalance.tsx
+++ b/front/src/components/ui/AnimatedBalance.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { animate } from 'framer-motion';
+
+interface AnimatedBalanceProps {
+  value: number;
+}
+
+export function AnimatedBalance({ value }: AnimatedBalanceProps) {
+  const [display, setDisplay] = useState(0);
+
+  useEffect(() => {
+    const controls = animate(0, value, {
+      duration: 0.8,
+      ease: [0.22, 1, 0.36, 1],
+      onUpdate: (latest) => setDisplay(latest),
+    });
+    return () => controls.stop();
+  }, [value]);
+
+  return (
+    <span className="text-5xl font-bold text-gold-1 leading-none drop-shadow-[0_0_6px_var(--glow)]">
+      {new Intl.NumberFormat('es-CO', {
+        style: 'currency',
+        currency: 'COP',
+        maximumFractionDigits: 0,
+      }).format(display)}
+    </span>
+  );
+}

--- a/front/src/components/ui/DuelCTAButton.tsx
+++ b/front/src/components/ui/DuelCTAButton.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { motion, type HTMLMotionProps } from 'framer-motion';
+import { cn } from '@/lib/utils';
+
+export function DuelCTAButton({
+  className,
+  ...props
+}: HTMLMotionProps<'button'>) {
+  return (
+    <motion.button
+      whileHover={{ scale: 1.02, boxShadow: '0 0 36px rgba(245,211,108,.35)' }}
+      whileTap={{ scale: 0.98 }}
+      transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+      className={cn(
+        'w-full rounded-2xl px-6 py-4 font-semibold text-[#15181D] [background:linear-gradient(180deg,#F8EDBD_0%,#F5D36C_45%,#D9A441_100%)] shadow-[0_8px_24px_rgba(245,211,108,.18)] disabled:opacity-50 disabled:pointer-events-none',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/front/src/components/ui/GoldButton.tsx
+++ b/front/src/components/ui/GoldButton.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { ButtonHTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+interface GoldButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function GoldButton({ className, ...props }: GoldButtonProps) {
+  return (
+    <button
+      className={cn(
+        'w-full select-none rounded-xl px-5 py-3 text-base font-semibold text-[#15181D] transition-all duration-200 [background:linear-gradient(180deg,#F6E7AA,#F5D36C_40%,#D9A441)] shadow-[0_6px_16px_rgba(0,0,0,.35)] hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(245,211,108,.20)] active:translate-y-0 active:brightness-95 focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
+        className
+      )}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add AnimatedBalance component with gold sparkle
- implement reusable GoldButton and DuelCTAButton
- update home page with pulsing live indicator and new buttons

## Testing
- `npm run lint` *(fails: ESLint reports numerous Prettier formatting errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b734bd52e08330ae55d58ce5feead4