### PR TITLE
Remove capitalize class from status badge

### DIFF
--- a/front/src/app/(app)/history/page.tsx
+++ b/front/src/app/(app)/history/page.tsx
@@ -120,13 +120,13 @@ const HistoryPageContent = () => {
               </CardDescription>
             </div>
             <Badge
-              className={`capitalize ${
+              className={
                 bet.result === 'win'
                   ? '!bg-success !text-bg'
                   : bet.result === 'loss'
                   ? '!bg-error !text-bg'
                   : ''
-              }`}
+              }
             >
               {statusLabel}
             </Badge>


### PR DESCRIPTION
## Summary
- drop capitalize styling from history status badge

## Testing
- `npm run lint` (fails: ESLint must be installed)
- `npm run typecheck` (fails: cannot find module 'framer-motion', '@radix-ui/react-separator')

------
https://chatgpt.com/codex/tasks/task_e_68b73a2acd248330878546c4bfb8ce20