### PR TITLE
feat: apply marketing typography to buttons

### DIFF
--- a/front/src/components/ui/Button.tsx
+++ b/front/src/components/ui/Button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 aria-[busy=true]:opacity-50 aria-[busy=true]:pointer-events-none",
+  "btn fantasy-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 aria-[busy=true]:opacity-50 aria-[busy=true]:pointer-events-none",
   {
     variants: {
       variant: {

--- a/front/src/components/ui/DuelCTAButton.tsx
+++ b/front/src/components/ui/DuelCTAButton.tsx
@@ -13,7 +13,7 @@ export function DuelCTAButton({
       whileTap={{ scale: 0.98 }}
       transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
       className={cn(
-        'inline-flex w-full items-center justify-center gap-2 rounded-[20px] px-6 py-4 font-semibold text-center text-[#15181D] [background:linear-gradient(180deg,#F8EDBD_0%,#F5D36C_45%,#D9A441_100%)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
+        'inline-flex w-full items-center justify-center gap-2 rounded-[20px] px-6 py-4 font-semibold text-center fantasy-text text-[#15181D] [background:linear-gradient(180deg,#F8EDBD_0%,#F5D36C_45%,#D9A441_100%)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
         className
       )}
       {...props}

--- a/front/src/components/ui/GoldButton.tsx
+++ b/front/src/components/ui/GoldButton.tsx
@@ -9,7 +9,7 @@ export function GoldButton({ className, ...props }: GoldButtonProps) {
   return (
     <button
       className={cn(
-        'inline-flex items-center justify-center w-full select-none rounded-[20px] px-5 py-4 text-base font-semibold text-center text-[#15181D] transition-all duration-200 [background:linear-gradient(180deg,#F6E7AA,#F5D36C_40%,#D9A441)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] hover:-translate-y-0.5 hover:shadow-[0_0_24px_rgba(245,211,108,.25)] active:translate-y-0 active:brightness-95 focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
+        'inline-flex items-center justify-center w-full select-none rounded-[20px] px-5 py-4 text-base font-semibold text-center fantasy-text text-[#15181D] transition-all duration-200 [background:linear-gradient(180deg,#F6E7AA,#F5D36C_40%,#D9A441)] shadow-[0_6px_16px_rgba(0,0,0,.35),0_8px_24px_rgba(245,211,108,.12)] hover:-translate-y-0.5 hover:shadow-[0_0_24px_rgba(245,211,108,.25)] active:translate-y-0 active:brightness-95 focus:outline-none focus:ring-2 focus:ring-[#F5D36C]/50 disabled:opacity-50 disabled:pointer-events-none',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- apply `fantasy-text` class to primary Button component
- use marketing-style typography in GoldButton and DuelCTAButton

## Testing
- `npm run lint` *(fails: numerous prettier/eslint errors in existing files)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b88d88a3808330abf773536eea3214