### PR TITLE
Consolidate landing page into single section

### DIFF
--- a/front/src/app/(marketing)/page.tsx
+++ b/front/src/app/(marketing)/page.tsx
@@ -119,24 +119,23 @@
                 <div className="mt-1 text-[11px] tracking-[.18em] opacity-75">GLADIADORES</div>
               </article>
             </div>
-          </section>
 
-          <section
-            className="container mx-auto px-5 relative mt-6 rounded-3xl p-6 border border-[rgba(233,196,106,.16)] shadow-[0_10px_26px_rgba(0,0,0,.35)] overflow-hidden"
-            style={{ background: 'linear-gradient(180deg, rgba(18,23,33,.88) 0%, rgba(11,15,20,1) 100%)' }}
-          >
             <div
-              className="pointer-events-none absolute -inset-x-px -top-px h-36 rounded-t-3xl"
-              style={{}}
-            />
-            <h2 className="text-center my-2 font-cinzel font-extrabold text-[26px] leading-tight text-[#f0e0a6]">
-              Forja tu leyenda
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              <article className="card card-lg relative">
-                <svg className="absolute right-3 top-3 opacity-90" width="28" height="28" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                  <path d="M12 2l3 6 6 .9-4.5 4.4 1 6.3L12 16l-5.5 3.6 1-6.3L3 8.9 9 8l3-6z" stroke="currentColor" strokeWidth="1.3" color="#CDA434" />
-                </svg>
+              className="relative mt-6 rounded-3xl p-6 border border-[rgba(233,196,106,.16)] shadow-[0_10px_26px_rgba(0,0,0,.35)] overflow-hidden"
+              style={{ background: 'linear-gradient(180deg, rgba(18,23,33,.88) 0%, rgba(11,15,20,1) 100%)' }}
+            >
+              <div
+                className="pointer-events-none absolute -inset-x-px -top-px h-36 rounded-t-3xl"
+                style={{}}
+              />
+              <h2 className="text-center my-2 font-cinzel font-extrabold text-[26px] leading-tight text-[#f0e0a6]">
+                Forja tu leyenda
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <article className="card card-lg relative">
+                  <svg className="absolute right-3 top-3 opacity-90" width="28" height="28" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M12 2l3 6 6 .9-4.5 4.4 1 6.3L12 16l-5.5 3.6 1-6.3L3 8.9 9 8l3-6z" stroke="currentColor" strokeWidth="1.3" color="#CDA434" />
+                  </svg>
                 <h3 className="m-0 mb-1 font-bold text-[#f0e0a6]">Duelos 1vs1</h3>
                 <p className="m-0 text-muted">Rapidos.</p>
               </article>
@@ -198,7 +197,8 @@
                 </div>
               </div>
             </footer>
-          </section>
+          </div>
+        </section>
         </main>
       </div>
     );


### PR DESCRIPTION
## Summary
- merge marketing page content into one section to reduce empty gaps

## Testing
- `npm run lint` *(fails: numerous Prettier errors across repo)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b7d13cdc6c833094d7727150bb63cd