### PR TITLE
Center text in frontend buttons

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -161,6 +161,7 @@
     padding: 0 16px;
     border-radius: var(--radius-2xl);
     font-weight: 700;
+    text-align: center;
     transform: scale(0.98);
     transition:
       transform 0.2s,


### PR DESCRIPTION
## Summary
- center button labels by adding `text-align: center` to global btn class

## Testing
- `npm run lint` *(fails: numerous Prettier/ESLint errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68b7abb1e8b483309e4e1014368f5ed7