### PR TITLE
Remove page scrollbars and center button text

### DIFF
--- a/front/src/app/(app)/chat/[matchId]/page.tsx
+++ b/front/src/app/(app)/chat/[matchId]/page.tsx
@@ -527,8 +527,15 @@ const ChatPageContent = () => {
 
 
 export default function ChatPage() {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
   return (
-    <AppLayout>
+    <AppLayout mainClassName="flex flex-col items-center justify-center p-0 overflow-hidden">
       <ChatPageContent />
     </AppLayout>
   );

--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -887,8 +887,15 @@ const HomePageContent = () => {
 };
 
 export default function HomePage() {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
   return (
-    <AppLayout mainClassName="flex flex-col items-center justify-center animate-none">
+    <AppLayout mainClassName="flex flex-col items-center justify-center p-0 overflow-hidden">
       <HomePageContent />
     </AppLayout>
   );

--- a/front/src/components/ui/CartoonButton.tsx
+++ b/front/src/components/ui/CartoonButton.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 const cartoonButtonVariants = cva(
-  'inline-flex items-center justify-center rounded-lg fantasy-text text-lg font-semibold tracking-wide transition-transform duration-150 ease-in-out hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-0.5 disabled:pointer-events-none disabled:opacity-70',
+  'inline-flex items-center justify-center rounded-lg fantasy-text text-lg font-semibold text-center tracking-wide transition-transform duration-150 ease-in-out hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-0.5 disabled:pointer-events-none disabled:opacity-70',
   {
     variants: {
       variant: {

--- a/front/src/components/ui/DuelCTAButton.tsx
+++ b/front/src/components/ui/DuelCTAButton.tsx
@@ -13,7 +13,7 @@ export function DuelCTAButton({
       whileTap={{ scale: 0.98 }}
       transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
       className={cn(
-        'w-full rounded-[20px] px-6 py-4 font-semibold text-[#15181D] [background:linear-gradient(180deg,#F8EDBD_0%,#F5D36C_45%,#D9A441_100%)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
+        'w-full rounded-[20px] px-6 py-4 font-semibold text-center text-[#15181D] [background:linear-gradient(180deg,#F8EDBD_0%,#F5D36C_45%,#D9A441_100%)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
         className
       )}
       {...props}

--- a/front/src/components/ui/GoldButton.tsx
+++ b/front/src/components/ui/GoldButton.tsx
@@ -9,7 +9,7 @@ export function GoldButton({ className, ...props }: GoldButtonProps) {
   return (
     <button
       className={cn(
-        'w-full select-none rounded-[20px] px-5 py-4 text-base font-semibold text-[#15181D] transition-all duration-200 [background:linear-gradient(180deg,#F6E7AA,#F5D36C_40%,#D9A441)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] hover:-translate-y-0.5 hover:shadow-[0_0_24px_rgba(245,211,108,.25)] active:translate-y-0 active:brightness-95 focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
+        'w-full select-none rounded-[20px] px-5 py-4 text-base font-semibold text-center text-[#15181D] transition-all duration-200 [background:linear-gradient(180deg,#F6E7AA,#F5D36C_40%,#D9A441)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] hover:-translate-y-0.5 hover:shadow-[0_0_24px_rgba(245,211,108,.25)] active:translate-y-0 active:brightness-95 focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Prevent body scrolling on home and chat pages so layout stays fixed
- Center text in reusable button components for consistent alignment

## Testing
- `npm run lint` *(fails: Prettier formatting errors across repository)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b7725e96c8833089c288b6312eed4a