### PR TITLE
Redesign home screen layout

### DIFF
--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -485,11 +485,11 @@ const HomePageContent = () => {
     }
   };
 
-  return (
-    <div className="space-y-8">
-      <Card className="space-y-4 p-4 md:p-6">
-        <div className="flex items-center gap-4">
-          <Avatar className="h-16 w-16">
+    return (
+      <div className="space-y-6">
+        <Card className="space-y-4 p-5 md:p-6">
+          <div className="flex items-center gap-4">
+            <Avatar className="h-12 w-12 ring-2 ring-[#F5D36C]/30">
             <AvatarImage
               src={
                 user.avatarUrl ||
@@ -498,7 +498,7 @@ const HomePageContent = () => {
               alt={user.username}
               data-ai-hint="gaming avatar"
             />
-            <AvatarFallback className="text-3xl">
+            <AvatarFallback className="text-xl">
               {user.username?.[0] || 'U'}
             </AvatarFallback>
           </Avatar>
@@ -510,14 +510,14 @@ const HomePageContent = () => {
             <CardDescription>¡Bienvenido de nuevo, Gladiador!</CardDescription>
           </div>
         </div>
-        <Card
-          variant="alt"
-          className="flex flex-col items-center text-center p-6 gap-4 card-saldo-animate"
-        >
-          <SaldoIcon className="h-6 w-6 text-gold-1" />
-          <AnimatedBalance value={user.balance} />
-          <span className="text-xs text-text-3 uppercase">Saldo actual</span>
-          <div className="mt-4 flex w-full flex-col gap-3">
+          <Card
+            variant="alt"
+            className="flex flex-col items-center text-center p-6 gap-4 card-saldo-animate"
+          >
+            <SaldoIcon className="h-6 w-6 text-gold-1" />
+            <AnimatedBalance value={user.balance} />
+            <span className="text-sm text-[#8A919E] uppercase tracking-[0.02em]">Saldo actual</span>
+            <div className="mt-4 flex w-full flex-col gap-3">
             <GoldButton
               onClick={handleOpenDepositModal}
               aria-busy={isDepositLoading}
@@ -540,39 +540,39 @@ const HomePageContent = () => {
         </Card>
       </Card>
 
-      <Card className="max-w-[920px] mx-auto">
-        <CardHeader className="items-center text-center space-y-3">
-          <Badge className="gap-2">
-            <Swords className="h-5 w-5 text-gold-1" aria-label="duelos" />
-            <motion.span
-              animate={{ scale: [1, 1.3, 1] }}
-              transition={{
-                repeat: Infinity,
-                duration: 1.2,
-                ease: 'easeInOut',
-              }}
-              className="inline-flex h-2 w-2 rounded-full bg-[#E24D4D]"
-            />
-            En vivo · Duelos
-          </Badge>
-          <CardTitle className="text-4xl font-headline text-gold-1">
-            Buscar Duelo
-          </CardTitle>
-          <CardDescription className="text-center text-text-2">
-            Inscripción $6.000 COP. Ganador recibe $10.800 COP. Requiere saldo ≥
-            $6.000.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex justify-center">
-          <DuelCTAButton
-            onClick={handleOpenModeModal}
-            className="sm:w-auto px-8 py-4 text-xl font-headline"
-            disabled={user.balance < 6000}
-          >
-            <Swords className="h-5 w-5" aria-hidden="true" /> Buscar Oponente
-          </DuelCTAButton>
-        </CardContent>
-      </Card>
+        <Card className="max-w-[920px] mx-auto">
+          <CardHeader className="items-center text-center space-y-3">
+            <Badge className="gap-2 rounded-[12px] bg-[#1A1F26] text-[#D9A441]">
+              <Swords className="h-5 w-5 text-gold-1" aria-label="duelos" />
+              <motion.span
+                animate={{ scale: [1, 1.3, 1] }}
+                transition={{
+                  repeat: Infinity,
+                  duration: 1.2,
+                  ease: 'easeInOut',
+                }}
+                className="inline-flex h-2 w-2 rounded-full bg-[#E24D4D]"
+              />
+              En vivo · Duelos
+            </Badge>
+            <CardTitle className="text-3xl font-headline text-gold-1">
+              Buscar Duelo
+            </CardTitle>
+            <CardDescription className="text-center text-[#C9CFD6] text-sm">
+              Inscripción $6.000 COP. Ganador recibe $10.800 COP. Requiere saldo ≥
+              $6.000.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <DuelCTAButton
+              onClick={handleOpenModeModal}
+              className="sm:w-auto px-8 text-lg font-headline flex items-center gap-2"
+              disabled={user.balance < 6000}
+            >
+              <Swords className="h-5 w-5" aria-hidden="true" /> Buscar Oponente
+            </DuelCTAButton>
+          </CardContent>
+        </Card>
 
       {/* Mode Select Modal */}
       {isModeModalOpen && (

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -7,18 +7,18 @@
   [data-theme='theme-arena'] {
     /* Design tokens */
     --bg-0: #0b0f14;
-    --bg-1: #111418;
+    --bg-1: #0e1318;
     --bg-2: #0f141a;
-    --gold-1: #ffd369;
-    --gold-2: #d4af37;
-    --gold-3: #b98c2a;
+    --gold-1: #f5d36c;
+    --gold-2: #d9a441;
+    --gold-3: #b8860b;
     --text-1: #ece8d9;
-    --text-2: #c9c6b8;
-    --text-3: #8f8b79;
-    --line: rgba(255, 255, 255, 0.08);
-    --glow: rgba(212, 175, 55, 0.45);
-    --radius-xl: 0.75rem;
-    --radius-2xl: 1rem;
+    --text-2: #c9cfd6;
+    --text-3: #8a919e;
+    --line: #232830;
+    --glow: rgba(245, 211, 108, 0.45);
+    --radius-xl: 1rem;
+    --radius-2xl: 1.25rem;
     --shadow-glow: 0 10px 30px -20px var(--glow);
     --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.06);
     /* Legacy variables for existing styles */

--- a/front/src/components/ui/AnimatedBalance.tsx
+++ b/front/src/components/ui/AnimatedBalance.tsx
@@ -20,7 +20,7 @@ export function AnimatedBalance({ value }: AnimatedBalanceProps) {
   }, [value]);
 
   return (
-    <span className="text-5xl font-bold text-gold-1 leading-none drop-shadow-[0_0_6px_var(--glow)]">
+    <span className="text-[40px] font-bold text-gold-1 leading-none drop-shadow-[0_0_6px_var(--glow)]">
       {new Intl.NumberFormat('es-CO', {
         style: 'currency',
         currency: 'COP',

--- a/front/src/components/ui/DuelCTAButton.tsx
+++ b/front/src/components/ui/DuelCTAButton.tsx
@@ -13,7 +13,7 @@ export function DuelCTAButton({
       whileTap={{ scale: 0.98 }}
       transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
       className={cn(
-        'w-full rounded-2xl px-6 py-4 font-semibold text-[#15181D] [background:linear-gradient(180deg,#F8EDBD_0%,#F5D36C_45%,#D9A441_100%)] shadow-[0_8px_24px_rgba(245,211,108,.18)] disabled:opacity-50 disabled:pointer-events-none',
+        'w-full rounded-[20px] px-6 py-4 font-semibold text-[#15181D] [background:linear-gradient(180deg,#F8EDBD_0%,#F5D36C_45%,#D9A441_100%)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
         className
       )}
       {...props}

--- a/front/src/components/ui/GoldButton.tsx
+++ b/front/src/components/ui/GoldButton.tsx
@@ -9,7 +9,7 @@ export function GoldButton({ className, ...props }: GoldButtonProps) {
   return (
     <button
       className={cn(
-        'w-full select-none rounded-xl px-5 py-3 text-base font-semibold text-[#15181D] transition-all duration-200 [background:linear-gradient(180deg,#F6E7AA,#F5D36C_40%,#D9A441)] shadow-[0_6px_16px_rgba(0,0,0,.35)] hover:-translate-y-0.5 hover:shadow-[0_10px_26px_rgba(245,211,108,.20)] active:translate-y-0 active:brightness-95 focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
+        'w-full select-none rounded-[20px] px-5 py-4 text-base font-semibold text-[#15181D] transition-all duration-200 [background:linear-gradient(180deg,#F6E7AA,#F5D36C_40%,#D9A441)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] hover:-translate-y-0.5 hover:shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.25)] active:translate-y-0 active:brightness-95 focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- align global design tokens with gladiator palette and updated radii
- restyle gold CTA buttons with rounded corners and dual shadows
- refresh home screen header, balance card, and duel search section

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck` *(fails: Cannot find module 'framer-motion')*

------
https://chatgpt.com/codex/tasks/task_e_68b754bd949c83309d989f7824ed6ec2