### PR TITLE
Revamp duel search layout and center home page

### DIFF
--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -486,7 +486,7 @@ const HomePageContent = () => {
   };
 
     return (
-      <div className="space-y-6">
+      <div className="w-full max-w-[920px] space-y-6">
         <Card className="space-y-4 p-5 md:p-6">
           <div className="flex items-center gap-4">
             <Avatar className="h-12 w-12 ring-2 ring-[#F5D36C]/30">
@@ -558,18 +558,33 @@ const HomePageContent = () => {
             <CardTitle className="text-3xl font-headline text-gold-1">
               Buscar Duelo
             </CardTitle>
-            <CardDescription className="text-center text-[#C9CFD6] text-sm">
-              Inscripción $6.000 COP. Ganador recibe $10.800 COP. Requiere saldo ≥
-              $6.000.
-            </CardDescription>
           </CardHeader>
-          <CardContent className="flex justify-center">
+          <CardContent className="flex flex-col items-center gap-4">
+            <div className="grid grid-cols-2 gap-4 w-full max-w-sm">
+              <div className="flex flex-col items-center gap-1 rounded-md bg-[#1A1F26] p-3">
+                <p className="text-sm text-muted-foreground">Inscripción</p>
+                <div className="flex items-center gap-1">
+                  <Coins className="h-4 w-4 text-gold-1" />
+                  <p className="text-lg font-headline text-gold-1">$6.000</p>
+                </div>
+              </div>
+              <div className="flex flex-col items-center gap-1 rounded-md bg-[#1A1F26] p-3">
+                <p className="text-sm text-muted-foreground">Premio</p>
+                <div className="flex items-center gap-1">
+                  <Coins className="h-4 w-4 text-gold-1" />
+                  <p className="text-lg font-headline text-gold-1">$10.800 COP</p>
+                </div>
+              </div>
+            </div>
+            <p className="text-center text-[#C9CFD6] text-sm">
+              Requiere saldo ≥ $6.000.
+            </p>
             <DuelCTAButton
               onClick={handleOpenModeModal}
               className="sm:w-auto px-8 text-lg font-headline flex items-center gap-2"
               disabled={user.balance < 6000}
             >
-              <Swords className="h-5 w-5" aria-hidden="true" /> Buscar Oponente
+              <Swords className="h-5 w-5" aria-hidden="true" /> UNIRSE AL DUELO
             </DuelCTAButton>
           </CardContent>
         </Card>
@@ -873,7 +888,7 @@ const HomePageContent = () => {
 
 export default function HomePage() {
   return (
-    <AppLayout>
+    <AppLayout mainClassName="flex flex-col items-center justify-center animate-none">
       <HomePageContent />
     </AppLayout>
   );

--- a/front/src/components/AppLayout.tsx
+++ b/front/src/components/AppLayout.tsx
@@ -6,8 +6,13 @@ import Navbar from './Navbar';
 import TopNavbar from './TopNavbar';
 import BottomNav from './BottomNav';
 import AuthGuard from './AuthGuard';
+import { cn } from '@/lib/utils';
+interface AppLayoutProps {
+  children: React.ReactNode;
+  mainClassName?: string;
+}
 
-const AppLayout = ({ children }: { children: React.ReactNode }) => {
+const AppLayout = ({ children, mainClassName }: AppLayoutProps) => {
   return (
     <AuthGuard>
       <div className="flex flex-col min-h-screen bg-bg-0 text-text-1 font-body">
@@ -17,7 +22,12 @@ const AppLayout = ({ children }: { children: React.ReactNode }) => {
         <div className="hidden md:block">
           <Navbar />
         </div>
-        <main className="flex-grow container mx-auto px-4 pt-16 pb-24 md:pt-8 md:pb-8 md:px-6 lg:px-8 lg:py-10 animate-fade-in-up">
+        <main
+          className={cn(
+            'flex-grow container mx-auto px-4 pt-16 pb-24 md:pt-8 md:pb-8 md:px-6 lg:px-8 lg:py-10 animate-fade-in-up',
+            mainClassName
+          )}
+        >
           {children}
         </main>
         <footer className="bg-bg-1 text-center py-4 text-sm text-text-2 font-headline">


### PR DESCRIPTION
## Summary
- redesign the "Buscar Duelo" card with registration and prize boxes
- change CTA button to "UNIRSE AL DUELO"
- allow customizing AppLayout main container and center the home page content without animations

## Testing
- `npm run lint` *(fails: numerous prettier/prettier violations across repository)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b75a76df1c83309f916c834cf1a3af