### PR TITLE
Adjust landing CTA sizing

### DIFF
--- a/front/src/app/(marketing)/landing.css
+++ b/front/src/app/(marketing)/landing.css
@@ -38,6 +38,7 @@ body { @apply font-sans antialiased; }
 
 /* ====== Botones ====== */
 .btn { @apply inline-flex items-center justify-center gap-2 font-semibold min-h-12; }
+.btn-lg { @apply text-lg px-6 py-3; }
 .btn-pill { @apply rounded-full; }
 .btn-ghost { @apply border border-white/10 bg-white/5; }
 

--- a/front/src/app/(marketing)/page.tsx
+++ b/front/src/app/(marketing)/page.tsx
@@ -166,7 +166,7 @@
                   <h3 className="font-cinzel text-[24px] leading-tight text-[color:var(--gold-3)] m-0">¿Listo para combatir?</h3>
                   <p className="text-muted m-0 mt-2">Únete a los duelos en vivo.</p>
                 </div>
-                <div className="w-full max-w-[340px] grid grid-cols-1 gap-2">
+                <div className="w-full max-w-md grid grid-cols-1 gap-2">
                   <Link
                     href="/login"
                     className="btn btn-solid btn-lg btn-pill px-6 text-[#141414] text-center fantasy-text"


### PR DESCRIPTION
## Summary
- add btn-lg styles for larger marketing buttons
- widen landing call-to-action section

## Testing
- `npm run lint` *(fails: multiple prettier errors across repo)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b741de79208330896f94e81532618a