### PR TITLE
Align topbar height with marketing layout

### DIFF
--- a/front/src/components/AppLayout.tsx
+++ b/front/src/components/AppLayout.tsx
@@ -24,7 +24,7 @@ const AppLayout = ({ children, mainClassName }: AppLayoutProps) => {
         </div>
         <main
           className={cn(
-            'flex-grow container mx-auto px-4 pt-16 pb-24 md:pt-8 md:pb-8 md:px-6 lg:px-8 lg:py-10 animate-fade-in-up',
+            'flex-grow container mx-auto px-4 pt-20 pb-24 md:pt-8 md:pb-8 md:px-6 lg:px-8 lg:py-10 animate-fade-in-up',
             mainClassName
           )}
         >

--- a/front/src/components/MainLayout.tsx
+++ b/front/src/components/MainLayout.tsx
@@ -10,7 +10,7 @@ const MainLayout = ({ children }: { children: React.ReactNode }) => {
     <AuthGuard>
       <div className="flex flex-col min-h-screen bg-background text-foreground font-body">
         <TopNavbar />
-        <main className="flex-grow pt-16 pb-24 px-4">{children}</main>
+        <main className="flex-grow pt-20 pb-24 px-4">{children}</main>
         <BottomNav />
       </div>
     </AuthGuard>

--- a/front/src/components/Navbar.tsx
+++ b/front/src/components/Navbar.tsx
@@ -45,7 +45,7 @@ const Navbar = () => {
 
   return (
     <header className="navbar sticky top-0 z-50">
-      <div className="container mx-auto flex items-center justify-between py-3">
+      <div className="container mx-auto flex items-center justify-between py-4">
         {/* Logo */}
         <Link
           href="/home"

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -25,7 +25,7 @@ const TopNavbar = () => {
       : undefined;
 
   return (
-    <header className="md:hidden navbar fixed top-0 left-0 right-0 z-50 h-16 px-4 py-3 flex justify-between items-center">
+    <header className="md:hidden navbar fixed top-0 left-0 right-0 z-50 h-20 px-4 py-4 flex justify-between items-center">
       <div className="flex items-center gap-1 font-bold text-lg text-[color:var(--gold)] fantasy-text">
         <Image src="/logo.png" alt="Arena Real logo" width={32} height={32} className="h-8 w-8" />
         Arena Real


### PR DESCRIPTION
## Summary
- Expand mobile TopNavbar height
- Offset layouts for taller topbar
- Increase desktop Navbar padding

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck` *(fails: Cannot find module 'framer-motion'; '@radix-ui/react-separator')*

------
https://chatgpt.com/codex/tasks/task_e_68b7837c49848330b1bf67d20e7d566f