### PR TITLE
Center home page and reduce top padding

### DIFF
--- a/front/src/app/(app)/history/page.tsx
+++ b/front/src/app/(app)/history/page.tsx
@@ -263,7 +263,7 @@ const HistoryPageContent = () => {
 
 export default function HistoryPage() {
   return (
-    <AppLayout>
+    <AppLayout mainClassName="pt-6">
       <HistoryPageContent />
     </AppLayout>
   );

--- a/front/src/app/(app)/home/page.tsx
+++ b/front/src/app/(app)/home/page.tsx
@@ -883,7 +883,7 @@ const HomePageContent = () => {
 
 export default function HomePage() {
   return (
-    <AppLayout mainClassName="flex flex-col items-stretch justify-start md:justify-center pb-20 md:pb-10 pt-20">
+    <AppLayout mainClassName="flex flex-col items-center justify-center p-0">
       <HomePageContent />
     </AppLayout>
   );


### PR DESCRIPTION
## Summary
- Center home page content without extra padding and remove scrolling
- Reduce top spacing on duel history page

## Testing
- `npm run lint` *(fails: numerous prettier/prettier errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba801977f083309d399d438df28a36