### PR TITLE
Align balance card and center button text

### DIFF
--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -18,7 +18,6 @@ import { Badge } from '@/components/ui/Badge';
 import { CartoonButton } from '@/components/ui/CartoonButton';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { SaldoIcon } from '@/components/icons/ClashRoyaleIcons';
 import { useToast } from '@/hooks/use-toast';
 import {
   Coins,
@@ -510,14 +509,19 @@ const HomePageContent = () => {
             <CardDescription>¡Bienvenido de nuevo, Gladiador!</CardDescription>
           </div>
         </div>
-          <Card
-            variant="alt"
-            className="flex flex-col items-center text-center p-6 gap-4 card-saldo-animate"
-          >
-            <SaldoIcon className="h-6 w-6 text-gold-1" />
-            <AnimatedBalance value={user.balance} />
-            <span className="text-sm text-[#8A919E] uppercase tracking-[0.02em]">Saldo actual</span>
-            <div className="mt-4 flex w-full flex-col gap-3">
+        <Card
+          variant="alt"
+          className="flex items-center gap-3 p-4 w-fit mx-auto card-saldo-animate"
+        >
+          <div className="flex flex-col items-center w-fit">
+            <div className="self-start">
+              <AnimatedBalance value={user.balance} />
+            </div>
+            <span className="text-sm text-[#8A919E] uppercase tracking-[0.02em]">
+              Saldo actual
+            </span>
+          </div>
+          <div className="flex flex-col gap-3">
             <GoldButton
               onClick={handleOpenDepositModal}
               aria-busy={isDepositLoading}

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -161,6 +161,7 @@
     padding: 0 16px;
     border-radius: var(--radius-2xl);
     font-weight: 700;
+    text-align: center;
     transform: scale(0.98);
     transition:
       transform 0.2s,

--- a/front/src/components/ui/DuelCTAButton.tsx
+++ b/front/src/components/ui/DuelCTAButton.tsx
@@ -13,7 +13,7 @@ export function DuelCTAButton({
       whileTap={{ scale: 0.98 }}
       transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
       className={cn(
-        'w-full rounded-[20px] px-6 py-4 font-semibold text-center text-[#15181D] [background:linear-gradient(180deg,#F8EDBD_0%,#F5D36C_45%,#D9A441_100%)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
+        'inline-flex w-full items-center justify-center gap-2 rounded-[20px] px-6 py-4 font-semibold text-center text-[#15181D] [background:linear-gradient(180deg,#F8EDBD_0%,#F5D36C_45%,#D9A441_100%)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
         className
       )}
       {...props}

--- a/front/src/components/ui/GoldButton.tsx
+++ b/front/src/components/ui/GoldButton.tsx
@@ -9,7 +9,7 @@ export function GoldButton({ className, ...props }: GoldButtonProps) {
   return (
     <button
       className={cn(
-        'w-full select-none rounded-[20px] px-5 py-4 text-base font-semibold text-center text-[#15181D] transition-all duration-200 [background:linear-gradient(180deg,#F6E7AA,#F5D36C_40%,#D9A441)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] hover:-translate-y-0.5 hover:shadow-[0_0_24px_rgba(245,211,108,.25)] active:translate-y-0 active:brightness-95 focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
+        'inline-flex items-center justify-center w-full select-none rounded-[20px] px-5 py-4 text-base font-semibold text-center text-[#15181D] transition-all duration-200 [background:linear-gradient(180deg,#F6E7AA,#F5D36C_40%,#D9A441)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] hover:-translate-y-0.5 hover:shadow-[0_0_24px_rgba(245,211,108,.25)] active:translate-y-0 active:brightness-95 focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- left-align balance and place deposit/withdraw buttons to its right, removing coin icon
- center GoldButton text using flex alignment
- tighten balance card width and center balance label
- center Duel CTA button content responsively

## Testing
- `npm run lint` *(fails: many prettier errors across project)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b7abb1e8b483309e4e1014368f5ed7