### PR TITLE
Make top bar persistent and streamline icons

### DIFF
--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -73,16 +73,13 @@ const HomePageContent = () => {
   const [timeLeft, setTimeLeft] = useState(25);
   const timerRef = React.useRef<NodeJS.Timeout | null>(null);
 
-  const anyModalOpen = isModeModalOpen || isSearching || !!pendingMatch || isDepositModalOpen || isWithdrawModalOpen;
-
-  // Scroll lock SOLO cuando hay modal/overlay
   useEffect(() => {
-    if (anyModalOpen) {
-      const prev = document.body.style.overflow;
-      document.body.style.overflow = 'hidden';
-      return () => { document.body.style.overflow = prev; };
-    }
-  }, [anyModalOpen]);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
 
   const handleMatchFound = (data: MatchEventData) => {
     setIsSearching(false);

--- a/front/src/components/AppLayout.tsx
+++ b/front/src/components/AppLayout.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import React from 'react';
-import Navbar from './Navbar';
 import TopNavbar from './TopNavbar';
 import BottomNav from './BottomNav';
 import AuthGuard from './AuthGuard';
@@ -16,15 +15,10 @@ const AppLayout = ({ children, mainClassName }: AppLayoutProps) => {
   return (
     <AuthGuard>
       <div className="flex flex-col min-h-screen bg-bg-0 text-text-1 font-body">
-        <div className="md:hidden">
-          <TopNavbar />
-        </div>
-        <div className="hidden md:block">
-          <Navbar />
-        </div>
+        <TopNavbar />
         <main
           className={cn(
-            'flex-grow container mx-auto px-4 pt-4 pb-24 md:pt-6 md:pb-8 md:px-6 lg:px-8 lg:pt-6 lg:pb-10 animate-fade-in-up',
+            'flex-grow container mx-auto px-4 pt-24 pb-24 md:px-6 md:pb-8 lg:px-8 lg:pb-10 animate-fade-in-up',
             mainClassName
           )}
         >

--- a/front/src/components/TopNavbar.tsx
+++ b/front/src/components/TopNavbar.tsx
@@ -9,7 +9,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Button } from "@/components/ui/Button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useAuth } from "@/hooks/useAuth";
@@ -25,7 +24,7 @@ const TopNavbar = () => {
       : undefined;
 
   return (
-    <header className="md:hidden navbar fixed top-0 left-0 right-0 z-50 h-20 px-4 py-4 flex justify-between items-center">
+    <header className="navbar fixed top-0 left-0 right-0 z-50 h-20 px-4 py-4 flex justify-between items-center">
       <div className="flex items-center gap-1 font-bold text-lg text-[color:var(--gold)] fantasy-text">
         <Image src="/logo.png" alt="Arena Real logo" width={32} height={32} className="h-8 w-8" />
         Arena Real
@@ -34,17 +33,15 @@ const TopNavbar = () => {
       <div className="flex items-center gap-4">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
+            <button
               aria-label="Notificaciones"
-              className="relative p-2 h-10 w-10 rounded-full border-0 gap-0"
+              className="relative p-2 rounded-full hover:scale-105 focus:outline-none bg-transparent"
             >
               <Bell className="h-5 w-5" />
               {unreadCount > 0 && (
                 <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full" />
               )}
-            </Button>
+            </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-64">
             <DropdownMenuItem
@@ -72,10 +69,9 @@ const TopNavbar = () => {
         </DropdownMenu>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="p-0 h-auto w-auto rounded-full gap-0 hover:scale-105"
+            <button
+              className="p-0 h-auto w-auto rounded-full hover:scale-105 focus:outline-none bg-transparent"
+              aria-label="Menú de usuario"
             >
               <Avatar className="h-8 w-8">
                 {avatarSrc && (
@@ -89,7 +85,7 @@ const TopNavbar = () => {
                   {user?.username?.[0]?.toUpperCase() || 'U'}
                 </AvatarFallback>
               </Avatar>
-            </Button>
+            </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-40">
             <DropdownMenuItem asChild>


### PR DESCRIPTION
## Summary
- Show `TopNavbar` for all viewports and drop `Navbar`
- Hide homepage scrollbar
- Remove square backgrounds around notification bell and avatar

## Testing
- `npm --prefix front run lint` (fails: Prettier formatting errors)
- `npm --prefix front run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba76ed39a0833095bd70934cd5bc93