### PR TITLE
Reduce home page spacing

### DIFF
--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -899,7 +899,9 @@ export default function HomePage() {
   }, []);
 
   return (
-    <AppLayout mainClassName="flex flex-col items-center justify-center p-0 overflow-hidden">
+    <AppLayout
+      mainClassName="flex flex-col pt-4 pb-8 md:pt-6 md:pb-10 overflow-hidden"
+    >
       <HomePageContent />
     </AppLayout>
   );


### PR DESCRIPTION
## Summary
- trim excess top and bottom space on authenticated home page

## Testing
- `npm run lint` *(fails: numerous prettier formatting errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b7d3b379008330a1a1802c96c09136