### PR TITLE
Improve history tabs responsiveness and chat page spacing

### DIFF
--- a/front/src/app/(app)/chat/page.tsx
+++ b/front/src/app/(app)/chat/page.tsx
@@ -139,7 +139,7 @@ const ChatListPageContent = () => {
 
 export default function ChatListPage() {
   return (
-    <AppLayout>
+    <AppLayout mainClassName="pt-4 md:pt-6">
       <ChatListPageContent />
     </AppLayout>
   );

--- a/front/src/app/(app)/history/page.tsx
+++ b/front/src/app/(app)/history/page.tsx
@@ -1,13 +1,23 @@
-
-"use client";
+'use client';
 
 import React, { useState, useEffect } from 'react';
 import AppLayout from '@/components/AppLayout';
 import { useAuth } from '@/hooks/useAuth';
 import type { Bet, BackendPartidaResponseDto } from '@/types';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
-import { ScrollTextIcon, VictoryIcon, DefeatIcon, InfoIcon } from '@/components/icons/ClashRoyaleIcons';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/Card';
+import {
+  ScrollTextIcon,
+  VictoryIcon,
+  DefeatIcon,
+  InfoIcon,
+} from '@/components/icons/ClashRoyaleIcons';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/Badge';
 import { getUserDuelsAction } from '@/lib/actions';
 import { BACKEND_URL } from '@/lib/config';
@@ -27,15 +37,17 @@ const HistoryPageContent = () => {
 
   useEffect(() => {
     const loadOpponents = async () => {
-      const ids = Array.from(new Set(bets.map(b => b.opponentId).filter(Boolean))) as string[];
+      const ids = Array.from(
+        new Set(bets.map((b) => b.opponentId).filter(Boolean))
+      ) as string[];
       await Promise.all(
-        ids.map(async id => {
+        ids.map(async (id) => {
           if (opponents[id]) return;
           try {
             const res = await fetch(`${BACKEND_URL}/api/jugadores/${id}`);
             if (res.ok) {
               const data = await res.json();
-              setOpponents(prev => ({ ...prev, [id]: data.nombre }));
+              setOpponents((prev) => ({ ...prev, [id]: data.nombre }));
             }
           } catch (err) {
             console.error('Error al obtener oponente', err);
@@ -53,22 +65,29 @@ const HistoryPageContent = () => {
       if (user?.id) {
         const duelResult = await getUserDuelsAction(user.id);
         if (duelResult.duels) {
-          const mapped = duelResult.duels.map((d: BackendPartidaResponseDto) => {
-            const matchDate = d.validadaEn || d.creada;
-            return {
-              id: d.apuestaId,
-              userId: user.id,
-              matchId: d.id,
-              amount: d.monto,
-              opponentId: d.jugador1Id === user.id ? d.jugador2Id : d.jugador1Id,
-              matchDate,
-              result: d.ganadorId ? (d.ganadorId === user.id ? 'win' : 'loss') : undefined,
-              status: d.estado as any,
-              modoJuego: d.modoJuego,
-              opponentTag: undefined,
-              prize: Number(d.premio ?? 0),
-            } as Bet;
-          });
+          const mapped = duelResult.duels.map(
+            (d: BackendPartidaResponseDto) => {
+              const matchDate = d.validadaEn || d.creada;
+              return {
+                id: d.apuestaId,
+                userId: user.id,
+                matchId: d.id,
+                amount: d.monto,
+                opponentId:
+                  d.jugador1Id === user.id ? d.jugador2Id : d.jugador1Id,
+                matchDate,
+                result: d.ganadorId
+                  ? d.ganadorId === user.id
+                    ? 'win'
+                    : 'loss'
+                  : undefined,
+                status: d.estado as any,
+                modoJuego: d.modoJuego,
+                opponentTag: undefined,
+                prize: Number(d.premio ?? 0),
+              } as Bet;
+            }
+          );
           setBets(mapped);
         } else {
           setBets([]);
@@ -84,11 +103,12 @@ const HistoryPageContent = () => {
     }
   }, [user, authIsLoading]);
 
-  if (isPageLoading || authIsLoading) return <p>Cargando historial de duelos...</p>;
+  if (isPageLoading || authIsLoading)
+    return <p>Cargando historial de duelos...</p>;
   if (!user) return <p>Debes iniciar sesión para ver tu historial.</p>;
 
-  const wonBets = bets.filter(bet => bet.result === 'win');
-  const lostBets = bets.filter(bet => bet.result === 'loss');
+  const wonBets = bets.filter((bet) => bet.result === 'win');
+  const lostBets = bets.filter((bet) => bet.result === 'loss');
 
   const BetCard = ({ bet }: { bet: Bet }) => {
     const name = bet.opponentId ? opponents[bet.opponentId] : undefined;
@@ -96,14 +116,14 @@ const HistoryPageContent = () => {
       bet.result === 'win'
         ? 'Ganada'
         : bet.result === 'loss'
-        ? 'Perdida'
-        : bet.status
-        ? bet.status
-            .toLowerCase()
-            .split('_')
-            .map(s => s.charAt(0).toUpperCase() + s.slice(1))
-            .join(' ')
-        : 'Pendiente';
+          ? 'Perdida'
+          : bet.status
+            ? bet.status
+                .toLowerCase()
+                .split('_')
+                .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+                .join(' ')
+            : 'Pendiente';
     const formattedDate = new Date(bet.matchDate).toLocaleString('es-CO', {
       dateStyle: 'short',
       timeStyle: 'short',
@@ -113,7 +133,9 @@ const HistoryPageContent = () => {
         <CardHeader className="pb-3">
           <div className="flex justify-between items-start">
             <div>
-              <CardTitle className="text-xl text-primary">Duelo: {bet.modoJuego}</CardTitle>
+              <CardTitle className="text-xl text-primary">
+                Duelo: {bet.modoJuego}
+              </CardTitle>
               <CardDescription className="text-sm text-muted-foreground">
                 Partida ID: {bet.matchId} <br />
                 Fecha y hora: {formattedDate}
@@ -124,8 +146,8 @@ const HistoryPageContent = () => {
                 bet.result === 'win'
                   ? '!bg-success !text-bg'
                   : bet.result === 'loss'
-                  ? '!bg-error !text-bg'
-                  : ''
+                    ? '!bg-error !text-bg'
+                    : ''
               }`}
             >
               {statusLabel}
@@ -137,7 +159,9 @@ const HistoryPageContent = () => {
             <div>
               <p className="text-base">
                 Inscripción:{' '}
-                <span className="font-semibold text-accent">{formatCOP(bet.amount)}</span>
+                <span className="font-semibold text-accent">
+                  {formatCOP(bet.amount)}
+                </span>
               </p>
               {bet.result !== 'loss' && (
                 <p className="text-base">
@@ -153,9 +177,15 @@ const HistoryPageContent = () => {
                 </p>
               )}
             </div>
-            {bet.result === 'win' && <VictoryIcon className="h-8 w-8 text-green-500" />}
-            {bet.result === 'loss' && <DefeatIcon className="h-8 w-8 text-destructive" />}
-            {!bet.result && <InfoIcon className="h-8 w-8 text-muted-foreground" />}
+            {bet.result === 'win' && (
+              <VictoryIcon className="h-8 w-8 text-green-500" />
+            )}
+            {bet.result === 'loss' && (
+              <DefeatIcon className="h-8 w-8 text-destructive" />
+            )}
+            {!bet.result && (
+              <InfoIcon className="h-8 w-8 text-muted-foreground" />
+            )}
           </div>
         </CardContent>
       </Card>
@@ -167,35 +197,60 @@ const HistoryPageContent = () => {
       <CardHeader className="bg-primary/10">
         <div className="flex items-center space-x-3">
           <ScrollTextIcon className="h-8 w-8 text-accent" />
-          <CardTitle className="text-3xl font-headline text-primary">Historial de Duelos</CardTitle>
+          <CardTitle className="text-3xl font-headline text-primary">
+            Historial de Duelos
+          </CardTitle>
         </div>
-        <CardDescription className="text-muted-foreground text-lg pt-1">Aquí verás tus duelos y sus resultados.</CardDescription>
+        <CardDescription className="text-muted-foreground text-lg pt-1">
+          Aquí verás tus duelos y sus resultados.
+        </CardDescription>
       </CardHeader>
       <CardContent className="p-6">
         <Tabs defaultValue="all" className="w-full">
-          <TabsList className="grid w-full grid-cols-4 mb-6 p-1.5 bg-secondary rounded-lg gap-1.5">
-            <TabsTrigger value="all" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-soft hover:bg-primary/20">Todos ({bets.length})</TabsTrigger>
-            <TabsTrigger value="ganadas" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-green-500 data-[state=active]:text-white data-[state=active]:shadow-soft hover:bg-primary/20">Ganadas ({wonBets.length})</TabsTrigger>
-            <TabsTrigger value="perdidas" className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-destructive data-[state=active]:text-destructive-foreground data-[state=active]:shadow-soft hover:bg-primary/20">Perdidas ({lostBets.length})</TabsTrigger>
+          <TabsList className="grid w-full grid-cols-3 sm:grid-cols-4 justify-items-center mb-6 p-1.5 bg-secondary rounded-lg gap-1.5">
+            <TabsTrigger
+              value="all"
+              className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-soft hover:bg-primary/20"
+            >
+              Todos ({bets.length})
+            </TabsTrigger>
+            <TabsTrigger
+              value="ganadas"
+              className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-green-500 data-[state=active]:text-white data-[state=active]:shadow-soft hover:bg-primary/20"
+            >
+              Ganadas ({wonBets.length})
+            </TabsTrigger>
+            <TabsTrigger
+              value="perdidas"
+              className="py-2.5 px-3 text-base rounded-md data-[state=active]:bg-destructive data-[state=active]:text-destructive-foreground data-[state=active]:shadow-soft hover:bg-primary/20"
+            >
+              Perdidas ({lostBets.length})
+            </TabsTrigger>
           </TabsList>
-          
+
           <TabsContent value="all">
             {bets.length === 0 ? (
-              <p className="text-center text-muted-foreground py-8">No tienes Duelos en tu historial todavía.</p>
+              <p className="text-center text-muted-foreground py-8">
+                No tienes Duelos en tu historial todavía.
+              </p>
             ) : (
               bets.map((bet) => <BetCard key={bet.id} bet={bet} />)
             )}
           </TabsContent>
           <TabsContent value="ganadas">
             {wonBets.length === 0 ? (
-              <p className="text-center text-muted-foreground py-8">No has ganado ningun duelo todavía.</p>
+              <p className="text-center text-muted-foreground py-8">
+                No has ganado ningun duelo todavía.
+              </p>
             ) : (
               wonBets.map((bet) => <BetCard key={bet.id} bet={bet} />)
             )}
           </TabsContent>
           <TabsContent value="perdidas">
             {lostBets.length === 0 ? (
-              <p className="text-center text-muted-foreground py-8">No has perdido ningun duelo todavía.</p>
+              <p className="text-center text-muted-foreground py-8">
+                No has perdido ningun duelo todavía.
+              </p>
             ) : (
               lostBets.map((bet) => <BetCard key={bet.id} bet={bet} />)
             )}


### PR DESCRIPTION
## Summary
- make history page tab list responsive across breakpoints
- center tab items without scrollbars
- reduce chat list page padding so content sits closer to the top bar

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck` *(fails: Cannot find module 'framer-motion' and other declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bd48b388833094c21d68aa7e0115